### PR TITLE
Prettier Keycombos

### DIFF
--- a/lively.morphic/events/KeyHandler.js
+++ b/lively.morphic/events/KeyHandler.js
@@ -303,8 +303,10 @@ export default class KeyHandler {
     if (typeof command === 'function') { return this.addCommand({ exec: command, bindKey: keyCombo, name: command.name || keyCombo }); }
 
     const allCombos = Array.isArray(keyCombo)
-      ? keyCombo : keyCombo.includes('|')
-          ? keyCombo.split('|') : [keyCombo];
+      ? keyCombo
+      : keyCombo.includes('|')
+        ? keyCombo.split('|')
+        : [keyCombo];
 
     allCombos.forEach((keyPart) => {
       let chain = '';
@@ -342,7 +344,8 @@ export default class KeyHandler {
 
   addCommand (command) {
     return !command || !command.bindKey
-      ? undefined : this.addCommandToBinding(command.bindKey, command);
+      ? undefined
+      : this.addCommandToBinding(command.bindKey, command);
   }
 
   addCommandToBinding (keyCombo, command) {

--- a/lively.morphic/events/KeyHandler.js
+++ b/lively.morphic/events/KeyHandler.js
@@ -197,9 +197,9 @@ export default class KeyHandler {
     const map = this._prettyCombos || (this._prettyCombos = {});
     if (this._prettyCombos[combo]) return map[combo];
     return map[combo] = combo
-      .replace(regexps.meta, '⌘')
-      .replace(regexps.alt, '⌥')
-      .replace(regexps.ctrl, '⌃')
+      .replace(regexps.meta, bowserOS() == 'mac' ? '⌘' : '⊞ ')
+      .replace(regexps.alt, bowserOS() == 'mac' ? '⌥' : 'Alt ')
+      .replace(regexps.ctrl, bowserOS() == 'mac' ? '⌃' : 'Ctrl ')
       .replace(regexps.tab, '⇥')
       .replace(regexps.enter, '⏎')
       .replace(regexps.shift, '⇧')


### PR DESCRIPTION
Closes #59 

In the original Issue the scope was maybe larger, but these were the worst offenders from my point of view.
The Shift, Enter,... symbols are on most reasonable keyboards, the three symbols I touched are platform specific.

I am absolutely open to change the Windows one, maybe just writing meta is better.