### PR TITLE
prompts: add static example method for all prompts

### DIFF
--- a/lively.components/prompts.js
+++ b/lively.components/prompts.js
@@ -116,6 +116,10 @@ export class AbstractPrompt extends Morph {
 }
 
 export class InformPrompt extends AbstractPrompt {
+  static example () {
+    $world.inform('Computer says no.');
+  }
+
   static get properties () {
     return {
       lineWrapping: { defaultValue: true },
@@ -165,6 +169,10 @@ export class InformPrompt extends AbstractPrompt {
 // new ConfirmPrompt().openInWorld()
 
 export class ConfirmPrompt extends AbstractPrompt {
+  static example () {
+    $world.confirm('Isn\'t this a nice prompt.');
+  }
+
   static get properties () {
     return {
       lineWrapping: { defaultValue: true },
@@ -219,6 +227,10 @@ export class ConfirmPrompt extends AbstractPrompt {
 // new MultipleChoicePrompt({ label: 'hallo', choices: [1,2,3]}).openInWorld()
 
 export class MultipleChoicePrompt extends AbstractPrompt {
+  static example () {
+    $world.multipleChoicePrompt('Choose wisely:', { choices: [1, 2, 3] });
+  }
+
   static get properties () {
     return {
       title: {
@@ -541,8 +553,11 @@ export class EditPrompt extends AbstractPrompt {
   focus () { this.getSubmorphNamed('editor').focus(); }
 }
 
-
 export class PasswordPrompt extends AbstractPrompt {
+  static async example () {
+    await $world.passwordPrompt('Enter your secret password:');
+  }
+
   static get properties () {
     return {
       maxWidth: {


### PR DESCRIPTION
This is just a tiny quality-of-life change. Some of the prompt-types already had a static example function that utilized the wrappers in `world`. I added the remaining ones.