### PR TITLE
#56 no drops in dev-tools and option in morphic properties menu

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -1068,8 +1068,8 @@ export default class Browser extends Morph {
       .map(m => ({ string: m.nameInPackage + (m.isLoaded ? '' : ' [not loaded]'), value: m, isListItem: true }));
 
     await this.ui.moduleList.whenRendered();
-    //since list items are not generated at the time of browser creation,
-    //drops need to be deactivated separately
+    // since list items are not generated at the time of browser creation,
+    // drops need to be deactivated separately
     this.ui.moduleList.doNotAcceptDropsForThisAndSubmorphs();
   }
 

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -75,10 +75,7 @@ export default class Browser extends Morph {
     // packageName, moduleName, codeEntity, scroll, textPosition like {row: 0, column: 0}
     const browser = browserOrProps instanceof Browser
       ? browserOrProps : new this(browserOrProps);
-    if (!browser.world()) {
-      const window = browser.openInWindow();
-      window.doNotAcceptDropsForThisAndSubmorphs();
-    }
+    if (!browser.world()) browser.openInWindow();
     return browser.browse(browseSpec, optSystemInterface);
   }
 
@@ -1068,9 +1065,7 @@ export default class Browser extends Morph {
       .map(m => ({ string: m.nameInPackage + (m.isLoaded ? '' : ' [not loaded]'), value: m, isListItem: true }));
 
     await this.ui.moduleList.whenRendered();
-    // since list items are not generated at the time of browser creation,
-    // drops need to be deactivated separately
-    this.ui.moduleList.doNotAcceptDropsForThisAndSubmorphs();
+    this.owner.doNotAcceptDropsForThisAndSubmorphs();
   }
 
   updateCodeEntities (mod) {

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -75,7 +75,10 @@ export default class Browser extends Morph {
     // packageName, moduleName, codeEntity, scroll, textPosition like {row: 0, column: 0}
     const browser = browserOrProps instanceof Browser
       ? browserOrProps : new this(browserOrProps);
-    if (!browser.world()) browser.openInWindow();
+    if (!browser.world()) {
+      const window = browser.openInWindow();
+      window.doNotAcceptDropsForThisAndSubmorphs();
+    }
     return browser.browse(browseSpec, optSystemInterface);
   }
 
@@ -1065,6 +1068,9 @@ export default class Browser extends Morph {
       .map(m => ({ string: m.nameInPackage + (m.isLoaded ? '' : ' [not loaded]'), value: m, isListItem: true }));
 
     await this.ui.moduleList.whenRendered();
+    //since list items are not generated at the time of browser creation,
+    //drops need to be deactivated separately
+    this.ui.moduleList.doNotAcceptDropsForThisAndSubmorphs();
   }
 
   updateCodeEntities (mod) {

--- a/lively.ide/js/inspector.js
+++ b/lively.ide/js/inspector.js
@@ -799,10 +799,12 @@ class PropertyTree extends Tree {
 }
 
 export default class Inspector extends Morph {
+
   static openInWindow (props) {
     if (System._testsRunning) return console.log(props.targetObject);
     const i = new this(props);
-    i.openInWindow();
+    let window = i.openInWindow();
+    window.doNotAcceptDropsForThisAndSubmorphs();
     return i;
   }
 
@@ -1103,6 +1105,8 @@ export default class Inspector extends Morph {
       }
     });
     this.ui.propertyTree.update(true);
+    //block drops even if target,... changes
+    this.ui.propertyTree.doNotAcceptDropsForThisAndSubmorphs();
   }
 
   get isInspector () { return true; }

--- a/lively.ide/js/inspector.js
+++ b/lively.ide/js/inspector.js
@@ -799,11 +799,10 @@ class PropertyTree extends Tree {
 }
 
 export default class Inspector extends Morph {
-
   static openInWindow (props) {
     if (System._testsRunning) return console.log(props.targetObject);
     const i = new this(props);
-    let window = i.openInWindow();
+    const window = i.openInWindow();
     window.doNotAcceptDropsForThisAndSubmorphs();
     return i;
   }
@@ -1105,7 +1104,7 @@ export default class Inspector extends Morph {
       }
     });
     this.ui.propertyTree.update(true);
-    //block drops even if target,... changes
+    // block drops even if target,... changes
     this.ui.propertyTree.doNotAcceptDropsForThisAndSubmorphs();
   }
 

