### PR TITLE
inspector: select morphs via mouse up

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1940,7 +1940,7 @@ export class InteractiveMorphSelector {
     this.whenDone = deferred.promise;
     this.selectorMorph = Icon.makeLabel('crosshairs', { fontSize: 20, hasFixedPosition: true, epiMorph: true }).openInWorld();
     connect(this.world.firstHand, 'position', this, 'scanForTargetAt');
-    once(this.selectorMorph, 'onMouseDown', this, 'selectTarget');
+    once(this.selectorMorph, 'onMouseUp', this, 'selectTarget');
     once(this.selectorMorph, 'onKeyDown', this, 'stopSelect');
     this.selectorMorph.focus();
     this.scanForTargetAt(this.world.firstHand.position);

--- a/lively.ide/js/inspector.js
+++ b/lively.ide/js/inspector.js
@@ -998,7 +998,8 @@ export default class Inspector extends Morph {
         targetModule: 'lively://lively.morphic/inspector',
         get context () {
           return thisBindingSelector.selection == 'selection'
-            ? codeEditor.owner.selectedContext : codeEditor.owner.targetObject;
+            ? codeEditor.owner.selectedContext
+            : codeEditor.owner.targetObject;
         },
         get systemInterface () {
           return Path('treeData.systemInterface').get(propertyTree);
@@ -1031,7 +1032,8 @@ export default class Inspector extends Morph {
         targetModule: 'lively://lively.morphic/inspector',
         get context () {
           return thisBindingSelector.selection == 'selection'
-            ? codeEditor.owner.selectedContext : codeEditor.owner.targetObject;
+            ? codeEditor.owner.selectedContext
+            : codeEditor.owner.targetObject;
         },
         get systemInterface () {
           return propertyTree.treeData.systemInterface;
@@ -1040,7 +1042,7 @@ export default class Inspector extends Morph {
       }
     ).catch(err => $world.logError(err));
 
-    connect(targetPicker, 'onMouseDown', this, 'selectTarget');
+    connect(targetPicker, 'onMouseUp', this, 'selectTarget');
     connect(propertyTree, 'onScroll', this, 'repositionOpenWidget');
     connect(resizer, 'onDrag', this, 'adjustProportions');
     connect(terminalToggler, 'onMouseDown', this, 'toggleCodeEditor');


### PR DESCRIPTION
Closes #288

The change in the inspector is necessary, otherwise clicking the target selector button and then releasing the mouse selects the target inspector button requiring one to keep the mouse pressed for the duration of the selection.