### PR TITLE
add menu to close/minimize multiple windows

### DIFF
--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -114,6 +114,15 @@ export default class Window extends Morph {
           {alias: "reset",  target: w, command: "resize active window", args: {window: this, how: "reset"}},
         ]
       ],
+      [
+        "Window Management", [
+          {alias: "minimize all except this",   target: w, command: "toggle minimize all except active window"},
+          {alias: "close all except this", target: w, command: "close all except active window"},
+          {isDivider: true},
+          {alias: "minimize all",  target: w, command: "toggle minimize all windows"},
+          {alias: "close all",  target: w, command: "close all windows"},
+        ]
+      ],
       {isDivider: true},
       ...(await this.targetMorph.menuItems())
     ]);

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -390,6 +390,42 @@ var commands = [
   },
 
   {
+    name: "toggle minimize all windows",
+    exec: world => {
+      var allWindows = world.getWindows();
+      allWindows && allWindows.map(w => w.toggleMinimize());
+      return true;
+    }
+  },
+
+  {
+    name: "toggle minimize all except active window",
+    exec: world => {
+      var allWindowsExceptActive = world.getWindows().filter(w => !w.isActive());
+      allWindowsExceptActive && allWindowsExceptActive.map(w => w.toggleMinimize());
+      return true;
+    }
+  },
+
+  {
+    name: "close all except active window",
+    exec: world => {
+      var allWindowsExceptActive = world.getWindows().filter(w => !w.isActive());
+      allWindowsExceptActive && allWindowsExceptActive.map(w => w.close());
+      return true;
+    }
+  },
+
+  {
+    name: "close all windows",
+    exec: world => {
+      var allWindows = world.getWindows();
+      allWindows && allWindows.map(w => w.close());
+      return true;
+    }
+  },
+
+  {
     name: "open status message of focused morph",
     exec: world => {
       var focused = world.focusedMorph;

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -454,6 +454,13 @@ export class LivelyWorld extends World {
       ],
       {command: "report a bug",          target: this},
       {isDivider: true},
+      ["Windows",
+       [
+          {command: "toggle minimize all windows", target: this},
+          {command: "close all windows", target: this}
+       ]
+      ],
+      {isDivider: true},
       {command: "save world",          target: this},
       {command: "load world",          target: this},
     ];


### PR DESCRIPTION
Hi,

I added some ease-of-use menu items, the screenshots should be self-explanatory.

![windows_world_menu](https://user-images.githubusercontent.com/14252419/96857149-f253ed80-145e-11eb-9806-78a3cbcfbab7.png)
![window_menu](https://user-images.githubusercontent.com/14252419/96857152-f2ec8400-145e-11eb-8e84-c40c7a3375b6.png)

Naturally, I am absolutely open to any criticism!

I could also imagine elaborating on this functionality, e.g. "close all other browsers" in browsers, workspaces,... if that is something that would be nice.

I plan on investigating the whole world-menu to get more accustomed to `lively` and maybe fix some things that are broken right now, however I think this change stands for its own, although it touches the world menu.
