### PR TITLE
freezer: add lively.collab to exclusion list

### DIFF
--- a/lively.freezer/index.js
+++ b/lively.freezer/index.js
@@ -110,7 +110,8 @@ const ADVANCED_EXCLUDED_MODULES = [
   'lively.modules',
   'babel-plugin-transform-jsx',
   'lively-system-interface',
-  'lively.storage'
+  'lively.storage',
+  'lively.collab'
 ];
 
 const DEFAULT_EXCLUDED_MODULES_PART = [


### PR DESCRIPTION
Otherwise the comment browser may be frozen as well.