### PR TITLE
Hotfix: enable copying in browser

### DIFF
--- a/lively.morphic/text/document.js
+++ b/lively.morphic/text/document.js
@@ -1422,7 +1422,7 @@ export default class Document {
     end = this.clipPositionToLines(end);
     if (lessPosition(end, start)) [start, end] = [end, start];
 
-    const { row, column } = start;
+    let { row, column } = start;
     const { row: endRow, column: endColumn } = end;
 
     if (row === endRow) {


### PR DESCRIPTION
In the text/document.js row can't be a const, because it is changed in line 1435. This is a hotfix which solves the problem.