--- a/lively.ide/js/objecteditor/index.js
+++ b/lively.ide/js/objecteditor/index.js
@@ -61,6 +61,7 @@ export class ObjectEditor extends Morph {
         evalEnvironment
       });
     }
+    win.doNotAcceptDropsForThisAndSubmorphs();
     return win;
   }
 

--- a/lively.ide/js/workspace.js
+++ b/lively.ide/js/workspace.js
@@ -76,12 +76,6 @@ export default class Workspace extends Window {
     };
   }
 
-  build () {
-    super.build();
-    // deactivate dropping for actual window
-    this.doNotAcceptDropsForThisAndSubmorphs();
-  }
-
   async openWindowMenu () {
     const menuItems = [
       [
@@ -126,7 +120,7 @@ export default class Workspace extends Window {
   }
 
   relayoutWindowControls () {
-    // deactivate dropping for code editor,...
+    // deactivate here since all submorphs are present
     this.doNotAcceptDropsForThisAndSubmorphs();
     super.relayoutWindowControls();
     const list = this.getSubmorphNamed('eval backend button');

--- a/lively.ide/js/workspace.js
+++ b/lively.ide/js/workspace.js
@@ -76,7 +76,13 @@ export default class Workspace extends Window {
     };
   }
 
-  async openWindowMenu () {
+  build() {
+    super.build();
+    // deactivate dropping for actual window
+    this.doNotAcceptDropsForThisAndSubmorphs();
+  }
+
+  async openWindowMenu() {
     const menuItems = [
       [
         'Change Window Title',
@@ -119,7 +125,13 @@ export default class Workspace extends Window {
     this.jsPlugin.highlight();
   }
 
+<<<<<<< HEAD
   relayoutWindowControls () {
+=======
+  relayoutWindowControls() {
+    //deactivate dropping for code editor,...
+    this.doNotAcceptDropsForThisAndSubmorphs(); 
+>>>>>>> #56 no drops in dev-tools and option in morphic properties menu
     super.relayoutWindowControls();
     const list = this.getSubmorphNamed('eval backend button');
     const title = this.ui.windowTitle;

--- a/lively.ide/js/workspace.js
+++ b/lively.ide/js/workspace.js
@@ -76,13 +76,13 @@ export default class Workspace extends Window {
     };
   }
 
-  build() {
+  build () {
     super.build();
     // deactivate dropping for actual window
     this.doNotAcceptDropsForThisAndSubmorphs();
   }
 
-  async openWindowMenu() {
+  async openWindowMenu () {
     const menuItems = [
       [
         'Change Window Title',
@@ -125,13 +125,9 @@ export default class Workspace extends Window {
     this.jsPlugin.highlight();
   }
 
-<<<<<<< HEAD
   relayoutWindowControls () {
-=======
-  relayoutWindowControls() {
-    //deactivate dropping for code editor,...
-    this.doNotAcceptDropsForThisAndSubmorphs(); 
->>>>>>> #56 no drops in dev-tools and option in morphic properties menu
+    // deactivate dropping for code editor,...
+    this.doNotAcceptDropsForThisAndSubmorphs();
     super.relayoutWindowControls();
     const list = this.getSubmorphNamed('eval backend button');
     const title = this.ui.windowTitle;

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -961,10 +961,18 @@ export class LivelyWorld extends World {
         [[...(morph[propName] ? checked : unchecked), ' ' + propName, { float: 'none' }],
           () => morph[propName] = !morph[propName]]));
 
-    items.push(['Fit to submorphs', async () => {
-      let padding = await self.world().prompt('Padding around submorphs:', {
-        input: 'Rectangle.inset(5)',
-        historyId: 'lively.morphic-fit-to-submorphs-padding-hist',
+    morphicMenuItems[1].push(['this and submorphs accept drops', () => {
+      this.acceptDropsForThisAndSubmorphs();
+    }])
+
+    morphicMenuItems[1].push(['this and submorphs do not accept drops', () => {
+      this.doNotAcceptDropsForThisAndSubmorphs();
+    }]);
+    
+    items.push(["Fit to submorphs", async () => {
+      let padding = await self.world().prompt("Padding around submorphs:", {
+        input: "Rectangle.inset(5)",
+        historyId: "lively.morphic-fit-to-submorphs-padding-hist",
         requester: self
       });
       if (typeof padding !== 'string') return;

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -963,16 +963,16 @@ export class LivelyWorld extends World {
 
     morphicMenuItems[1].push(['this and submorphs accept drops', () => {
       this.acceptDropsForThisAndSubmorphs();
-    }])
+    }]);
 
     morphicMenuItems[1].push(['this and submorphs do not accept drops', () => {
       this.doNotAcceptDropsForThisAndSubmorphs();
     }]);
-    
-    items.push(["Fit to submorphs", async () => {
-      let padding = await self.world().prompt("Padding around submorphs:", {
-        input: "Rectangle.inset(5)",
-        historyId: "lively.morphic-fit-to-submorphs-padding-hist",
+
+    items.push(['Fit to submorphs', async () => {
+      let padding = await self.world().prompt('Padding around submorphs:', {
+        input: 'Rectangle.inset(5)',
+        historyId: 'lively.morphic-fit-to-submorphs-padding-hist',
         requester: self
       });
       if (typeof padding !== 'string') return;

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -962,11 +962,11 @@ export class LivelyWorld extends World {
           () => morph[propName] = !morph[propName]]));
 
     morphicMenuItems[1].push(['this and submorphs accept drops', () => {
-      this.acceptDropsForThisAndSubmorphs();
+      morph.acceptDropsForThisAndSubmorphs();
     }]);
 
     morphicMenuItems[1].push(['this and submorphs do not accept drops', () => {
-      this.doNotAcceptDropsForThisAndSubmorphs();
+      morph.doNotAcceptDropsForThisAndSubmorphs();
     }]);
 
     items.push(['Fit to submorphs', async () => {

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2256,7 +2256,21 @@ export class Morph {
     evt.hand.dropMorphsOn(this);
   }
 
-  wantsToBeDroppedOn (dropTarget) {
+  doNotAcceptDropsForThisAndSubmorphs() {
+    this.acceptsDrops = false;
+    this.submorphs.forEach((m) => {
+      m.doNotAcceptDropsForThisAndSubmorphs();
+    })
+  }
+
+  acceptDropsForThisAndSubmorphs() {
+    this.acceptsDrops = true;
+    this.submorphs.forEach((m) => {
+      m.acceptDropsForThisAndSubmorphs();
+    })
+  } 
+
+  wantsToBeDroppedOn(dropTarget) {
     // called when `this` is grabbed and a drop target for `this` needs to be found
     return true;
   }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2257,7 +2257,7 @@ export class Morph {
   }
 
   doNotAcceptDropsForThisAndSubmorphs () {
-    this.withAllSubmorphsDo(m => { m.acceptsDrops = false; debugger; });
+    this.withAllSubmorphsDo(m => m.acceptsDrops = false);
   }
 
   acceptDropsForThisAndSubmorphs () {

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2256,21 +2256,15 @@ export class Morph {
     evt.hand.dropMorphsOn(this);
   }
 
-  doNotAcceptDropsForThisAndSubmorphs() {
-    this.acceptsDrops = false;
-    this.submorphs.forEach((m) => {
-      m.doNotAcceptDropsForThisAndSubmorphs();
-    })
+  doNotAcceptDropsForThisAndSubmorphs () {
+    this.withAllSubmorphsDo(m => { m.acceptsDrops = false; debugger; });
   }
 
-  acceptDropsForThisAndSubmorphs() {
-    this.acceptsDrops = true;
-    this.submorphs.forEach((m) => {
-      m.acceptDropsForThisAndSubmorphs();
-    })
-  } 
+  acceptDropsForThisAndSubmorphs () {
+    this.withAllSubmorphsDo(m => m.acceptsDrops = true);
+  }
 
-  wantsToBeDroppedOn(dropTarget) {
+  wantsToBeDroppedOn (dropTarget) {
     // called when `this` is grabbed and a drop target for `this` needs to be found
     return true;
   }


### PR DESCRIPTION
Browser, Object Editor, JS Workspace and Inspector do not accept drops anymore.
The morph menu allows to accept/not accept drops for a whole hierarchy of morphs.

![Tooltip_072](https://user-images.githubusercontent.com/14252419/98812893-9fe56b80-2423-11eb-8347-38917e482370.png)

We briefly discussed a better solution to block drops in all dev-tools and e.g. color-pickers as well. Since we did not come up with a good solution we opted for this, since these tools were the biggest pain points for us.

This closes #56