### PR TITLE
Compare colors with delta instead of ===

### DIFF
--- a/lively.graphics/color.js
+++ b/lively.graphics/color.js
@@ -267,7 +267,7 @@ export class Color {
   equals (other) {
     if (!other) return false;
     const delta = 0.00000001;
-    return this.r - other.r < delta && this.g - other.g < delta && this.b - other.b < delta && this.a - other.a < delta;
+    return Math.abs(this.r - other.r) < delta && Math.abs(this.g - other.g) < delta && Math.abs(this.b - other.b) < delta && Math.abs(this.a - other.a) < delta;
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/lively.graphics/color.js
+++ b/lively.graphics/color.js
@@ -266,7 +266,8 @@ export class Color {
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   equals (other) {
     if (!other) return false;
-    return this.r === other.r && this.g === other.g && this.b === other.b && this.a === other.a;
+    const delta = 0.00000001;
+    return this.r - other.r < delta && this.g - other.g < delta && this.b - other.b < delta && this.a - other.a < delta;
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-


### PR DESCRIPTION
In the color.js equals implementation, colors were compared with ===, this caused errors because of the rounding of floats.
It was changed to a delta