### PR TITLE
prompt: add option to select input upon opening

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -732,7 +732,7 @@ export class LivelyWorld extends World {
     return this.openPrompt(new InformPrompt({ label, ...opts }), opts);
   }
 
-  prompt (label, opts = { requester: null, input: '', historyId: null, useLastInput: false }) {
+  prompt (label, opts = { requester: null, input: '', historyId: null, useLastInput: false }, selectInput = false) {
     // await this.world().prompt("test", {input: "123"})
     // options = {
     //   input: STRING, -- optional, prefilled input string
@@ -743,6 +743,9 @@ export class LivelyWorld extends World {
     const textPrompt = new TextPrompt({ label, ...opts });
     if (opts.forceConfirm) {
       textPrompt.get('cancel button').disable();
+    }
+    if (selectInput) {
+      textPrompt.get('input').selectAll();
     }
     return this.openPrompt(textPrompt, opts);
   }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2931,7 +2931,8 @@ export class Image extends Morph {
       historyId: 'lively.morphic-image-url-inputs',
       input: this.imageUrl.startsWith('data:') ? '' : this.imageUrl,
       requester: this
-    });
+    },
+    true);
     if (typeof url === 'string') { this.imageUrl = url; }
   }
 

--- a/lively.morphic/text/label.js
+++ b/lively.morphic/text/label.js
@@ -524,7 +524,8 @@ export class Label extends Morph {
     const newLabel = await this.world().prompt('edit label', {
       input: this.textString,
       historyId: 'lively.morphic-label-edit-hist'
-    });
+    },
+    true);
     if (typeof newLabel === 'string') { this.textString = newLabel; }
   }
 


### PR DESCRIPTION
Also preselects the already input text when changing the content of a label or the image URL over the morph menu.

This was feedback from the user testing on Friday, that it is cumbersome to change those values.