### PR TITLE
freezer: check for undefined before matching string

### DIFF
--- a/lively.freezer/index.js
+++ b/lively.freezer/index.js
@@ -1174,7 +1174,7 @@ class LivelyRollup {
   }
 
   needsClassInstrumentation (moduleId, moduleSource) {
-    if (moduleSource.match(/extends\ (Morph|Image|Ellipse|HTMLMorph|Path|Polygon|Text|InteractiveMorph)/)) return true;
+    if (moduleSource && moduleSource.match(/extends\ (Morph|Image|Ellipse|HTMLMorph|Path|Polygon|Text|InteractiveMorph)/)) return true;
     if (CLASS_INSTRUMENTATION_MODULES_EXCLUSION.some(pkgName => moduleId.includes(pkgName))) { return false; }
     if (CLASS_INSTRUMENTATION_MODULES.some(pkgName => moduleId.includes(pkgName) || pkgName == moduleId) || belongsToObjectPackage(moduleId)) {
       return true;


### PR DESCRIPTION
Closes #300 

The `needsClassInstrumentation` method was called elsewhere with only one parameter `id`. This lead to source being undefined and therefore no method `match` being found. Checking for undefined fixed the problem for me. I tested it with one of our interactives as well as a basic rect morph.