### PR TITLE
Add a method so the latest element on the undo stack can be deleted

### DIFF
--- a/lively.morphic/undo.js
+++ b/lively.morphic/undo.js
@@ -65,7 +65,8 @@ class Undo {
   toString () {
     const { name, changes, no } = this;
     const isRecording = this.isRecording();
-    const changesString = !changes.length ? 'no changes'
+    const changesString = !changes.length
+      ? 'no changes'
       : '\n  ' + changes.map(({ selector, args, prop, value, target }) =>
         selector
           ? `${target}.${selector}(${args.map(printArg)})`
@@ -159,6 +160,13 @@ export class UndoManager {
     return undo;
   }
 
+  removeLatestUndo () {
+    this.undoStop();
+    const undo = this.undos.pop();
+    arr.remove(this.grouping.current, undo);
+    return undo;
+  }
+
   undo () {
     this.undoStop();
     const undo = this.undos.pop();
@@ -181,7 +189,8 @@ export class UndoManager {
   }
 
   toString () {
-    const undosPrinted = this.undos.length === 0 ? ''
+    const undosPrinted = this.undos.length === 0
+      ? ''
       : `\n  ${this.undos.length > 20 ? '...\n  ' : ''}${this.undos.slice(-20).join('\n  ')}`;
     const undoInProgress = !!this.undoInProgress;
     return `UndoManager(${this.undos.length} undos, ${this.redos.length} redos, ${undoInProgress ? ', UNDO IN PROGRESS' : ''}${undosPrinted})`;

--- a/lively.morphic/undo.js
+++ b/lively.morphic/undo.js
@@ -168,8 +168,7 @@ export class UndoManager {
   }
 
   undo () {
-    this.undoStop();
-    const undo = this.undos.pop();
+    const undo = this.removeLatestUndo();
     if (!undo) return;
     arr.remove(this.grouping.current, undo);
     this.redos.unshift(undo);


### PR DESCRIPTION
We needed this to accomplish correct undo behavior in a more complex scenario.

Short story is that we check *after* an action was completed if this was an allowed action and revert it manually if this was not the case. This nevertheless created an corresponding undo, since the beginning of the process is the same with legal actions. Therefore we wanted to remove these.

We see that this method needs to be used with care and are open to discuss alternatives/give a more in-depth explanation of what happens in our application if you have strong concerns about this. 