### PR TITLE
Expanding properties/commands in JS browser

### DIFF
--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -114,18 +114,21 @@ function parsePropertiesMethod (node, parent, type) {
     node,
     name: node.key.name
   };
-  const nodes = [propertiesNode];
-  const children = [];
-  propertiesNode.node.value.body.body[0].argument.properties.forEach(property => {
-    children.push({
-      type: property.type,
-      parent: propertiesNode,
-      node: property,
-      name: property.key ? property.key.name : property.argument.arguments[0].value
+  try {
+    const children = [];
+    propertiesNode.node.value.body.body[0].argument.properties.forEach(property => {
+      children.push({
+        type: property.type,
+        parent: propertiesNode,
+        node: property,
+        name: property.key ? property.key.name : property.argument.arguments[0].value
+      });
     });
-  });
-  propertiesNode.children = children;
-  return propertiesNode;
+    propertiesNode.children = children;
+  } finally {
+    // in case the try fails we are equivalent to the base case in es6ClassMethod
+    return propertiesNode;
+  }
 }
 
 function parseCommandsMethod (node, parent, type) {
@@ -135,23 +138,26 @@ function parseCommandsMethod (node, parent, type) {
     node,
     name: node.key.name
   };
-  const nodes = [commandsNode];
-  const children = [];
-  if (commandsNode.node.value.body.body) {
-    const commands = commandsNode.node.value.body.body[0].argument.elements;
-    if (commands) {
-      commands.forEach(command => {
-        children.push({
-          type: command.type,
-          parent: commandsNode,
-          node: command,
-          name: command.properties[0].value.value
+  try {
+    const children = [];
+    if (commandsNode.node.value.body.body) {
+      const commands = commandsNode.node.value.body.body[0].argument.elements;
+      if (commands) {
+        commands.forEach(command => {
+          children.push({
+            type: command.type,
+            parent: commandsNode,
+            node: command,
+            name: command.properties[0].value.value
+          });
         });
-      });
-      commandsNode.children = children;
+        commandsNode.children = children;
+      }
     }
+  } finally {
+    // in case the try fails we are equivalent to the base case in es6ClassMethod
+    return commandsNode;
   }
-  return commandsNode;
 }
 
 function varDefs (varDeclNode) {

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -125,6 +125,28 @@ function es6ClassMethod (node, parent, i) {
     : null;
 }
 
+function parseCommands (node, parent, type) {
+  const commandsNode = {
+    type,
+    parent,
+    node,
+    name: node.key.name
+  };
+  const nodes = [commandsNode];
+  const children = [];
+  commandsNode.node.value.body.body[0].argument.elements.forEach(command => {
+    debugger;
+    children.push({
+      type: command.type,
+      parent: commandsNode,
+      node: command,
+      name: command.properties[0].value.value
+    });
+  });
+  commandsNode.children = children;
+  return commandsNode;
+}
+
 function varDefs (varDeclNode) {
   if (varDeclNode.type !== 'VariableDeclaration') return null;
   const result = [];
@@ -139,6 +161,14 @@ function varDefs (varDeclNode) {
     if (initNode.type === 'ObjectExpression') {
       def.type = 'object-decl';
       def.children = objectKeyValsAsDefs(initNode).map(ea =>
+        ({ ...ea, type: 'object-' + ea.type, parent: def }));
+      result.push(...def.children);
+      continue;
+    }
+
+    if (initNode.type === 'ArrayExpression') {
+      def.type = 'array-decl';
+      def.children = arrayEntriesAsDefs(initNode).map(ea =>
         ({ ...ea, type: 'object-' + ea.type, parent: def }));
       result.push(...def.children);
       continue;

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -95,26 +95,9 @@ function es6ClassMethod (node, parent, i) {
   else if (node.kind === 'method') type = node.static ? 'class-class-method' : 'class-instance-method';
   else if (node.kind === 'get') type = node.static ? 'class-class-getter' : 'class-instance-getter';
   else if (node.kind === 'set') type = node.static ? 'class-class-setter' : 'class-instance-setter';
-  if (type == 'class-class-getter' && node.key.name == 'properties') {
-    const propertiesNode = {
-      type,
-      parent,
-      node,
-      name: node.key.name
-    };
-    const nodes = [propertiesNode];
-    const children = [];
-    propertiesNode.node.value.body.body[0].argument.properties.forEach(property => {
-      children.push({
-        type: property.type,
-        parent: propertiesNode,
-        node: property,
-        name: property.key ? property.key.name : property.argument.arguments[0].value
-      });
-    });
-    propertiesNode.children = children;
-    return propertiesNode;
-  }
+  if (type == 'class-instance-getter' && node.key.name == 'commands') return parseCommandsMethod(node, parent, type);
+  if (type == 'class-class-getter' && node.key.name == 'properties') return parsePropertiesMethod(node, parent, type);
+
   return type
     ? {
         type,
@@ -125,7 +108,28 @@ function es6ClassMethod (node, parent, i) {
     : null;
 }
 
-function parseCommands (node, parent, type) {
+function parsePropertiesMethod (node, parent, type) {
+  const propertiesNode = {
+    type,
+    parent,
+    node,
+    name: node.key.name
+  };
+  const nodes = [propertiesNode];
+  const children = [];
+  propertiesNode.node.value.body.body[0].argument.properties.forEach(property => {
+    children.push({
+      type: property.type,
+      parent: propertiesNode,
+      node: property,
+      name: property.key ? property.key.name : property.argument.arguments[0].value
+    });
+  });
+  propertiesNode.children = children;
+  return propertiesNode;
+}
+
+function parseCommandsMethod (node, parent, type) {
   const commandsNode = {
     type,
     parent,

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -32,7 +32,6 @@ object-decl
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 export function findDecls (parsed, options) {
   // lively.debugNextMethodCall(lively.ast.codeCategorizer, "findDecls")
-
   options = options || obj.merge({ hideOneLiners: false }, options);
 
   if (typeof parsed === 'string') { parsed = parse(parsed, { addSource: true }); }
@@ -138,16 +137,20 @@ function parseCommandsMethod (node, parent, type) {
   };
   const nodes = [commandsNode];
   const children = [];
-  commandsNode.node.value.body.body[0].argument.elements.forEach(command => {
-    debugger;
-    children.push({
-      type: command.type,
-      parent: commandsNode,
-      node: command,
-      name: command.properties[0].value.value
-    });
-  });
-  commandsNode.children = children;
+  if (commandsNode.node.value.body.body) {
+    const commands = commandsNode.node.value.body.body[0].argument.elements;
+    if (commands) {
+      commands.forEach(command => {
+        children.push({
+          type: command.type,
+          parent: commandsNode,
+          node: command,
+          name: command.properties[0].value.value
+        });
+      });
+      commandsNode.children = children;
+    }
+  }
   return commandsNode;
 }
 
@@ -243,9 +246,8 @@ function objectKeyValsAsDefs (objectExpression, parent) {
 }
 
 function arrayEntriesAsDefs (arrayExpression, parent) {
-  debugger;
   return arrayExpression.elements.map(node => ({
-    name: node.properties[0].value.value,
+    name: node.value || node.properties[0].value.value,
     type: node.type,
     node,
     parent

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -208,6 +208,16 @@ function objectKeyValsAsDefs (objectExpression, parent) {
   }));
 }
 
+function arrayEntriesAsDefs (arrayExpression, parent) {
+  debugger;
+  return arrayExpression.elements.map(node => ({
+    name: node.properties[0].value.value,
+    type: node.type,
+    node,
+    parent
+  }));
+}
+
 function isFunctionWrapper (node) {
   return Path('expression.type').get(node) === 'CallExpression' &&
       Path('expression.callee.type').get(node) === 'FunctionExpression';

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -68,7 +68,6 @@ export function findDecls (parsed, options) {
 
     defs.push(...found);
   }
-
   return defs;
 }
 
@@ -129,7 +128,6 @@ function varDefs (varDeclNode) {
       result.push(...def.children);
     }
   }
-
   return result;
 }
 
@@ -174,7 +172,9 @@ function functionWrapper (node, options) {
 
 function unwrapExport (node) {
   return (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration') &&
-      node.declaration ? node.declaration : node;
+      node.declaration
+    ? node.declaration
+    : node;
 }
 
 function objectKeyValsAsDefs (objectExpression, parent) {

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -95,12 +95,34 @@ function es6ClassMethod (node, parent, i) {
   else if (node.kind === 'method') type = node.static ? 'class-class-method' : 'class-instance-method';
   else if (node.kind === 'get') type = node.static ? 'class-class-getter' : 'class-instance-getter';
   else if (node.kind === 'set') type = node.static ? 'class-class-setter' : 'class-instance-setter';
-  return type ? {
-    type,
-    parent,
-    node,
-    name: node.key.name
-  } : null;
+  if (type == 'class-class-getter' && node.key.name == 'properties') {
+    const propertiesNode = {
+      type,
+      parent,
+      node,
+      name: node.key.name
+    };
+    const nodes = [propertiesNode];
+    const children = [];
+    propertiesNode.node.value.body.body[0].argument.properties.forEach(property => {
+      children.push({
+        type: property.type,
+        parent: propertiesNode,
+        node: property,
+        name: property.key ? property.key.name : property.argument.arguments[0].value
+      });
+    });
+    propertiesNode.children = children;
+    return propertiesNode;
+  }
+  return type
+    ? {
+        type,
+        parent,
+        node,
+        name: node.key.name
+      }
+    : null;
 }
 
 function varDefs (varDeclNode) {

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -63,8 +63,10 @@ class CodeDefTreeData extends TreeData {
   collapse (node, bool) { node.isCollapsed = bool; }
   getChildren (node) {
     return this.isLeaf(node)
-      ? null : this.isCollapsed(node)
-          ? [] : node.children;
+      ? null
+      : this.isCollapsed(node)
+        ? []
+        : node.children;
   }
 }
 
@@ -74,7 +76,8 @@ export default class Browser extends Morph {
     // browse spec:
     // packageName, moduleName, codeEntity, scroll, textPosition like {row: 0, column: 0}
     const browser = browserOrProps instanceof Browser
-      ? browserOrProps : new this(browserOrProps);
+      ? browserOrProps
+      : new this(browserOrProps);
     if (!browser.world()) browser.openInWindow();
     return browser.browse(browseSpec, optSystemInterface);
   }
@@ -1298,7 +1301,8 @@ export default class Browser extends Morph {
       const result = await this.reloadModule(false);
       sourceEditor.textString = content;
       return !result || result instanceof Error
-        ? this.showError(err) : this.save(attempt + 1);
+        ? this.showError(err)
+        : this.save(attempt + 1);
     } finally { this.state.isSaving = false; }
 
     this.setStatusMessage('saved ' + module.nameInPackage, Color.white, 5000, {
@@ -1512,7 +1516,8 @@ export default class Browser extends Morph {
   focus (evt) {
     const { metaInfoText, sourceEditor } = this.ui;
     const t = evt && evt.targetMorph === metaInfoText
-      ? metaInfoText : sourceEditor;
+      ? metaInfoText
+      : sourceEditor;
     t.focus();
   }
 


### PR DESCRIPTION
Closes #210 

getters for properties and commands as well as array declarations are now expandable in the browser.

Tests could be another useful addition, they provide no declarations at all in the browser right now, but I am not able to tackle that right now. I wrote it down however. 

---

I handled one case for ...generateUnfolded in Morph explicitly, I do not know if there are many more like it?  (@merryman?)
