### PR TITLE
Enhancement/serialize-varmapping

### DIFF
--- a/lively.bindings/index.js
+++ b/lively.bindings/index.js
@@ -1,21 +1,21 @@
-import { string, arr, Closure, obj } from "lively.lang";
-import { stringifyFunctionWithoutToplevelRecorder } from "lively.source-transform";
+import { string, arr, Closure, obj } from 'lively.lang';
+import { stringifyFunctionWithoutToplevelRecorder } from 'lively.source-transform';
+import { ExpressionSerializer } from 'lively.serializer2';
 
 export { connect, disconnect, disconnectAll, once, signal, noUpdate };
 
 export class AttributeConnection {
-
-  constructor(source, sourceProp, target, targetProp, spec) {
+  constructor (source, sourceProp, target, targetProp, spec) {
     this.init(source, sourceProp, target, targetProp, spec);
   }
 
-  init(source, sourceProp, target, targetProp, spec) {
-    this.doNotSerialize = ['isActive', 'converter', 'updater', 'varMapping'];
+  init (source, sourceProp, target, targetProp, spec) {
+    this.doNotSerialize = ['isActive', 'converter', 'updater'];
     this.sourceObj = source;
     this.sourceAttrName = sourceProp;
     this.targetObj = target;
     this.targetMethodName = targetProp;
-    this.varMapping = {source, target};
+    this.varMapping = { source, target };
 
     spec = {
       removeAfterUpdate: false,
@@ -25,24 +25,17 @@ export class AttributeConnection {
       ...spec
     };
 
-    if (spec.removeAfterUpdate)
-      this.removeAfterUpdate = true;
-    if (spec.forceAttributeConnection)
-      this.forceAttributeConnection = true;
-    if (typeof spec.garbageCollect === "boolean")
-      this.garbageCollect = spec.garbageCollect;
-    if (typeof spec.signalOnAssignment === "boolean")
-      this.signalOnAssignment = spec.signalOnAssignment
+    if (spec.removeAfterUpdate) { this.removeAfterUpdate = true; }
+    if (spec.forceAttributeConnection) { this.forceAttributeConnection = true; }
+    if (typeof spec.garbageCollect === 'boolean') { this.garbageCollect = spec.garbageCollect; }
+    if (typeof spec.signalOnAssignment === 'boolean') { this.signalOnAssignment = spec.signalOnAssignment; }
 
     // when converter function references objects from its environment
     // we can't serialize it. To fail as early as possible we will
     // serialize the converter / updater already in the setters
-    if (spec.converter)
-      this.setConverter(spec.converter);
-    if (spec.updater)
-      this.setUpdater(spec.updater);
-    if (spec.varMapping)
-      this.varMapping = Object.assign(spec.varMapping, this.varMapping);
+    if (spec.converter) { this.setConverter(spec.converter); }
+    if (spec.updater) { this.setUpdater(spec.updater); }
+    if (spec.varMapping) { this.varMapping = Object.assign(spec.varMapping, this.varMapping); }
 
     // ensure that spec is valid
     this.getSpec();
@@ -50,38 +43,60 @@ export class AttributeConnection {
     return this;
   }
 
-  __additionally_serialize__(snapshot, ref, pool, addFn) {
-    if (!arr.equals(arr.without(Object.keys(this.varMapping), '_rev'), ['source', 'target'])) {
-       addFn('varMapping', this.varMapping);
-    } else if (snapshot.props.varMapping) {
-       delete snapshot.props.varMapping;
+  __additionally_serialize__ (snapshot, ref, pool, addFn) {
+    delete this.varMapping._rev; // unnecessary left-over from serializer
+
+    // if only source and target are set in the varMapping, we don't need to serialize it,
+    // since we already serialize those in this.sourceObj and this.targetObj
+    if (arr.equals(Object.keys(this.varMapping), ['source', 'target'])) {
+      delete snapshot.props.varMapping;
+      return;
     }
+
+    addFn('varMapping', this._getSerializableVarMapping());
   }
 
-  __after_deserialize__(snapshot, objRef) {
-    if (!this.varMapping) this.varMapping = {};
-    this.varMapping.source = this.sourceObj;
-    this.varMapping.target = this.targetObj;
+  __after_deserialize__ (snapshot, objRef) {
+    // since we usually don't serialize source and target of varMapping, set it here
+    if (!this.varMapping) {
+      this.varMapping = {};
+      this.varMapping.source = this.sourceObj;
+      this.varMapping.target = this.targetObj;
+    }
     this.onSourceAndTargetRestored();
   }
-  
-  onSourceAndTargetRestored() {
-    if (this.sourceObj && this.targetObj)
-      this.connect();
+
+  _getSerializableVarMapping () {
+    const varMappingCopy = { ...this.varMapping };
+    for (const varName of Object.keys(varMappingCopy)) {
+      try {
+        if (obj.isFunction(varMappingCopy[varName])) {
+          varMappingCopy[varName] = new ExpressionSerializer()
+            .getExpressionForFunction(varMappingCopy[varName]);
+        }
+      } catch (err) {
+        throw new Error(`Cannot be serialized due to lack of module information: ${varName} in ${this}`);
+      }
+    }
+    return varMappingCopy;
   }
 
-  copy(copier) {
+  onSourceAndTargetRestored () {
+    if (this.sourceObj && this.targetObj) { this.connect(); }
+  }
+
+  copy (copier) {
     return AttributeConnection.fromLiteral(this.toLiteral(), copier);
   }
 
-  fixInstanceAfterCopyingFromSite(name, ref, index) {
+  fixInstanceAfterCopyingFromSite (name, ref, index) {
     // alert("removed connection: "  + this)
     this.disconnect();
   }
 
-  clone() {
-    //rk 2012-10-09: What is the reason to have clone AND copy?!
-    var con = new this.constructor(
+  clone () {
+    // rk 2012-10-09: What is the reason to have clone AND copy?!
+    const con = new this.constructor(
       this.getSourceObj(), this.getSourceAttrName(),
       this.getTargetObj(), this.getTargetMethodName(),
       this.getSpec());
@@ -91,26 +106,25 @@ export class AttributeConnection {
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // accessing
-  getTargetObj() { return this.targetObj }
-  getSourceObj() { return this.sourceObj }
-  getSourceAttrName() { return this.sourceAttrName }
-  getTargetMethodName() { return this.targetMethodName }
-  getSourceValue() { return this.getSourceObj()[this.getSourceAttrName()] }
-  getPrivateSourceValue() { return this.sourceObj[this.privateAttrName(this.sourceAttrName)] }
+  getTargetObj () { return this.targetObj; }
+  getSourceObj () { return this.sourceObj; }
+  getSourceAttrName () { return this.sourceAttrName; }
+  getTargetMethodName () { return this.targetMethodName; }
+  getSourceValue () { return this.getSourceObj()[this.getSourceAttrName()]; }
+  getPrivateSourceValue () { return this.sourceObj[this.privateAttrName(this.sourceAttrName)]; }
 
-  getConverter() {
+  getConverter () {
     if (!this.converterString) return null;
-    if (!this.converter)
-      this.converter = Closure.fromSource(this.converterString, this.varMapping).recreateFunc();
+    if (!this.converter) { this.converter = Closure.fromSource(this.converterString, this.varMapping).recreateFunc(); }
     return this.converter;
   }
 
-  setConverter(funcOrSource) {
+  setConverter (funcOrSource) {
     delete this.converter;
     return this.converterString = funcOrSource ? String(funcOrSource) : null;
   }
 
-  getUpdater() {
+  getUpdater () {
     if (!this.updaterString) return null;
     if (!this.updater) {
       this.updater = Closure.fromSource(this.updaterString, this.varMapping).recreateFunc();
@@ -118,23 +132,23 @@ export class AttributeConnection {
     return this.updater;
   }
 
-  setUpdater(funcOrSource) {
+  setUpdater (funcOrSource) {
     delete this.updater;
     return this.updaterString = funcOrSource ? stringifyFunctionWithoutToplevelRecorder(funcOrSource) : null;
   }
 
-  getSpec() {
-    var spec = {};
+  getSpec () {
+    const spec = {};
     if (this.updaterString) spec.updater = this.getUpdater();
     if (this.converterString) spec.converter = this.getConverter();
     if (this.removeAfterUpdate) spec.removeAfterUpdate = true;
     if (this.forceAttributeConnection) spec.forceAttributeConnection = true;
-    if (this.hasOwnProperty("garbageCollect")) spec.garbageCollect = this.garbageCollect;
-    if (this.hasOwnProperty("signalOnAssignment")) spec.signalOnAssignment = this.signalOnAssignment;
+    if (this.hasOwnProperty('garbageCollect')) spec.garbageCollect = this.garbageCollect;
+    if (this.hasOwnProperty('signalOnAssignment')) spec.signalOnAssignment = this.signalOnAssignment;
     return spec;
   }
 
-  resetSpec() {
+  resetSpec () {
     delete this.garbageCollect;
     delete this.signalOnAssignment;
     delete this.removeAfterUpdate;
@@ -145,14 +159,14 @@ export class AttributeConnection {
     delete this.updaterString;
   }
 
-  privateAttrName(attrName) { return '$$' + attrName }
+  privateAttrName (attrName) { return '$$' + attrName; }
 
-  activate() { this.isActive = true }
+  activate () { this.isActive = true; }
 
-  deactivate() { delete this.isActive; }
+  deactivate () { delete this.isActive; }
 
-  connect() {
-    let existing = this.getExistingConnection();
+  connect () {
+    const existing = this.getExistingConnection();
     if (existing !== this) {
       // when existing == null just add new connection when
       // existing === this then connect was called twice or we are in
@@ -163,20 +177,20 @@ export class AttributeConnection {
 
     // Check for existing getters that might be there and not belong to
     // lively.bindings We deal with them in addSourceObjGetterAndSetter()
-    let {sourceObj, sourceAttrName, forceAttributeConnection} = this,
-        existingSetter = sourceObj.__lookupSetter__(sourceAttrName),
-        existingGetter = sourceObj.__lookupGetter__(sourceAttrName);
+    const { sourceObj, sourceAttrName, forceAttributeConnection } = this;
+    const existingSetter = sourceObj.__lookupSetter__(sourceAttrName);
+    const existingGetter = sourceObj.__lookupGetter__(sourceAttrName);
 
     // Check if a method is the source. We check both the value behind
     // sourceAttrName and $$sourceAttrName because when deserializing
     // scripts those get currently stored in $$sourceAttrName (for
     // non-scripts it doesn't matter since those methods should be in the
     // prototype chain)
-    let methodOrValue = !existingSetter && !existingGetter &&
+    const methodOrValue = !existingSetter && !existingGetter &&
       (this.getSourceValue() || this.getPrivateSourceValue());
 
     // method connect... FIXME refactori into own class!
-    if (typeof methodOrValue === "function" && !forceAttributeConnection) {
+    if (typeof methodOrValue === 'function' && !forceAttributeConnection) {
       if (!methodOrValue.isWrapped) {
         this.addConnectionWrapper(sourceObj, sourceAttrName, methodOrValue);
       }
@@ -187,24 +201,21 @@ export class AttributeConnection {
     return this;
   }
 
-  disconnect() {
-    let {sourceObj} = this;
-    if (!sourceObj || !sourceObj.attributeConnections)
-      return this.removeSourceObjGetterAndSetter();
+  disconnect () {
+    const { sourceObj } = this;
+    if (!sourceObj || !sourceObj.attributeConnections) { return this.removeSourceObjGetterAndSetter(); }
 
     sourceObj.attributeConnections = sourceObj.attributeConnections.filter(con =>
       !this.isSimilarConnection(con));
-    let connectionsWithSameSourceAttr = sourceObj.attributeConnections.filter(con =>
+    const connectionsWithSameSourceAttr = sourceObj.attributeConnections.filter(con =>
       this.getSourceAttrName() == con.getSourceAttrName());
-    if (sourceObj.attributeConnections.length == 0)
-      delete sourceObj.attributeConnections;
-    if (connectionsWithSameSourceAttr.length == 0)
-      this.removeSourceObjGetterAndSetter();
+    if (sourceObj.attributeConnections.length == 0) { delete sourceObj.attributeConnections; }
+    if (connectionsWithSameSourceAttr.length == 0) { this.removeSourceObjGetterAndSetter(); }
 
     return null;
   }
 
-  update(newValue, oldValue) {
+  update (newValue, oldValue) {
     // This method is optimized for Safari and Chrome.
     // See tests.BindingTests.BindingsProfiler
     // The following requirements exists:
@@ -217,67 +228,67 @@ export class AttributeConnection {
     //   using arr.from. Note 2014-02-10: We currently need to modify the
     //   argument array for allowing conversion.
 
-    if (this.isActive/*this.isRecursivelyActivated()*/) return null;
+    if (this.isActive/* this.isRecursivelyActivated() */) return null;
 
-    var connection = this,
-        updater = this.getUpdater(),
-        converter = this.getConverter(),
-        target = this.targetObj,
-        propName = this.targetMethodName;
+    const connection = this;
+    const updater = this.getUpdater();
+    const converter = this.getConverter();
+    const target = this.targetObj;
+    const propName = this.targetMethodName;
 
     if (!target || !propName) {
-      var msg = 'Cannot update ' + this.toString(newValue)
-          + ' because of no target ('
-          + target + ') or targetProp (' + propName+') ';
+      const msg = 'Cannot update ' + this.toString(newValue) +
+          ' because of no target (' +
+          target + ') or targetProp (' + propName + ') ';
       if (this.isWeakConnection) { this.disconnect(); }
       console.error(msg);
       return null;
     }
 
-    var targetMethod = target[propName],
-        callOrSetTarget = function(arg1/*newValue*/, arg2/*oldValue*/, arg3, arg4, arg5, arg6) {
-          // use a function and not a method to capture this in self and so
-          // that no bind is necessary and oldValue is accessible. Note that
-          // when updater calls this method arguments can be more than just
-          // the new value
-          let args = [arg1, arg2, arg3, arg4, arg5, arg6];
-          if (converter) {
-            newValue = converter.call(connection, arg1, arg2);
-            arg1 = args[0] = newValue;
-          }
-          let result = (typeof targetMethod === 'function') ?
-            targetMethod.apply(target, args) :
-            target[propName] = arg1;
-          if (connection.removeAfterUpdate) connection.disconnect();
-          return result;
-        };
+    const targetMethod = target[propName];
+    const callOrSetTarget = function (arg1/* newValue */, arg2/* oldValue */, arg3, arg4, arg5, arg6) {
+      // use a function and not a method to capture this in self and so
+      // that no bind is necessary and oldValue is accessible. Note that
+      // when updater calls this method arguments can be more than just
+      // the new value
+      const args = [arg1, arg2, arg3, arg4, arg5, arg6];
+      if (converter) {
+        newValue = converter.call(connection, arg1, arg2);
+        arg1 = args[0] = newValue;
+      }
+      const result = (typeof targetMethod === 'function')
+        ? targetMethod.apply(target, args)
+        : target[propName] = arg1;
+      if (connection.removeAfterUpdate) connection.disconnect();
+      return result;
+    };
 
     try {
       this.isActive = true;
-      return updater ?
-        updater.call(this, callOrSetTarget, newValue, oldValue) :
-        callOrSetTarget(newValue, oldValue);
-    } catch(e) {
-      var world = (this.sourceObj && typeof this.sourceObj.world === "function" && this.sourceObj.world())
-               || (this.targetObj && typeof this.targetObj.world === "function" && this.targetObj.world());
+      return updater
+        ? updater.call(this, callOrSetTarget, newValue, oldValue)
+        : callOrSetTarget(newValue, oldValue);
+    } catch (e) {
+      const world = (this.sourceObj && typeof this.sourceObj.world === 'function' && this.sourceObj.world()) ||
+               (this.targetObj && typeof this.targetObj.world === 'function' && this.targetObj.world());
       if (world) {
         world.logError(e, 'AttributeConnection>>update: ');
       } else {
-        console.error('Error when trying to update ' + this + ' with value '
-                     + newValue + ':\n' + e + '\n' + e.stack);
+        console.error('Error when trying to update ' + this + ' with value ' +
+                     newValue + ':\n' + e + '\n' + e.stack);
       }
     } finally { delete this.isActive; }
 
     return null;
   }
 
-  addSourceObjGetterAndSetter(existingGetter, existingSetter) {
-    if ((existingGetter && existingGetter.isAttributeConnectionGetter)
-     || (existingSetter && existingSetter.isAttributeConnectionSetter)) { return; }
+  addSourceObjGetterAndSetter (existingGetter, existingSetter) {
+    if ((existingGetter && existingGetter.isAttributeConnectionGetter) ||
+     (existingSetter && existingSetter.isAttributeConnectionSetter)) { return; }
 
-    var {sourceObj, sourceAttrName} = this,
-        newAttrName = this.privateAttrName(sourceAttrName);
-    
+    const { sourceObj, sourceAttrName } = this;
+    const newAttrName = this.privateAttrName(sourceAttrName);
+
     if (sourceObj[newAttrName]) {
       console.warn('newAttrName ' + newAttrName + ' already exists.' +
              'Are there already other connections?');
@@ -304,26 +315,24 @@ export class AttributeConnection {
       if (!sourceObj.hasOwnProperty(sourceAttrName)) {
         sourceObj.__defineSetter__(newAttrName, (newVal) => {
           sourceObj.constructor.prototype.__lookupSetter__(sourceAttrName).bind(sourceObj)(newVal);
-        })
+        });
       } else {
         sourceObj.__defineSetter__(newAttrName, existingSetter);
       }
     }
 
     // assign old value to new slot
-    if (!existingGetter && !existingSetter && sourceObj.hasOwnProperty(sourceAttrName))
-      sourceObj[newAttrName] = sourceObj[sourceAttrName];
+    if (!existingGetter && !existingSetter && sourceObj.hasOwnProperty(sourceAttrName)) { sourceObj[newAttrName] = sourceObj[sourceAttrName]; }
 
     sourceObj.__defineSetter__(sourceAttrName, (newVal) => {
-      var oldVal = sourceObj[newAttrName];
+      const oldVal = sourceObj[newAttrName];
       sourceObj[newAttrName] = newVal;
       if (sourceObj.attributeConnections === undefined) {
         console.error('Sth wrong with sourceObj, has no attributeConnections');
         return null;
       }
       sourceObj.attributeConnections.forEach((c) => {
-        if (c && c.getSourceAttrName() === sourceAttrName && c.signalOnAssignment)
-          c.update(newVal, oldVal);
+        if (c && c.getSourceAttrName() === sourceAttrName && c.signalOnAssignment) { c.update(newVal, oldVal); }
       });
       return newVal;
     });
@@ -333,8 +342,8 @@ export class AttributeConnection {
     sourceObj.__lookupGetter__(sourceAttrName).isAttributeConnectionGetter = true;
   }
 
-  addConnectionWrapper(sourceObj, methodName, origMethod) {
-    if (typeof origMethod !== "function") {
+  addConnectionWrapper (sourceObj, methodName, origMethod) {
+    if (typeof origMethod !== 'function') {
       throw new Error('addConnectionWrapper didnt get a method to wrap');
     }
 
@@ -347,15 +356,13 @@ export class AttributeConnection {
     } else {
       getOriginal = () => Object.getPrototypeOf(sourceObj)[methodName];
     }
-    sourceObj[methodName] = function connectionWrapper() {
-      if (this.attributeConnections === undefined)
-          throw new Error('[lively.bindings] Something is wrong with connection source object, it has no attributeConnections');
-      var conns = this.attributeConnections.slice(),
-          result = this[methodName].originalFunction.apply(this, arguments);
-      for (var i = 0; i < conns.length; i++) {
-        var c = conns[i];
-        if (c.getSourceAttrName() === methodName)
-          c.update(arguments[0]);
+    sourceObj[methodName] = function connectionWrapper () {
+      if (this.attributeConnections === undefined) { throw new Error('[lively.bindings] Something is wrong with connection source object, it has no attributeConnections'); }
+      const conns = this.attributeConnections.slice();
+      const result = this[methodName].originalFunction.apply(this, arguments);
+      for (let i = 0; i < conns.length; i++) {
+        const c = conns[i];
+        if (c.getSourceAttrName() === methodName) { c.update(arguments[0]); }
       }
       return result;
     };
@@ -366,15 +373,15 @@ export class AttributeConnection {
     Object.defineProperty(sourceObj[methodName], 'originalFunction', {
       get: getOriginal
     });
-    sourceObj[methodName].toString = () => `<Wrapped ${getOriginal()}>`
+    sourceObj[methodName].toString = () => `<Wrapped ${getOriginal()}>`;
   }
 
-  removeSourceObjGetterAndSetter() {
+  removeSourceObjGetterAndSetter () {
     // delete the getter and setter and the slot were the real value was stored
     // assign the real value to the old slot
-    var realAttrName = this.sourceAttrName,
-      helperAttrName = this.privateAttrName(realAttrName),
-      srcObj = this.sourceObj;
+    const realAttrName = this.sourceAttrName;
+    const helperAttrName = this.privateAttrName(realAttrName);
+    const srcObj = this.sourceObj;
 
     if (!srcObj) return;
 
@@ -384,11 +391,11 @@ export class AttributeConnection {
         try { srcObj[realAttrName] = srcObj[helperAttrName]; } catch (err) {}
         delete srcObj[helperAttrName];
       }
-    } else if(srcObj[realAttrName] && srcObj[realAttrName].isConnectionWrapper) {
-      let wrapper = srcObj[realAttrName];
+    } else if (srcObj[realAttrName] && srcObj[realAttrName].isConnectionWrapper) {
+      const wrapper = srcObj[realAttrName];
       delete srcObj[realAttrName];
       if (!srcObj[realAttrName]) // only restore for scripts, non-scripts are restored via prototype chain
-          srcObj[realAttrName] = wrapper.originalFunction
+      { srcObj[realAttrName] = wrapper.originalFunction; }
     }
 
     if (srcObj.doNotSerialize && srcObj.doNotSerialize.includes(helperAttrName)) {
@@ -402,35 +409,34 @@ export class AttributeConnection {
     }
   }
 
-  addAttributeConnection() {
-    if (!this.sourceObj.attributeConnections)
-      this.sourceObj.attributeConnections = [];
+  addAttributeConnection () {
+    if (!this.sourceObj.attributeConnections) { this.sourceObj.attributeConnections = []; }
     this.sourceObj.attributeConnections.push(this);
   }
 
-  getExistingConnection() {
-    var conns = this.sourceObj && this.sourceObj.attributeConnections;
+  getExistingConnection () {
+    const conns = this.sourceObj && this.sourceObj.attributeConnections;
     if (!conns) return null;
-    for (var i = 0, len = conns.length; i < len; i++) {
+    for (let i = 0, len = conns.length; i < len; i++) {
       if (this.isSimilarConnection(conns[i])) return conns[i];
     }
     return null;
   }
 
-  isRecursivelyActivated() {
+  isRecursivelyActivated () {
     // is this enough? Maybe use Stack?
-    return this.isActive
+    return this.isActive;
   }
 
-  isSimilarConnection(other) {
+  isSimilarConnection (other) {
     if (!other || other.constructor != this.constructor) return false;
-    return this.sourceObj == other.sourceObj
-        && this.sourceAttrName == other.sourceAttrName
-        && this.targetObj == other.targetObj
-        && this.targetMethodName == other.targetMethodName;
+    return this.sourceObj == other.sourceObj &&
+        this.sourceAttrName == other.sourceAttrName &&
+        this.targetObj == other.targetObj &&
+        this.targetMethodName == other.targetMethodName;
   }
 
-  toString(optValue) {
+  toString (optValue) {
     try {
       return string.format(
         'AttributeConnection(%s.%s %s %s.%s)',
@@ -439,19 +445,17 @@ export class AttributeConnection {
         optValue ? ('-->' + String(optValue) + '-->') : '-->',
         this.getTargetObj(),
         this.getTargetMethodName());
-    } catch(e) { return '<Error in AttributeConnection>>toString>'; }
+    } catch (e) { return '<Error in AttributeConnection>>toString>'; }
   }
 }
 
-
-function connect(sourceObj, attrName, targetObj, targetMethodName, specOrConverter) {
-
+function connect (sourceObj, attrName, targetObj, targetMethodName, specOrConverter) {
   // 1: is it a function connection? targetMethodName => "call"
-  if (typeof targetObj === "function"
-      && (typeof targetMethodName === "undefined"
-          || typeof targetMethodName === "object")) {
+  if (typeof targetObj === 'function' &&
+      (typeof targetMethodName === 'undefined' ||
+          typeof targetMethodName === 'object')) {
     specOrConverter = targetMethodName;
-    targetMethodName = "call";
+    targetMethodName = 'call';
     // make function.call work, passing "null" as this
     if (!specOrConverter) specOrConverter = {};
     if (!specOrConverter.updater) specOrConverter.updater = ($upd, val) => $upd(null, val);
@@ -460,81 +464,75 @@ function connect(sourceObj, attrName, targetObj, targetMethodName, specOrConvert
   // 2: determine what kind of connection to create. Default is
   //  AttributeConnection but source.connections/
   //  source.getConnectionPoints can specify different settings
-  var connectionPoints = (sourceObj.getConnectionPoints && sourceObj.getConnectionPoints())
-                         || (sourceObj.connections),
-      connectionPoint = connectionPoints && connectionPoints[attrName],
-      klass = (connectionPoint && connectionPoint.map
-               && lively.morphic && lively.morphic.GeometryConnection)
-       || (connectionPoint && connectionPoint.connectionClassType
-           && lively.Class.forName(connectionPoint.connectionClassType))
-       || AttributeConnection, spec;
+  const connectionPoints = (sourceObj.getConnectionPoints && sourceObj.getConnectionPoints()) ||
+                         (sourceObj.connections);
+  const connectionPoint = connectionPoints && connectionPoints[attrName];
+  const klass = (connectionPoint && connectionPoint.map &&
+               lively.morphic && lively.morphic.GeometryConnection) ||
+       (connectionPoint && connectionPoint.connectionClassType &&
+           lively.Class.forName(connectionPoint.connectionClassType)) ||
+       AttributeConnection; let spec;
 
   // 3: connection settings: converter/updater/...
-  if (typeof specOrConverter === "function") {
-    console.warn('Directly passing a converter function to connect() '
-               + 'is deprecated! Use spec object instead!');
-    spec = {converter: specOrConverter};
+  if (typeof specOrConverter === 'function') {
+    console.warn('Directly passing a converter function to connect() ' +
+               'is deprecated! Use spec object instead!');
+    spec = { converter: specOrConverter };
   } else spec = specOrConverter;
 
   if (connectionPoint) spec = obj.merge(connectionPoint, spec);
 
   // 4: does a similar connection exist? Yes: update it with new specs,
   //  no: create new connection
-  var connection = new klass(sourceObj, attrName, targetObj, targetMethodName, spec),
-      existing = connection.getExistingConnection();
+  const connection = new klass(sourceObj, attrName, targetObj, targetMethodName, spec);
+  const existing = connection.getExistingConnection();
   if (existing) {
     existing.resetSpec();
     existing.init(sourceObj, attrName, targetObj, targetMethodName, spec);
     return existing;
   }
 
-  var result = connection.connect();
+  const result = connection.connect();
 
   // 5: notify source object if it has a #onConnect method
-  if (typeof sourceObj.onConnect === "function")
-    sourceObj.onConnect(attrName, targetObj, targetMethodName)
+  if (typeof sourceObj.onConnect === 'function') { sourceObj.onConnect(attrName, targetObj, targetMethodName); }
 
   // 6: If wanted updated the connection right now
-  if (connectionPoint && connectionPoint.updateOnConnect)
-    connection.update(sourceObj[attrName]);
+  if (connectionPoint && connectionPoint.updateOnConnect) { connection.update(sourceObj[attrName]); }
   return result;
 }
 
-function disconnect(sourceObj, attrName, targetObj, targetMethodName) {
-
+function disconnect (sourceObj, attrName, targetObj, targetMethodName) {
   // is it a function connection? targetMethodName => "call"
-  if (typeof targetObj === "function"
-      && (typeof targetMethodName === "undefined"
-          || typeof targetMethodName === "object")) {
-    targetMethodName = "call";
+  if (typeof targetObj === 'function' &&
+      (typeof targetMethodName === 'undefined' ||
+          typeof targetMethodName === 'object')) {
+    targetMethodName = 'call';
   }
 
   if (!sourceObj.attributeConnections) return;
 
-  for (let con of sourceObj.attributeConnections.slice()) {
-    if (con.getSourceAttrName() == attrName
-        && con.getTargetObj() === targetObj
-        && con.getTargetMethodName() == targetMethodName)
-          con.disconnect();
+  for (const con of sourceObj.attributeConnections.slice()) {
+    if (con.getSourceAttrName() == attrName &&
+        con.getTargetObj() === targetObj &&
+        con.getTargetMethodName() == targetMethodName) { con.disconnect(); }
   }
 
-  if (typeof sourceObj.onDisconnect == 'function')
-    sourceObj.onDisconnect(attrName, targetObj, targetMethodName);
+  if (typeof sourceObj.onDisconnect === 'function') { sourceObj.onDisconnect(attrName, targetObj, targetMethodName); }
 }
 
-function disconnectAll(sourceObj) {
+function disconnectAll (sourceObj) {
   let con;
-  while (sourceObj.attributeConnections && (con = sourceObj.attributeConnections[0]))
-    con.disconnect();
+  while (sourceObj.attributeConnections && (con = sourceObj.attributeConnections[0])) { con.disconnect(); }
 }
 
-function once(sourceObj, attrName, targetObj, targetMethodName, spec) {
+function once (sourceObj, attrName, targetObj, targetMethodName, spec) {
   // function connection:
-  if (typeof targetObj === "function"
-      && (typeof targetMethodName === "undefined"
-          || typeof targetMethodName === "object")) {
+  if (typeof targetObj === 'function' &&
+      (typeof targetMethodName === 'undefined' ||
+          typeof targetMethodName === 'object')) {
     spec = targetMethodName;
-    targetMethodName = "call";
+    targetMethodName = 'call';
     spec = spec || {};
     // make function.call work, passing "null" as this
     if (!spec) spec = {};
@@ -545,54 +543,55 @@ function once(sourceObj, attrName, targetObj, targetMethodName, spec) {
   return connect(sourceObj, attrName, targetObj, targetMethodName, spec);
 }
 
-function signal(sourceObj, attrName, newVal) {
-  var connections = sourceObj.attributeConnections;
+function signal (sourceObj, attrName, newVal) {
+  const connections = sourceObj.attributeConnections;
   if (!connections) return;
-  var oldVal = sourceObj[attrName];
-  for (var i = 0, len = connections.length; i < len; i++) {
-    var c = connections[i];
+  const oldVal = sourceObj[attrName];
+  for (let i = 0, len = connections.length; i < len; i++) {
+    const c = connections[i];
     if (c.getSourceAttrName() == attrName) c.update(newVal, oldVal);
   }
 }
 
-export function callWhenNotNull(sourceObj, sourceProp, targetObj, targetSelector) {
+export function callWhenNotNull (sourceObj, sourceProp, targetObj, targetSelector) {
   // ensure that sourceObj[sourceProp] is not null, then run targetObj[targetProp]()
   if (sourceObj[sourceProp] != null) {
     targetObj[targetSelector](sourceObj[sourceProp]);
   } else {
     connect(
       sourceObj, sourceProp, targetObj, targetSelector,
-      {removeAfterUpdate: true});
+      { removeAfterUpdate: true });
   }
 }
 
-export function callWhenPathNotNull(source, path, target, targetProp) {
-  var helper = {
+export function callWhenPathNotNull (source, path, target, targetProp) {
+  let helper = {
     key: path.pop(),
-    whenDefined(context) {
-      callWhenNotNull(context, this.key, target, targetProp)
+    whenDefined (context) {
+      callWhenNotNull(context, this.key, target, targetProp);
     }
-  }
+  };
 
   while (path.length > 0) {
     helper = {
       key: path.pop(),
       next: helper,
-      whenDefined(context) {
-        callWhenNotNull(context, this.key, this.next, 'whenDefined')
+      whenDefined (context) {
+        callWhenNotNull(context, this.key, this.next, 'whenDefined');
       }
-    }
+    };
   }
 
   helper.whenDefined(source);
 }
 
-function noUpdate(noUpdateSpec, func) {
-  var globalNoUpdate = false, result;
-  if (!func && typeof noUpdateSpec === "function") {
-    func = noUpdateSpec; globalNoUpdate = true; }
+function noUpdate (noUpdateSpec, func) {
+  let globalNoUpdate = false; let result;
+  if (!func && typeof noUpdateSpec === 'function') {
+    func = noUpdateSpec; globalNoUpdate = true;
+  }
   if (globalNoUpdate) { // rather a hack for now
-    var proto = AttributeConnection.prototype;
+    const proto = AttributeConnection.prototype;
     if (!proto.isActive) proto.isActive = 0;
     proto.isActive++;
     try { result = func(); } finally {
@@ -600,19 +599,18 @@ function noUpdate(noUpdateSpec, func) {
       if (proto.isActive <= 0) delete proto.isActive;
     }
   } else {
-    var obj = noUpdateSpec.sourceObj,
-        attr = noUpdateSpec.sourceAttribute,
-        targetObj = noUpdateSpec.targetObj,
-        targetAttr = noUpdateSpec.targetAttribute,
-        filter = targetObj && targetAttr ?
-          ea => ea.getSourceAttrName() === attr
-                   && targetObj === ea.getTargetObj()
-                   && targetAttr === ea.getTargetMethodName() :
-          ea => ea.getSourceAttrName() === attr,
-        conns = obj.attributeConnections && obj.attributeConnections.filter(filter);
+    const obj = noUpdateSpec.sourceObj;
+    const attr = noUpdateSpec.sourceAttribute;
+    const targetObj = noUpdateSpec.targetObj;
+    const targetAttr = noUpdateSpec.targetAttribute;
+    const filter = targetObj && targetAttr
+      ? ea => ea.getSourceAttrName() === attr &&
+                   targetObj === ea.getTargetObj() &&
+                   targetAttr === ea.getTargetMethodName()
+      : ea => ea.getSourceAttrName() === attr;
+    const conns = obj.attributeConnections && obj.attributeConnections.filter(filter);
     conns && arr.invoke(conns, 'activate');
-    try { result = func(); }
-    finally { conns && arr.invoke(conns,'deactivate'); }
+    try { result = func(); } finally { conns && arr.invoke(conns, 'deactivate'); }
   }
   return result;
 }

--- a/lively.serializer2/plugins.js
+++ b/lively.serializer2/plugins.js
@@ -241,6 +241,28 @@ class LivelyClassPropertiesPlugin {
 //   }
 // }
 
+class SerializableCheckPlugin {
+  additionallySerialize (pool, ref, snapshot, addFn) {
+    const { realObj } = ref;
+    if (!realObj) return;
+
+    if (typeof realObj === 'function') {
+      console.error(`Cannot serialize anonymous function ${realObj}`);
+      return;
+    }
+
+    Object.keys(realObj).forEach(key => {
+      if (!this._serializable(realObj[key])) {
+        console.error(`Attribute cannot be serialized: ${key} of ${realObj}. Might be an anonymous function?`);
+      }
+    });
+  }
+
+  _serializable (object) {
+    return typeof object !== 'function' || !!object[Symbol.for('lively-module-meta')];
+  }
+}
+
 export var plugins = {
   livelyClassPropertiesPlugin: new LivelyClassPropertiesPlugin(),
   dontSerializePropsPlugin: new DontSerializePropsPlugin(),
@@ -249,6 +271,7 @@ export var plugins = {
   classPlugin: new ClassPlugin(),
   customSerializePlugin: new CustomSerializePlugin(),
   indicationPlugin: new SerializationIndicationPlugin(),
+  serializableCheckPlugin: new SerializableCheckPlugin(),
   finishPlugin: new SerializationFinishPlugin()
 };
 
@@ -260,5 +283,6 @@ export var allPlugins = [
   plugins.onlySerializePropsPlugin,
   plugins.dontSerializePropsPlugin,
   plugins.livelyClassPropertiesPlugin,
+  plugins.serializableCheckPlugin,
   plugins.finishPlugin
 ];

--- a/lively.serializer2/plugins.js
+++ b/lively.serializer2/plugins.js
@@ -1,5 +1,4 @@
-import { obj } from "lively.lang";
-
+import { obj } from 'lively.lang';
 
 /*
 
@@ -28,7 +27,6 @@ propertiesToSerialize(pool, ref, snapshot, keysSoFar)
 additionallySerialize(pool, ref, snapshot, addFn)
   Can modify `snapshot`.  Return value is not used.
 
-
 # deserialization
 
 beforeDeserialization(pool, idAndSnapshot)
@@ -56,117 +54,99 @@ additionallyDeserializeAfterProperties(pool, ref, newObj, snapshot, serializedOb
 export class Plugin {
 }
 
-
 class CustomSerializePlugin {
-
   // can realObj be manually serialized, e.g. into an expression?
-  serializeObject(realObj, isProperty, pool, serializedObjMap, path) {
-    if (typeof realObj.__serialize__ !== "function") return null;
+  serializeObject (realObj, isProperty, pool, serializedObjMap, path) {
+    if (typeof realObj.__serialize__ !== 'function') return null;
     let serialized = realObj.__serialize__(pool, serializedObjMap, path);
-    if (serialized && serialized.hasOwnProperty("__expr__")) {
-      let expr = pool.expressionSerializer.exprStringEncode(serialized);
-      serialized = isProperty ? expr : {__expr__: expr};
+    if (serialized && serialized.hasOwnProperty('__expr__')) {
+      const expr = pool.expressionSerializer.exprStringEncode(serialized);
+      serialized = isProperty ? expr : { __expr__: expr };
     }
     return serialized;
   }
 
-  deserializeObject(pool, ref, snapshot, path) {
-    let {__expr__} = snapshot;
+  deserializeObject (pool, ref, snapshot, path) {
+    const { __expr__ } = snapshot;
     return __expr__ ? pool.expressionSerializer.deserializeExpr(__expr__) : null;
   }
-
 }
 
 class ClassPlugin {
-
   // record class meta info for re-instantiating
-  additionallySerialize(pool, ref, snapshot, addFn) {
+  additionallySerialize (pool, ref, snapshot, addFn) {
     pool.classHelper.addClassInfo(ref, ref.realObj, snapshot);
   }
 
-  deserializeObject(pool, ref, snapshot, path) {
+  deserializeObject (pool, ref, snapshot, path) {
     return pool.classHelper.restoreIfClassInstance(ref, snapshot);
   }
-
 }
 
 class SerializationIndicationPlugin {
-  
-  serializeObject(realObj, isProperty, pool, serializedObjMap, path) {
-    if (realObj && realObj.isMorph)
-      realObj.__isBeingSerialized__ = true;
+  serializeObject (realObj, isProperty, pool, serializedObjMap, path) {
+    if (realObj && realObj.isMorph) { realObj.__isBeingSerialized__ = true; }
     return null; // do not intercept serialization
   }
-  
 }
 
 class SerializationFinishPlugin {
-  additionallySerialize(pool, ref, snapshot, addFn) {
-    if (ref.realObj && ref.realObj.isMorph)
-      ref.realObj.__isBeingSerialized__ = false;
+  additionallySerialize (pool, ref, snapshot, addFn) {
+    if (ref.realObj && ref.realObj.isMorph) { ref.realObj.__isBeingSerialized__ = false; }
   }
 }
 
 class AdditionallySerializePlugin {
   // for objects with __additionally_serialize__(snapshot, ref, pool, addFn) method
 
-  additionallySerialize(pool, ref, snapshot, addFn) {
-    let {realObj} = ref;
-    if (realObj && typeof realObj.__additionally_serialize__  === "function")
-      realObj.__additionally_serialize__(snapshot, ref, pool, addFn);
+  additionallySerialize (pool, ref, snapshot, addFn) {
+    const { realObj } = ref;
+    if (realObj && typeof realObj.__additionally_serialize__ === 'function') { realObj.__additionally_serialize__(snapshot, ref, pool, addFn); }
   }
 
-  additionallyDeserializeBeforeProperties(pool, ref, newObj, props, snapshot, serializedObjMap, path) {
-    if (typeof newObj.__deserialize__ === "function")
-      newObj.__deserialize__(snapshot, ref, serializedObjMap, pool, path);
+  additionallyDeserializeBeforeProperties (pool, ref, newObj, props, snapshot, serializedObjMap, path) {
+    if (typeof newObj.__deserialize__ === 'function') { newObj.__deserialize__(snapshot, ref, serializedObjMap, pool, path); }
   }
 
-  additionallyDeserializeAfterProperties(pool, ref, newObj, snapshot, serializedObjMap, path) {
-    if (typeof newObj.__after_deserialize__ === "function")
-      newObj.__after_deserialize__(snapshot, ref, pool);
+  additionallyDeserializeAfterProperties (pool, ref, newObj, snapshot, serializedObjMap, path) {
+    if (typeof newObj.__after_deserialize__ === 'function') { newObj.__after_deserialize__(snapshot, ref, pool); }
   }
-
 }
 
 class OnlySerializePropsPlugin {
-
- propertiesToSerialize(pool, ref, snapshot, keysSoFar) {
-   let {realObj} = ref;
-   return (realObj && realObj.__only_serialize__) || null;
- }
+  propertiesToSerialize (pool, ref, snapshot, keysSoFar) {
+    const { realObj } = ref;
+    return (realObj && realObj.__only_serialize__) || null;
+  }
 }
 
 class DontSerializePropsPlugin {
-
- propertiesToSerialize(pool, ref, snapshot, keysSoFar) {
-   let {realObj} = ref;
-   if (!realObj || !realObj.__dont_serialize__) return null;
-   let ignoredKeys = obj.mergePropertyInHierarchy(realObj, "__dont_serialize__"),
-       keys = [];
-   for (let i = 0; i < keysSoFar.length; i++) {
-     let key = keysSoFar[i];
-     if (!ignoredKeys.includes(key))
-       keys.push(key);
-   }
-   return keys;
- }
-
+  propertiesToSerialize (pool, ref, snapshot, keysSoFar) {
+    const { realObj } = ref;
+    if (!realObj || !realObj.__dont_serialize__) return null;
+    const ignoredKeys = obj.mergePropertyInHierarchy(realObj, '__dont_serialize__');
+    const keys = [];
+    for (let i = 0; i < keysSoFar.length; i++) {
+      const key = keysSoFar[i];
+      if (!ignoredKeys.includes(key)) { keys.push(key); }
+    }
+    return keys;
+  }
 }
 
 class LivelyClassPropertiesPlugin {
-
-  propertiesToSerialize(pool, ref, snapshot, keysSoFar) {
+  propertiesToSerialize (pool, ref, snapshot, keysSoFar) {
     // serialize class properties as indicated by realObj.constructor.properties
-    let {realObj} = ref,
-        classProperties = realObj.constructor[Symbol.for("lively.classes-properties-and-settings")];
+    const { realObj } = ref;
+    const classProperties = realObj.constructor[Symbol.for('lively.classes-properties-and-settings')];
 
     if (!classProperties) return null;
 
-    let {properties, propertySettings} = classProperties,
-        valueStoreProperty = propertySettings.valueStoreProperty || "_state",
-        valueStore = realObj[valueStoreProperty],
-        only = !!realObj.__only_serialize__,
-        keys = [];
+    const { properties, propertySettings } = classProperties;
+    const valueStoreProperty = propertySettings.valueStoreProperty || '_state';
+    const valueStore = realObj[valueStoreProperty];
+    const only = !!realObj.__only_serialize__;
+    const keys = [];
 
     if (!valueStore) return;
 
@@ -175,12 +155,12 @@ class LivelyClassPropertiesPlugin {
     // was producing that list.
 
     if (only) {
-      for (var i = 0; i < keysSoFar.length; i++) {
-        let key = keysSoFar[i], spec = properties[key];
+      for (let i = 0; i < keysSoFar.length; i++) {
+        const key = keysSoFar[i]; const spec = properties[key];
         if (key === valueStoreProperty) continue;
         if (spec) {
-          if (spec && (spec.derived || spec.readOnly
-                    || (spec.hasOwnProperty("serialize") && !spec.serialize))) continue;
+          if (spec && (spec.derived || spec.readOnly ||
+                    (spec.hasOwnProperty('serialize') && !spec.serialize))) continue;
         }
         keys.push(key);
       }
@@ -188,31 +168,29 @@ class LivelyClassPropertiesPlugin {
     }
 
     // Otherwise properties add to keysSoFar
-    var valueStoreKeyIdx = keysSoFar.indexOf(valueStoreProperty);
+    const valueStoreKeyIdx = keysSoFar.indexOf(valueStoreProperty);
     if (valueStoreKeyIdx > -1) keysSoFar.splice(valueStoreKeyIdx, 1);
 
-    for (var key in properties) {
-      var spec = properties[key],
-          idx = keysSoFar.indexOf(key);
+    for (const key in properties) {
+      const spec = properties[key];
+      const idx = keysSoFar.indexOf(key);
       if (spec.derived || spec.readOnly ||
-          (spec.hasOwnProperty("serialize") && !spec.serialize)) {
+          (spec.hasOwnProperty('serialize') && !spec.serialize)) {
         if (idx > -1) keysSoFar.splice(idx, 1);
       } else if (idx === -1) keys.push(key);
     }
     return keys.concat(keysSoFar);
-
   }
 
-
-  additionallyDeserializeBeforeProperties(pool, ref, newObj, props, snapshot, serializedObjMap, path) {
+  additionallyDeserializeBeforeProperties (pool, ref, newObj, props, snapshot, serializedObjMap, path) {
     // deserialize class properties as indicated by realObj.constructor.properties
-    var classProperties = newObj.constructor[Symbol.for("lively.classes-properties-and-settings")];
-    
+    const classProperties = newObj.constructor[Symbol.for('lively.classes-properties-and-settings')];
+
     if (!classProperties) return props;
 
-    var {properties, propertySettings, order: sortedKeys } = classProperties,
-        valueStoreProperty = propertySettings.valueStoreProperty || "_state",
-        props = snapshot.props;
+    const { properties, propertySettings, order: sortedKeys } = classProperties;
+    const valueStoreProperty = propertySettings.valueStoreProperty || '_state';
+    var props = snapshot.props;
 
     // if props has a valueStoreProperty then we directly deserialize that.
     // As of 2017-02-26 this is for backwards compat.
@@ -220,13 +198,12 @@ class LivelyClassPropertiesPlugin {
 
     props = obj.clone(props);
 
-    if (!newObj.hasOwnProperty(valueStoreProperty))
-      newObj.initializeProperties();
+    if (!newObj.hasOwnProperty(valueStoreProperty)) { newObj.initializeProperties(); }
 
-    var valueStore = newObj[valueStoreProperty];
-    for (var i = 0; i < sortedKeys.length; i++) {
-      var key = sortedKeys[i],
-          spec = properties[key];
+    const valueStore = newObj[valueStoreProperty];
+    for (let i = 0; i < sortedKeys.length; i++) {
+      const key = sortedKeys[i];
+      const spec = properties[key];
       if (!props.hasOwnProperty(key)) continue;
       ref.recreatePropertyAndSetProperty(newObj, props, key, serializedObjMap, pool, path);
       delete props[key];
@@ -237,19 +214,19 @@ class LivelyClassPropertiesPlugin {
 }
 
 // export class LeakDetectorPlugin {
-//   
+//
 //   afterSerialization(pool, snapshot, realObj) {
 //     let i = SnapshotInspector.forPoolAndSnapshot(snapshot, pool),
-//         weakRefs = new Set([...(i.classes.AttributeConnection || {objects: []}).objects, 
+//         weakRefs = new Set([...(i.classes.AttributeConnection || {objects: []}).objects,
 //                             ...(i.classes["{source, target}"] || {objects: []}).objects,
 //                             ...(i.classes["{_rev, source, target}"] || {objects: []}).objects].map(c => c[0])),
 //         G = i.referenceGraph(), invG = graph.invert(G),
 //         memoryLeaks = arr.compact(
 //                       arr.flatten(Object.entries(invG)
-//                          .filter(([id, c]) => 
-//                              c.length < 3 
-//                              && snapshot.id != id 
-//                              && !weakRefs.has(id) 
+//                          .filter(([id, c]) =>
+//                              c.length < 3
+//                              && snapshot.id != id
+//                              && !weakRefs.has(id)
 //                              && c.every(r => weakRefs.has(r)))
 //                          .map(([id]) => {
 //                            let subgraph = graph.subgraphReachableBy(G, id), obj = pool.resolveToObj(id);
@@ -266,14 +243,14 @@ class LivelyClassPropertiesPlugin {
 
 export var plugins = {
   livelyClassPropertiesPlugin: new LivelyClassPropertiesPlugin(),
-  dontSerializePropsPlugin:    new DontSerializePropsPlugin(),
-  onlySerializePropsPlugin:    new OnlySerializePropsPlugin(),
+  dontSerializePropsPlugin: new DontSerializePropsPlugin(),
+  onlySerializePropsPlugin: new OnlySerializePropsPlugin(),
   additionallySerializePlugin: new AdditionallySerializePlugin(),
-  classPlugin:                 new ClassPlugin(),
-  customSerializePlugin:       new CustomSerializePlugin(),
-  indicationPlugin:            new SerializationIndicationPlugin(),
-  finishPlugin:                new SerializationFinishPlugin(),
-}
+  classPlugin: new ClassPlugin(),
+  customSerializePlugin: new CustomSerializePlugin(),
+  indicationPlugin: new SerializationIndicationPlugin(),
+  finishPlugin: new SerializationFinishPlugin()
+};
 
 export var allPlugins = [
   plugins.indicationPlugin,
@@ -283,5 +260,5 @@ export var allPlugins = [
   plugins.onlySerializePropsPlugin,
   plugins.dontSerializePropsPlugin,
   plugins.livelyClassPropertiesPlugin,
-  plugins.finishPlugin,
-]
+  plugins.finishPlugin
+];

--- a/lively.serializer2/plugins/expression-serializer.js
+++ b/lively.serializer2/plugins/expression-serializer.js
@@ -1,24 +1,24 @@
-import { string, Closure, Path, obj, properties, arr } from "lively.lang";
-import { getSerializableClassMeta } from "../class-helper.js";
-import { connect } from "lively.bindings";
-/*global System*/
+import { string, Closure, Path, obj, properties, arr } from 'lively.lang';
+import { getSerializableClassMeta } from '../class-helper.js';
+import { connect } from 'lively.bindings';
+import { joinPath } from 'lively.lang/string.js';
+/* global System */
 export default class ExpressionSerializer {
-
-  constructor(opts) {
-    var {prefix} = {
-      prefix: "__lv_expr__",
+  constructor (opts) {
+    const { prefix } = {
+      prefix: '__lv_expr__',
       ...opts
-    }
-    this.prefix = prefix + ":";
+    };
+    this.prefix = prefix + ':';
   }
 
-  isSerializedExpression(string) {
+  isSerializedExpression (string) {
     return string.indexOf(this.prefix) === 0;
   }
 
-  requiredModulesOf__expr__(__expr__) {
+  requiredModulesOf__expr__ (__expr__) {
     if (!this.isSerializedExpression(__expr__)) return null;
-    var {bindings} = this.exprStringDecode(__expr__);
+    const { bindings } = this.exprStringDecode(__expr__);
     return bindings ? Object.keys(bindings) : null;
   }
 
@@ -26,108 +26,114 @@ export default class ExpressionSerializer {
   // encode / decode of serialized expressions
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  exprStringDecode(string) {
+  exprStringDecode (string) {
     // 1. read prefix
     // string = "_prefix:{foo}:package/foo.js:foo()"
     // => {expr: "foo()", bindings: {"package/foo.js": ["foo"]}}
 
-    let idx = string.indexOf(":"),
-        prefix = string.slice(0, idx),
-        rest = string.slice(idx+1),
-        bindings = {},
-        httpPlaceholder = `__HTTP_PLACEHOLDER__`,
-        hasBindings = false;
+    let idx = string.indexOf(':');
+    const prefix = string.slice(0, idx);
+    let rest = string.slice(idx + 1);
+    const bindings = {};
+    const httpPlaceholder = '__HTTP_PLACEHOLDER__';
+    let hasBindings = false;
 
     // 2. bindings?
-    while (rest && rest.startsWith("{") && (idx = rest.indexOf("}:")) >= 0) {
+    while (rest && rest.startsWith('{') && (idx = rest.indexOf('}:')) >= 0) {
       hasBindings = true;
-      let importedVars = rest.slice(1,idx);
-      rest = rest.slice(idx+2); // skip }:
+      const importedVars = rest.slice(1, idx);
+      rest = rest.slice(idx + 2); // skip }:
       if (rest.includes('https:') && rest.indexOf('https:') < rest.indexOf(':')) {
         rest = rest.replace('https:', httpPlaceholder);
-        idx = rest.indexOf(":") - httpPlaceholder.length + 'https:'.length;
+        idx = rest.indexOf(':') - httpPlaceholder.length + 'https:'.length;
         rest = rest.replace(httpPlaceholder, 'https:');
-      } else idx = rest.indexOf(":") // end of package
-      let from = rest.slice(0, idx),
-          imports = importedVars.split(",")
-            .filter(ea => Boolean(ea.trim()))
-            .map(ea => {
-              if (!ea.includes(":")) return ea;
-              let [exported, local] = ea.split(":");
-              return {exported, local};
-            })
+      } else idx = rest.indexOf(':'); // end of package
+      const from = rest.slice(0, idx);
+      const imports = importedVars.split(',')
+        .filter(ea => Boolean(ea.trim()))
+        .map(ea => {
+          if (!ea.includes(':')) return ea;
+          const [exported, local] = ea.split(':');
+          return { exported, local };
+        });
       bindings[from] = imports;
-      rest = rest.slice(idx+1); // skip :
+      rest = rest.slice(idx + 1); // skip :
     }
 
-    return {__expr__: rest, bindings: hasBindings ? bindings : null};
+    return { __expr__: rest, bindings: hasBindings ? bindings : null };
   }
 
-  exprStringEncode({__expr__, bindings}) {
+  exprStringEncode ({ __expr__, bindings }) {
     // {expr: "foo()", bindings: {"package/foo.js": ["foo"]}}
     // => "_prefix:{foo}:package/foo.js:foo()"
 
-    var string = String(__expr__);
+    let string = String(__expr__);
     if (bindings) {
-      var keys = Object.keys(bindings);
-      for (var i = 0; i < keys.length; i++) {
-        var from = keys[i], binding = bindings[from];
+      const keys = Object.keys(bindings);
+      for (let i = 0; i < keys.length; i++) {
+        const from = keys[i]; let binding = bindings[from];
         if (Array.isArray(binding)) {
           binding = binding.map(ea =>
-            typeof ea === "string" ? ea : ea.exported + ":" + ea.local).join(",")
+            typeof ea === 'string' ? ea : ea.exported + ':' + ea.local).join(',');
         }
         string = `{${binding}}:${from}:${string}`;
       }
     }
-    return this.prefix + string
+    return this.prefix + string;
   }
 
+  getExpressionForFunction (func) {
+    const { package: pkg, pathInPackage } = func[Symbol.for('lively-module-meta')];
+    return this.exprStringEncode({
+      __expr__: func.name,
+      bindings: {
+        [joinPath(pkg.name, pathInPackage)]: [func.name]
+      }
+    });
+  }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // serialization
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-  
-  convert__expr__obj(obj) {
+
+  convert__expr__obj (obj) {
     // obj.__expr__ is encoded serialized expression *without* prefix
-    console.assert("__expr__" in obj, "obj has no property __expr__");
+    console.assert('__expr__' in obj, 'obj has no property __expr__');
     return this.prefix + obj.__expr__;
   }
 
-  
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // deserialization
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
   // note __boundValues__ becomes a dynamically scoped "variable" inside eval
-  __eval__(source, boundValues) { 
-    return __eval__(source, boundValues); 
+  __eval__ (source, boundValues) {
+    return __eval__(source, boundValues);
   }
 
-  deserializeExpr(encoded) {
-    if (!encoded.startsWith(this.prefix))
-      throw new Error(`"${encoded}" is not a serialized expression, missing prefix "${this.prefix}"`);
+  deserializeExpr (encoded) {
+    if (!encoded.startsWith(this.prefix)) { throw new Error(`"${encoded}" is not a serialized expression, missing prefix "${this.prefix}"`); }
     return this.deserializeExprObj(this.exprStringDecode(encoded));
   }
 
-  deserializeExprObj({__expr__: source, bindings}) {
-
-    let __boundValues__ = {};
+  deserializeExprObj ({ __expr__: source, bindings }) {
+    const __boundValues__ = {};
 
     if (bindings) {
-      let mods = bindings ? Object.keys(bindings) : [];
+      const mods = bindings ? Object.keys(bindings) : [];
 
       // synchronously get modules specified in bindings object and pull out
       // the vars needed for evaluating source. Add those to __boundValues__
       for (let i = 0; i < mods.length; i++) {
-        let modName = mods[i],
-            vars = bindings[modName],
-            exports;
+        const modName = mods[i];
+        const vars = bindings[modName];
+        let exports;
         if (lively.FreezerRuntime) {
           exports = lively.FreezerRuntime.get(lively.FreezerRuntime.decanonicalize(modName));
           if (!exports) {
             // try to fetch if global is defined
-            let mod = lively.FreezerRuntime.fetchStandaloneFor(modName);
-            if (mod) exports = mod.exports; 
+            const mod = lively.FreezerRuntime.fetchStandaloneFor(modName);
+            if (mod) exports = mod.exports;
           }
           if (exports.exports) exports = exports.exports;
         } else {
@@ -141,11 +147,11 @@ export default class ExpressionSerializer {
           }`);
         }
         for (let j = 0; j < vars.length; j++) {
-          let varName = vars[j], local, exported;
-          if (typeof varName === "string") {
+          const varName = vars[j]; let local; let exported;
+          if (typeof varName === 'string') {
             local = varName; exported = varName;
-          } else if (typeof varName === "object") { // alias
-            ({local, exported} = varName);
+          } else if (typeof varName === 'object') { // alias
+            ({ local, exported } = varName);
           }
           __boundValues__[local] = exports[exported];
           source = `var ${local} = __boundValues__.${local};\n${source}`;
@@ -156,7 +162,6 @@ export default class ExpressionSerializer {
     // evaluate
     return this.__eval__(source, __boundValues__);
   }
-
 }
 
 /*
@@ -171,15 +176,15 @@ const __eval__ = Closure.fromSource(`function __eval__(__source__, __boundValues
   return eval(__source__); 
 }`).getFunc();
 
-export function deserializeSpec(serializedSpec, subSpecHandler = (spec) => spec, base = {}) {
+export function deserializeSpec (serializedSpec, subSpecHandler = (spec) => spec, base = {}) {
   const exprSerializer = new ExpressionSerializer();
-  let deserializedSpec = base;
-  let props = base.isMorph ? base.propertiesAndPropertySettings().order : []
+  const deserializedSpec = base;
+  let props = base.isMorph ? base.propertiesAndPropertySettings().order : [];
   props = props.length ? props : obj.keys(serializedSpec);
 
-  for (let prop of props) {
+  for (const prop of props) {
     let value = serializedSpec[prop];
-    if (prop ==='_env' || prop ==='env' || prop === '__connections__' || prop === '__refs__') return;
+    if (prop === '_env' || prop === 'env' || prop === '__connections__' || prop === '__refs__') return;
     if (obj.isString(value) && exprSerializer.isSerializedExpression(value)) {
       value = exprSerializer.deserializeExpr(value);
     }
@@ -191,29 +196,31 @@ export function deserializeSpec(serializedSpec, subSpecHandler = (spec) => spec,
     }
     deserializedSpec[prop] = value;
   }
-  
-  if (serializedSpec.submorphs) deserializedSpec.submorphs = serializedSpec.submorphs.map(spec => {
-    return deserializeSpec(spec, subSpecHandler)
-  });
+
+  if (serializedSpec.submorphs) {
+    deserializedSpec.submorphs = serializedSpec.submorphs.map(spec => {
+      return deserializeSpec(spec, subSpecHandler);
+    });
+  }
 
   if (base) {
-    for (let prop of props.filter(key => !!serializedSpec[key])) base[prop] = deserializedSpec[prop];
+    for (const prop of props.filter(key => !!serializedSpec[key])) base[prop] = deserializedSpec[prop];
   }
-  
+
   if (serializedSpec.__refs__) {
-    for (let [pathToParent, pathToVal] of serializedSpec.__refs__) {
+    for (const [pathToParent, pathToVal] of serializedSpec.__refs__) {
       Path(pathToParent).set(deserializedSpec, Path(pathToVal).get(deserializedSpec));
     }
   }
   if (serializedSpec.__connections__) {
-    for (let conn of serializedSpec.__connections__) {
+    for (const conn of serializedSpec.__connections__) {
       connect(
         Path(conn.pathToSource).get(deserializedSpec),
         conn.sourceAttrName,
         Path(conn.pathToTarget).get(deserializedSpec),
         conn.targetMethodName, {
           ...obj.select(conn, ['garbageCollect', 'converterString', 'updaterString', 'varMapping'])
-      });
+        });
     }
   }
   return deserializedSpec;
@@ -221,205 +228,211 @@ export function deserializeSpec(serializedSpec, subSpecHandler = (spec) => spec,
 
 // this.exportToJSON()
 
-export function serializeSpec(morph, opts = {}) {
+export function serializeSpec (morph, opts = {}) {
   // quick hack to "snapshot" into JSON or serialized expression
-    var { 
-      keepFunctions = true,
-      skipAttributes = [],
-      keepConnections = true,
-      asExpression = false, 
-      root = true,
-      path = '',
-      skipUnchangedFromDefault = false,
-      nestedExpressions = {},
-      objToPath = new WeakMap(),
-      objRefs = [],
-      connections = [],
-    } = opts;
-    let subopts = {
-      skipAttributes,
-      skipUnchangedFromDefault,
-      root: false,
-      keepFunctions,
-      asExpression,
-      nestedExpressions,
-      connections,
-      objRefs,
-      objToPath,
-      keepConnections
-    };
+  let {
+    keepFunctions = true,
+    skipAttributes = [],
+    keepConnections = true,
+    asExpression = false,
+    root = true,
+    path = '',
+    skipUnchangedFromDefault = false,
+    nestedExpressions = {},
+    objToPath = new WeakMap(),
+    objRefs = [],
+    connections = []
+  } = opts;
+  const subopts = {
+    skipAttributes,
+    skipUnchangedFromDefault,
+    root: false,
+    keepFunctions,
+    asExpression,
+    nestedExpressions,
+    connections,
+    objRefs,
+    objToPath,
+    keepConnections
+  };
 
-    if (objToPath.has(morph)) {
-      // morph was already serialized, add ref and return
-      objRefs.push([path, /* => */ objToPath.get(morph)]) // store assignment
-      return null;
-    } else objToPath.set(morph, path);
-    if (asExpression) keepFunctions = false;
-    const exprSerializer = new ExpressionSerializer();
-    const getExpression = (name, val) => {
-      try {
-          val = val.__serialize__(); // serializeble expressions
-          if (asExpression) {
-            let exprId = string.newUUID();
-            nestedExpressions[exprId] = val;
-            val = exprId;
-          } else val = val.__expr__ ? exprSerializer.exprStringEncode(val) : val;
-        } catch (e) {
-          console.log(`[export to JSON] failed converting ${name} to serialized expression`); 
-        }
-      return val;
+  if (objToPath.has(morph)) {
+    // morph was already serialized, add ref and return
+    objRefs.push([path, /* => */ objToPath.get(morph)]); // store assignment
+    return null;
+  } else objToPath.set(morph, path);
+  if (asExpression) keepFunctions = false;
+  const exprSerializer = new ExpressionSerializer();
+  const getExpression = (name, val) => {
+    try {
+      val = val.__serialize__(); // serializeble expressions
+      if (asExpression) {
+        const exprId = string.newUUID();
+        nestedExpressions[exprId] = val;
+        val = exprId;
+      } else val = val.__expr__ ? exprSerializer.exprStringEncode(val) : val;
+    } catch (e) {
+      console.log(`[export to JSON] failed converting ${name} to serialized expression`);
     }
+    return val;
+  };
 
-    var exported = {};
+  const exported = {};
 
-    objToPath.set(morph, path);
+  objToPath.set(morph, path);
 
-    if (keepConnections && morph.attributeConnections)
-      connections.push(...morph.attributeConnections);
+  if (keepConnections && morph.attributeConnections) { connections.push(...morph.attributeConnections); }
 
-    if (morph.isText) {
-      exported.textAndAttributes = morph.textAndAttributes.map((ea, i) => {
-        return ea && ea.isMorph ? serializeSpec(ea, {
-           ...subopts,
-           path: path ? path + '.textAndAttributes.' + i : 'textAndAttributes.' + i ,
-        }) : ea
-      })
-    }
-
-    if (morph.submorphs && morph.submorphs.length > 0) {
-      exported.submorphs = morph.submorphs.map((ea, i) => serializeSpec(ea, {
-        ...subopts,
-        path: path ? path + '.submorphs.' + i : 'submorphs.' + i ,
-      })).filter(Boolean);
-    }
-
-    for (let name in morph.spec(skipUnchangedFromDefault)) {
-      let val = morph[name];
-      if (val && typeof val === 'object' && !Array.isArray(val) && !val.isMorph) {
-        objToPath.set(val, path ? path + '.' + name : name);
-      }
-      if (name === "submorphs") continue;
-      if (skipAttributes.includes(name)) continue;
-      if (name === 'metadata' && Path('commit.__serialize__').get(val)) {
-        exported[name] = { ...val, commit: getExpression(name + '.commit', val.commit)};
-        continue;
-      }
-      if (['borderColor', 'borderWidth', 'borderStyle', 'borderRadius'].includes(name)) {
-        let serializedVal = {};
-        for (let mem of ['top', 'left', 'right', 'bottom']) {
-          let memberValue = val[mem];
-          if (memberValue && memberValue.__serialize__) {
-             memberValue = memberValue.__serialize__();
-             if (memberValue && memberValue.__expr__) {
-               if (asExpression) {
-                 let uuid = string.newUUID();
-                 nestedExpressions[uuid] = memberValue;
-                 memberValue = uuid;
-               } else memberValue = exprSerializer.exprStringEncode(memberValue)
-             }
-          }
-          serializedVal[mem] = memberValue; 
-        }
-        exported[name] = serializedVal;
-        continue;
-      }
-      if (val && val.isMorph) {
-        exported[name] = serializeSpec(val, {
+  if (morph.isText) {
+    exported.textAndAttributes = morph.textAndAttributes.map((ea, i) => {
+      return ea && ea.isMorph
+        ? serializeSpec(ea, {
           ...subopts,
-          path: path ? path + "." + name : name
-        });
-        continue;
-      }
-      if (val && val.__serialize__) {
-        exported[name] = getExpression(name, val);
-        continue;
-      }
-      if (Array.isArray(val)) {
-        // check if each array member is seralizable
-        exported[name] = val.map((v, i) => {
-          if (v && v.isMorph)
-            return serializeSpec(v, {
-              ...subopts,
-              path: path ? path + '.' + name + '.' + i : name + '.' + i
-            });
-          if (v && v.__serialize__) {
-            return getExpression(name + '.' + i, v);
-          }
-          return v;
-        });
-        continue;
-      }
-      if (val && !obj.isString(val) && !obj.isNumber(val) &&          
-         properties.allOwnPropertiesOrFunctions(val).length > 0) {
-         for (let prop in val) {
-           if (val[prop] && val[prop].isMorph) val[prop] = serializeSpec(val[prop], {
-             ...subopts,
-             path: path ? path + '.' + name + '.' + prop : name + '.' + prop
-           });
-         }
-      }
-      exported[name] = val;
-    }
+          path: path ? path + '.textAndAttributes.' + i : 'textAndAttributes.' + i
+        })
+        : ea;
+    });
+  }
 
-    if (morph.isText) delete exported.textString;
-    
-    if (!asExpression) exported._id = morph._id;
-    if (keepFunctions) {
-      exported.type = morph.constructor; // not JSON!
-      Object.keys(morph).forEach(name =>
-        typeof morph[name] === "function" && (exported[name] = morph[name]));
-    } else {
-      if (exported.styleSheets) exported.styleSheets = [];
-      exported.type = getSerializableClassMeta(morph);
+  if (morph.submorphs && morph.submorphs.length > 0) {
+    exported.submorphs = morph.submorphs.map((ea, i) => serializeSpec(ea, {
+      ...subopts,
+      path: path ? path + '.submorphs.' + i : 'submorphs.' + i
+    })).filter(Boolean);
+  }
+
+  for (const name in morph.spec(skipUnchangedFromDefault)) {
+    const val = morph[name];
+    if (val && typeof val === 'object' && !Array.isArray(val) && !val.isMorph) {
+      objToPath.set(val, path ? path + '.' + name : name);
     }
-    // this.exportToJSON()
-    if (keepConnections && root) {
-       /*
-         Right now we can only reconstruct connections which are between morphs 
+    if (name === 'submorphs') continue;
+    if (skipAttributes.includes(name)) continue;
+    if (name === 'metadata' && Path('commit.__serialize__').get(val)) {
+      exported[name] = { ...val, commit: getExpression(name + '.commit', val.commit) };
+      continue;
+    }
+    if (['borderColor', 'borderWidth', 'borderStyle', 'borderRadius'].includes(name)) {
+      const serializedVal = {};
+      for (const mem of ['top', 'left', 'right', 'bottom']) {
+        let memberValue = val[mem];
+        if (memberValue && memberValue.__serialize__) {
+          memberValue = memberValue.__serialize__();
+          if (memberValue && memberValue.__expr__) {
+            if (asExpression) {
+              const uuid = string.newUUID();
+              nestedExpressions[uuid] = memberValue;
+              memberValue = uuid;
+            } else memberValue = exprSerializer.exprStringEncode(memberValue);
+          }
+        }
+        serializedVal[mem] = memberValue;
+      }
+      exported[name] = serializedVal;
+      continue;
+    }
+    if (val && val.isMorph) {
+      exported[name] = serializeSpec(val, {
+        ...subopts,
+        path: path ? path + '.' + name : name
+      });
+      continue;
+    }
+    if (val && val.__serialize__) {
+      exported[name] = getExpression(name, val);
+      continue;
+    }
+    if (Array.isArray(val)) {
+      // check if each array member is seralizable
+      exported[name] = val.map((v, i) => {
+        if (v && v.isMorph) {
+          return serializeSpec(v, {
+            ...subopts,
+            path: path ? path + '.' + name + '.' + i : name + '.' + i
+          });
+        }
+        if (v && v.__serialize__) {
+          return getExpression(name + '.' + i, v);
+        }
+        return v;
+      });
+      continue;
+    }
+    if (val && !obj.isString(val) && !obj.isNumber(val) &&
+         properties.allOwnPropertiesOrFunctions(val).length > 0) {
+      for (const prop in val) {
+        if (val[prop] && val[prop].isMorph) {
+          val[prop] = serializeSpec(val[prop], {
+            ...subopts,
+            path: path ? path + '.' + name + '.' + prop : name + '.' + prop
+          });
+        }
+      }
+    }
+    exported[name] = val;
+  }
+
+  if (morph.isText) delete exported.textString;
+
+  if (!asExpression) exported._id = morph._id;
+  if (keepFunctions) {
+    exported.type = morph.constructor; // not JSON!
+    Object.keys(morph).forEach(name =>
+      typeof morph[name] === 'function' && (exported[name] = morph[name]));
+  } else {
+    if (exported.styleSheets) exported.styleSheets = [];
+    exported.type = getSerializableClassMeta(morph);
+  }
+  // this.exportToJSON()
+  if (keepConnections && root) {
+    /*
+         Right now we can only reconstruct connections which are between morphs
          or objects which are directly referenced by a morph. Other ones are skipped.
        */
-       let connectionExpressions = []
-       for (let conn of connections) {
-         let { 
-           sourceAttrName, targetMethodName, sourceObj, targetObj,
-           updaterString, converterString, varMapping, garbageCollect
-         } = conn;
-         let pathToSource = objToPath.get(sourceObj);
-         let pathToTarget = objToPath.get(targetObj);
-         if (typeof pathToSource === 'string' && typeof pathToTarget === 'string') {
-           connectionExpressions.push({
-             pathToSource, pathToTarget, garbageCollect,
-             updaterString, converterString,
-             sourceAttrName, targetMethodName,
-             varMapping: {
-               properties
-             }
-           })
-           continue;
-         }
-         console.log('skipping:', conn);
-       }
-      if (!asExpression) exported.__connections__ = connectionExpressions;
-    }
-    
-    if (asExpression && root) {
-      // replace the nestedExpressions after stringification
-      let __expr__ = `morph(${obj.inspect(exported)})`;
-      let bindings = {
-        'lively.morphic': ['morph']
-      }
-      for (let exprId in nestedExpressions) {
-        __expr__ = __expr__.replace('\"' + exprId + '\"', nestedExpressions[exprId].__expr__);
-        Object.entries(nestedExpressions[exprId].bindings || {}).forEach(([binding, imports]) => {
-          if (bindings[binding])
-            bindings[binding] = arr.uniq([...bindings[binding], ...imports])
-          else bindings[binding] = imports;
+    const connectionExpressions = [];
+    for (const conn of connections) {
+      const {
+        sourceAttrName, targetMethodName, sourceObj, targetObj,
+        updaterString, converterString, varMapping, garbageCollect
+      } = conn;
+      const pathToSource = objToPath.get(sourceObj);
+      const pathToTarget = objToPath.get(targetObj);
+      if (typeof pathToSource === 'string' && typeof pathToTarget === 'string') {
+        connectionExpressions.push({
+          pathToSource,
+          pathToTarget,
+          garbageCollect,
+          updaterString,
+          converterString,
+          sourceAttrName,
+          targetMethodName,
+          varMapping: {
+            properties
+          }
         });
+        continue;
       }
-      return { __expr__, bindings }
+      console.log('skipping:', conn);
     }
+    if (!asExpression) exported.__connections__ = connectionExpressions;
+  }
 
-    if (root) exported.__refs__ = objRefs;
-  
-    return exported;
+  if (asExpression && root) {
+    // replace the nestedExpressions after stringification
+    let __expr__ = `morph(${obj.inspect(exported)})`;
+    const bindings = {
+      'lively.morphic': ['morph']
+    };
+    for (const exprId in nestedExpressions) {
+      __expr__ = __expr__.replace('\"' + exprId + '\"', nestedExpressions[exprId].__expr__);
+      Object.entries(nestedExpressions[exprId].bindings || {}).forEach(([binding, imports]) => {
+        if (bindings[binding]) { bindings[binding] = arr.uniq([...bindings[binding], ...imports]); } else bindings[binding] = imports;
+      });
+    }
+    return { __expr__, bindings };
+  }
+
+  if (root) exported.__refs__ = objRefs;
+
+  return exported;
 }


### PR DESCRIPTION
Serializes varMappings of attributeConnections. Throws error when a function cannot be serialized due to lacking module information. Also throws error when trying to serialize morphs with anonymous functions that would be lost.

A lot of changes due to linter. Changes with regard to content:
lively.bindings/index.js: lines 46 to 82
lively.serializer2/plugins/expression-serializer.js: lines 85 to 93
lively.serializer2/plugins.js: lines 244 to 288