### PR TITLE
try/finally when parsing array declarations for the browser

### DIFF
--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -181,10 +181,11 @@ function varDefs (varDeclNode) {
 
     if (initNode.type === 'ArrayExpression') {
       def.type = 'array-decl';
-      def.children = arrayEntriesAsDefs(initNode).map(ea =>
-        ({ ...ea, type: 'object-' + ea.type, parent: def }));
-      result.push(...def.children);
-      continue;
+      try {
+        def.children = arrayEntriesAsDefs(initNode).map(ea =>
+          ({ ...ea, type: 'object-' + ea.type, parent: def }));
+        result.push(...def.children);
+      } finally { continue; }
     }
 
     const objDefs = someObjectExpressionCall(initNode, def);


### PR DESCRIPTION
Opening the `drag-guides` on the current master resulted in the code-categorizer crashing.