### PR TITLE
number widgets: return floatingPoint when it has been explicitly set

### DIFF
--- a/lively.ide/value-widgets.js
+++ b/lively.ide/value-widgets.js
@@ -426,8 +426,11 @@ export class NumberWidget extends Morph {
           this.get('value').floatingPoint = isFloat;
         },
         get () {
+          if (typeof this.getProperty('floatingPoint') !== 'undefined') {
+            return this.getProperty('floatingPoint');
+          }
           const m = /[+-]?([0-9]*[.])?[0-9]+/.exec(this.number);
-          return this.getProperty('floatingPoint') || (this.scaleFactor == 1 && m && !!m[1]);
+          return this.scaleFactor == 1 && m && !!m[1];
         }
       }, // infer that indirectly by looking at the floating point of the passed number value
       padding: {
@@ -607,7 +610,6 @@ export class NumberWidget extends Morph {
     this.update(this.number - (1 / this.scaleFactor), false);
   }
 }
-
 
 export class ShadowWidget extends Morph {
   static get properties () {


### PR DESCRIPTION
We have NumberWidgets which we fill with floating point numbers but don't want to have displayed in a rounded fashion. This is why we set floatingPoint to false. This however did not do anything, because when floatingPoint is set to false, it ignores the property, and derives its value.

With this change, floatingPoint is only derived, if floatingPoint has not been explicitly set.