### PR TITLE
do not reset search by clicking in editor

### DIFF
--- a/lively.morphic/text/search.js
+++ b/lively.morphic/text/search.js
@@ -313,7 +313,7 @@ export class SearchWidget extends Morph {
     setTimeout(() => {
       let focusedMorph = world.focusedMorph;
       if (!this.withAllSubmorphsDetect(m => m.isFocused())) {
-          this.cancelSearch();
+          this.cancelSearch(false);
           return;
       }
       if (this.get('searchInput') != focusedMorph &&
@@ -329,12 +329,12 @@ export class SearchWidget extends Morph {
     this.textMap && this.textMap.update();
   }
 
-  cancelSearch() {
+  cancelSearch(resetEditor) {
     if (this.state.inProgress)
       this.state.last = this.state.inProgress;
     this.cleanup();
     this.removeTextMap();
-    if (this.state.before) {
+    if (this.state.before && resetEditor) {
       var {scroll, selectionRange} = this.state.before;
       this.target.selection = selectionRange;
       this.target.scroll = scroll;
@@ -554,7 +554,7 @@ export class SearchWidget extends Morph {
         return this.target.execCommand("occur", {needle: this.input});
       }},
       {name: "accept search", exec: () => { this.acceptSearch(); return true; }},
-      {name: "cancel search", exec: () => { this.cancelSearch(); return true; }},
+      {name: "cancel search", exec: () => { this.cancelSearch(true); return true; }},
       {name: "search next", exec: () => { this.searchNext(); return true; }},
       {name: "search prev", exec: () => { this.searchPrev(); return true; }},
 


### PR DESCRIPTION
As it is this closes #40.

There are two additional features I would like to add to this, if you agree that they make sense @merryman:

- [ ] I think it would be cool to have an indication of how many search results there are in the widget
- [ ] (optionally: show the current search position in the widget if the above was implemented (e.g. if there are 14 results and my cursor is at the third show 3/17))

I have to play around more debugging and actually looking at the search results that are being passed around, but I think as it is there is no single array of which we could take the length or something similar?

- [ ] add a button to switch between case-sensitive and insensitive search. My understanding right now is that the search is hardcoded to be case-insensitive? 