### PR TITLE
morph: signal onAbandon at the beginning of abandon

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1644,6 +1644,7 @@ export class Morph {
 
   abandon (remove = true) {
     // Use this method to signal the wish to permanently delete this object. Overwrite this method to clean up resources on its deletion. We do not have access to the JS VM, this method does not interact with the garbage collector and does not result in the actual deletion of the object, if there are still left over references to this object.
+    signal(this, 'onAbandon');
     this.emptyComments();
     if (remove) this.remove();
     this.submorphs.forEach(submorph => submorph.abandon(false)); // do not remove submorphs


### PR DESCRIPTION
Just a small signal in order to do clean up somewhere else before the morph is abandoned since at the beginning of the method the morph is still there. We need this in order to clean up editor elements when a Morph that is part of the currently open Interactive gets removed via its Halos.