### PR TITLE
Fix number widget relayout after setting unit

### DIFF
--- a/lively.ide/value-widgets.js
+++ b/lively.ide/value-widgets.js
@@ -399,7 +399,11 @@ export class NumberWidget extends Morph {
       unit: {
         type: 'Enum',
         isStyleProp: true,
-        values: ['px', '%', 'pt', '']
+        values: ['px', '%', 'pt', ''],
+        set (unit) {
+          this.setProperty('unit', unit);
+          if (typeof this.number === 'number') this.relayout(false);
+        }
       },
       autofit: {
         defaultValue: true,
@@ -605,10 +609,10 @@ export class NumberWidget extends Morph {
       this.relayoutButtons();
     }
     if (!fromScrubber) {
-      valueContainer.value = num.roundTo(this.number * this.scaleFactor, 1);
       valueContainer.min = this.min != -Infinity ? this.min * this.scaleFactor : this.min;
       valueContainer.max = this.max != Infinity ? this.max * this.scaleFactor : this.max;
       valueContainer.unit = this.unit;
+      valueContainer.value = num.roundTo(this.number * this.scaleFactor, 1);
     }
   }
 


### PR DESCRIPTION
Is there a reason we first set the value of the number widget and only after that set the unit? because the value scrubber won't be able to display the unit then in the first round of relayouting

closes #295 