### PR TITLE
Add check if key is defined and remove unnecessary cases

### DIFF
--- a/lively.morphic/events/Keys.js
+++ b/lively.morphic/events/Keys.js
@@ -96,7 +96,7 @@ const FUNCTION_KEYS = [
 ];
 
 function canonicalizeFunctionKey (key) {
-  key = key.toLowerCase();
+  if (key) { key = key.toLowerCase(); }
   switch (key) {
     case 'space': key = 'space'; break;
     case 'esc': key = 'escape'; break;
@@ -105,8 +105,6 @@ function canonicalizeFunctionKey (key) {
     case 'arrowright': key = 'right'; break;
     case 'arrowup': key = 'up'; break;
     case 'arrowdown': key = 'down'; break;
-    case 'esc': key = 'escape'; break;
-    case 'return': key = 'enter'; break;
   }
 
   return FUNCTION_KEYS.includes(key) ? string.capitalize(key) : '';
@@ -312,7 +310,8 @@ var Keys = {
 
   canonicalizeEvent (evt) {
     return evt._isLivelyKeyEventSpec
-      ? evt : Keys.keyComboToEventSpec(Keys.eventToKeyCombo(evt));
+      ? evt
+      : Keys.keyComboToEventSpec(Keys.eventToKeyCombo(evt));
   }
 
 };


### PR DESCRIPTION
There was a bug, where an error message got saved in the `event.keyCombo` because the `key` was `undefined`.