### PR TITLE
Add link to project wiki in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A docker image exists for this to try it out in the environment of your choice.
 2. Run the docker command as follows (replacing the seccomp section with the location above where the file was saved): `docker run -d --restart=unless-stopped --init --security-opt seccomp=/path/to/chrome.json --name lively-next -p 127.0.0.1:9011:9011 engagelively/lively-next:alpha4.5.0`
 3. Once completely started, navigate to [http://localhost:9011 ](http://localhost:9011)
 
+## Documentation
+
+Some hints and documentation can be found in the [project wiki](https://github.com/LivelyKernel/lively.next/wiki).
+
 ## License
 
 This project is [MIT licensed](LICENSE).


### PR DESCRIPTION
This is an open PR mainly as a public service announcement:

We have migrated the bulk of our internal wiki over into the wiki of this repositorie. Some smaller things might follow after internal revision, but this is nearly everything.

It is worth noting that some of these pages were created more as minutes from our discussions with @merryman than that they were directly intended as public documentation.
On the other side, some articles are of really high quality like the one @SilvanVerhoeven wrote about connections (at least in my opinion :slightly_smiling_face:).

However, this might be a good starting point. We will add to this wiki as of now when appropriate. 