### PR TITLE
Nicer Searching

### DIFF
--- a/lively.morphic/text/search.js
+++ b/lively.morphic/text/search.js
@@ -264,7 +264,7 @@ export class SearchWidget extends Morph {
     const cancelButton = this.getSubmorphNamed('cancelButton');
     const acceptButton = this.getSubmorphNamed('acceptButton');
     connect(acceptButton, 'fire', this, 'execCommand', { converter: () => 'accept search' });
-    connect(cancelButton, 'fire', this, 'execCommand', { converter: () => 'cancel search' });
+    connect(cancelButton, 'fire', this, 'execCommand', { converter: () => 'cancel search and reset cursor in text' });
     connect(nextButton, 'fire', this, 'execCommand', { converter: () => 'search next' });
     connect(prevButton, 'fire', this, 'execCommand', { converter: () => 'search prev' });
     connect(searchInput, 'inputChanged', this, 'search');
@@ -527,11 +527,12 @@ export class SearchWidget extends Morph {
 
   get keybindings () {
     return [
-      { keys: 'Enter', command: 'accept search or replace and go to next' },
+      { keys: 'Enter', command: 'search next or replace and go to next' },
+      { keys: 'Alt-Enter', command: 'search prev' },
       { keys: 'Tab', command: 'change focus' },
       { keys: 'Ctrl-O', command: 'occur with search term' },
       { keys: 'Ctrl-W', command: 'yank next word from text' },
-      { keys: 'Escape|Ctrl-G', command: 'cancel search' },
+      { keys: 'Escape', command: 'cancel search' },
       { keys: { win: 'Ctrl-F|Ctrl-S|Ctrl-G', mac: 'Meta-F|Ctrl-S|Meta-G' }, command: 'search next' },
       { keys: { win: 'Ctrl-Shift-F|Ctrl-R|Ctrl-Shift-G', mac: 'Meta-Shift-F|Ctrl-R|Meta-Shift-G' }, command: 'search prev' }
     ];
@@ -549,17 +550,19 @@ export class SearchWidget extends Morph {
         }
       },
       { name: 'accept search', exec: () => { this.acceptSearch(); return true; } },
-      { name: 'cancel search', exec: () => { this.cancelSearch(); return true; } },
+      { name: 'cancel search and reset cursor in text', exec: () => { this.cancelSearch(true); return true; } },
+      { name: 'cancel search', exec: () => { this.cancelSearch(false); return true; } },
       { name: 'search next', exec: () => { this.searchNext(); return true; } },
       { name: 'search prev', exec: () => { this.searchPrev(); return true; } },
 
       {
-        name: 'accept search or replace and go to next',
+        name: 'search next or replace and go to next',
         exec: (_, args, count) => {
+          this.get('searchInput').acceptInput();
           return this.execCommand(
             this.get('replaceInput').isFocused()
               ? 'replace and go to next'
-              : 'accept search', args, count);
+              : 'search next', args, count);
         }
       },
 

--- a/lively.morphic/text/search.js
+++ b/lively.morphic/text/search.js
@@ -309,7 +309,7 @@ export class SearchWidget extends Morph {
     setTimeout(() => {
       const focusedMorph = world.focusedMorph;
       if (!this.withAllSubmorphsDetect(m => m.isFocused())) {
-        this.cancelSearch();
+        this.cancelSearch(false);
         return;
       }
       if (this.get('searchInput') != focusedMorph &&
@@ -325,11 +325,11 @@ export class SearchWidget extends Morph {
     this.textMap && this.textMap.update();
   }
 
-  cancelSearch () {
+  cancelSearch (resetEditor) {
     if (this.state.inProgress) { this.state.last = this.state.inProgress; }
     this.cleanup();
     this.removeTextMap();
-    if (this.state.before) {
+    if (this.state.before && resetEditor) {
       const { scroll, selectionRange } = this.state.before;
       this.target.selection = selectionRange;
       this.target.scroll = scroll;

--- a/lively.morphic/text/search.js
+++ b/lively.morphic/text/search.js
@@ -528,7 +528,7 @@ export class SearchWidget extends Morph {
   get keybindings () {
     return [
       { keys: 'Enter', command: 'search next or replace and go to next' },
-      { keys: 'Alt-Enter', command: 'search prev' },
+      { keys: 'Alt-Enter', command: 'only search prev' },
       { keys: 'Tab', command: 'change focus' },
       { keys: 'Ctrl-O', command: 'occur with search term' },
       { keys: 'Ctrl-W', command: 'yank next word from text' },
@@ -554,6 +554,7 @@ export class SearchWidget extends Morph {
       { name: 'cancel search', exec: () => { this.cancelSearch(false); return true; } },
       { name: 'search next', exec: () => { this.searchNext(); return true; } },
       { name: 'search prev', exec: () => { this.searchPrev(); return true; } },
+      { name: 'only search prev', exec: () => { if (this.get('searchInput').isFocused()) { this.searchPrev(); return true; } } },
 
       {
         name: 'search next or replace and go to next',


### PR DESCRIPTION
- clicking in the text will leave the cursor where it is and not reset the position
- if the old (reset) behavior is wanted, the cancel button is present
- navigate the search results with enter and alt-enter (normally it would be shift-enter, but that is bound to delete the word before the cursor....)
- pressing enter will also write the input to the search history
- escape will leave the cursor where it is and close the search

There are more things that would be nice regarding the search widget, but these are the ones with "bang for the buck", at least for us :wink: 