### PR TITLE
Use trash icon for CloseHaloItem

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -864,9 +864,9 @@ class CloseHaloItem extends HaloItem {
 
   static get properties () {
     return {
-      styleClasses: {defaultValue: ["fas", "fa-trash"]},
-      draggable: {defaultValue: false},
-      tooltip: {defaultValue: "Remove this morph from the world"}
+      styleClasses: { defaultValue: ['fas', 'fa-trash'] },
+      draggable: { defaultValue: false },
+      tooltip: { defaultValue: 'Remove this morph from the world' }
     };
   }
 

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -864,9 +864,9 @@ class CloseHaloItem extends HaloItem {
 
   static get properties () {
     return {
-      styleClasses: { defaultValue: ['fas', 'fa-times'] },
-      draggable: { defaultValue: false },
-      tooltip: { defaultValue: 'Remove this morph from the world' }
+      styleClasses: {defaultValue: ["fas", "fa-trash"]},
+      draggable: {defaultValue: false},
+      tooltip: {defaultValue: "Remove this morph from the world"}
     };
   }
 


### PR DESCRIPTION
In a user study, we found the "Times" icon in a Morph' shalo not to be clear enough about deleting the whole Morph. That's why we replaced the icon with a "Trash" icon.