### PR TITLE
Deprecate array functions

### DIFF
--- a/lively-system-interface/commands/mocha-tests.js
+++ b/lively-system-interface/commands/mocha-tests.js
@@ -21,7 +21,7 @@ export async function runMochaTests (grep, testsByFile, onChange, onError) {
       let files = arr.compact(mocha.suite.suites).map(({ file }) => file);
       let tests = chain(testsByFile)
         .filter(ea => files.includes(ea.file))
-        .pluck('tests').flatten().value();
+        .pluck('tests').flat().value();
 
       if (!tests || !tests.length) { return reject(new Error(`Trying to run tests of ${files.join(', ')} but cannot find them in loaded tests!`)); }
       mocha.reporter(function Reporter (runner) {

--- a/lively-system-interface/interfaces/interface.js
+++ b/lively-system-interface/interfaces/interface.js
@@ -46,7 +46,7 @@ export class AbstractCoreInterface {
   doesModuleExist (name, isNormalized) { todo('doesModuleExist'); }
 
   async getModules () {
-    return arr.flatmap(await this.getPackages(), ea => ea.modules);
+    return await this.getPackages().flatMap(ea => ea.modules);
   }
 
   async getModule (name) {

--- a/lively-system-interface/interfaces/local-system.js
+++ b/lively-system-interface/interfaces/local-system.js
@@ -186,7 +186,7 @@ export class LocalCoreInterface extends AbstractCoreInterface {
     return decls.map(v => {
       let nameLength = v.name.length;
       const isExport = importsExports.exports.find(ea => ea.local === v.name);
-      const isImport = arr.include(imports, v.name);
+      const isImport = imports.includes(v.name);
       if (isExport) nameLength += ' [export]'.length;
       if (isImport) nameLength += ' [import]'.length;
       col1Width = Math.max(col1Width, nameLength);

--- a/lively.ast/lib/acorn-extension.js
+++ b/lively.ast/lib/acorn-extension.js
@@ -614,7 +614,7 @@ function findSiblings (parsed, node, beforeOrAfter) {
   const nodes = findNodesIncluding(parsed, node.start);
   const idx = nodes.indexOf(node);
   const parents = nodes.slice(0, idx);
-  const parentWithBody = arr.detect(parents.reverse(), function (p) { return Array.isArray(p.body); });
+  const parentWithBody = parents.reverse().find(function (p) { return Array.isArray(p.body); });
   const siblingsWithNode = parentWithBody.body;
   if (!beforeOrAfter) return arr.without(siblingsWithNode, node);
   const nodeIdxInSiblings = siblingsWithNode.indexOf(node);

--- a/lively.ast/lib/code-categorizer.js
+++ b/lively.ast/lib/code-categorizer.js
@@ -51,7 +51,7 @@ export function findDecls (parsed, options) {
 
     if (options.hideOneLiners) {
       if (parsed.loc) {
-        found = arr.filter(found, def =>
+        found = found.filter(def =>
           !def.node.loc || (def.node.loc.start.line !== def.node.loc.end.line));
       } else if (parsed.source) {
         const filtered = [];
@@ -307,7 +307,7 @@ function isFunctionWrapper (node) {
 }
 
 function declIds (idNodes) { // eslint-disable-line no-unused-vars
-  return arr.flatmap(idNodes, function (ea) {
+  return idNodes.flatMap(function (ea) {
     if (!ea) return [];
     if (ea.type === 'Identifier') return [ea];
     if (ea.type === 'RestElement') return [ea.argument];

--- a/lively.ast/lib/comments.js
+++ b/lively.ast/lib/comments.js
@@ -11,7 +11,8 @@ function getCommentPrecedingNode (parsed, node) {
   const blockPath = statementPath.slice(0, -2);
   const block = Path(blockPath).get(parsed);
 
-  return !block.comments || !block.comments.length ? null
+  return !block.comments || !block.comments.length
+    ? null
     : chain(extractComments(parsed))
       .reversed()
       .detect(function (ea) { return ea.followingNode === node; })
@@ -20,9 +21,11 @@ function getCommentPrecedingNode (parsed, node) {
 
 function extractComments (astOrCode, optCode) {
   const parsed = typeof astOrCode === 'string'
-    ? parse(astOrCode, { withComments: true }) : astOrCode;
+    ? parse(astOrCode, { withComments: true })
+    : astOrCode;
   const code = optCode || (typeof astOrCode === 'string'
-    ? astOrCode : stringify(astOrCode));
+    ? astOrCode
+    : stringify(astOrCode));
   const parsedComments = arr.sortBy(commentsWithPathsAndNodes(parsed), c => c.comment.start);
 
   return parsedComments.map(function (c, i) {

--- a/lively.ast/lib/comments.js
+++ b/lively.ast/lib/comments.js
@@ -15,7 +15,7 @@ function getCommentPrecedingNode (parsed, node) {
     ? null
     : chain(extractComments(parsed))
       .reversed()
-      .detect(function (ea) { return ea.followingNode === node; })
+      .find(function (ea) { return ea.followingNode === node; })
       .value();
 }
 
@@ -100,7 +100,7 @@ function extractComments (astOrCode, optCode) {
   }
 
   function followingNodeOf (comment) {
-    return arr.detect(comment.node.body, function (node) {
+    return comment.node.body.find(function (node) {
       return node.start > comment.comment.end;
     });
   }

--- a/lively.ast/lib/parser.js
+++ b/lively.ast/lib/parser.js
@@ -62,11 +62,14 @@ function fuzzyParse (source, options) {
   options.plugins = options.plugins || {};
   // if (options.plugins.hasOwnProperty("jsx")) options.plugins.jsx = options.plugins.jsx;
   options.plugins.jsx = options.plugins.hasOwnProperty('jsx')
-    ? options.plugins.jsx : true;
+    ? options.plugins.jsx
+    : true;
   options.plugins.asyncawait = options.plugins.hasOwnProperty('asyncawait')
-    ? options.plugins.asyncawait : { inAsyncFunction: true };
+    ? options.plugins.asyncawait
+    : { inAsyncFunction: true };
   options.plugins.objectSpread = options.plugins.hasOwnProperty('objectSpread')
-    ? options.plugins.objectSpread : true;
+    ? options.plugins.objectSpread
+    : true;
 
   let ast, safeSource, err;
   if (options.type === 'LabeledStatement') { safeSource = '$={' + source + '}'; }
@@ -169,11 +172,14 @@ function parse (source, options) {
   if (!options.hasOwnProperty('allowImportExportEverywhere')) { options.allowImportExportEverywhere = true; }
   options.plugins = options.plugins || {};
   options.plugins.jsx = options.plugins.hasOwnProperty('jsx')
-    ? options.plugins.jsx : true;
+    ? options.plugins.jsx
+    : true;
   options.plugins.asyncawait = options.plugins.hasOwnProperty('asyncawait')
-    ? options.plugins.asyncawait : { inAsyncFunction: true };
+    ? options.plugins.asyncawait
+    : { inAsyncFunction: true };
   options.plugins.objectSpread = options.plugins.hasOwnProperty('objectSpread')
-    ? options.plugins.objectSpread : true;
+    ? options.plugins.objectSpread
+    : true;
 
   if (options.withComments) {
     // record comments

--- a/lively.ast/lib/parser.js
+++ b/lively.ast/lib/parser.js
@@ -231,8 +231,7 @@ function parse (source, options) {
 
   function assignCommentsToBlockNodes (commentData) {
     comments.forEach(function (comment) {
-      let node = arr.detect(
-        nodesAt(comment.start, parsed).reverse(),
+      let node = nodesAt(comment.start, parsed).reverse().find(
         function (node) { return node.type === 'BlockStatement' || node.type === 'Program'; });
       if (!node) node = parsed;
       if (!node.comments) node.comments = [];
@@ -259,7 +258,7 @@ function parse (source, options) {
 
         // if the comments are seperated by a statement, don't merge
         const last = coalesceData.lastComment;
-        const nodeInbetween = arr.detect(blockNode.body, function (node) { return node.start >= last.end && node.end <= comment.start; });
+        const nodeInbetween = blockNode.body.find(function (node) { return node.start >= last.end && node.end <= comment.start; });
         if (nodeInbetween) {
           coalesceData.lastComment = comment;
           return coalesceData;

--- a/lively.ast/lib/transform.js
+++ b/lively.ast/lib/transform.js
@@ -1,7 +1,7 @@
 /* global process, global, exports */
 
-import { arr, obj, string, chain, Path } from 'lively.lang';
-import { helpers, scopes, topLevelDeclsAndRefs, topLevelFuncDecls } from './query.js';
+import { arr, obj, string, Path } from 'lively.lang';
+import { helpers, scopes, topLevelFuncDecls } from './query.js';
 import { parse, fuzzyParse } from './parser.js';
 import objectSpreadTransform from './object-spread-transform.js';
 import {
@@ -66,7 +66,8 @@ function replaceNode (target, replacementFunc, sourceOrChanges) {
   //                      If its and object -- {changes: ARRAY, source: STRING}
 
   const sourceChanges = typeof sourceOrChanges === 'object'
-    ? sourceOrChanges : { changes: [], source: sourceOrChanges };
+    ? sourceOrChanges
+    : { changes: [], source: sourceOrChanges };
   let insideChangedBefore = false;
   const pos = sourceChanges.changes.reduce(function (pos, change) {
     // fixup the start and end indices of target using the del/add
@@ -118,7 +119,8 @@ function replaceNodes (targetAndReplacementFuncs, sourceOrChanges) {
   const sorted = targetAndReplacementFuncs.sort((a, b) =>
     _compareNodesForReplacement(a.target, b.target));
   let sourceChanges = typeof sourceOrChanges === 'object'
-    ? sourceOrChanges : { changes: [], source: sourceOrChanges };
+    ? sourceOrChanges
+    : { changes: [], source: sourceOrChanges };
   for (let i = 0; i < sorted.length; i++) {
     const { target, replacementFunc } = sorted[i];
     sourceChanges = replaceNode(target, replacementFunc, sourceChanges);
@@ -146,7 +148,8 @@ function replace (astOrSource, targetNode, replacementFunc, options) {
 
   const parsed = typeof astOrSource === 'object' ? astOrSource : null;
   const source = typeof astOrSource === 'string'
-    ? astOrSource : (parsed.source || _node2string(parsed));
+    ? astOrSource
+    : (parsed.source || _node2string(parsed));
   return replaceNode(targetNode, replacementFunc, source);
 }
 
@@ -161,9 +164,11 @@ function oneDeclaratorPerVarDecl (astOrSource) {
   //    "var x = 3, y = (function() { var y = 3, x = 2; })(); ").source
 
   const parsed = typeof astOrSource === 'object'
-    ? astOrSource : parse(astOrSource);
+    ? astOrSource
+    : parse(astOrSource);
   const source = typeof astOrSource === 'string'
-    ? astOrSource : (parsed.source || _node2string(parsed));
+    ? astOrSource
+    : (parsed.source || _node2string(parsed));
   const scope = scopes(parsed);
   const varDecls = __findVarDecls(scope);
 
@@ -194,9 +199,11 @@ function oneDeclaratorPerVarDecl (astOrSource) {
 
 function oneDeclaratorForVarsInDestructoring (astOrSource) {
   const parsed = typeof astOrSource === 'object'
-    ? astOrSource : parse(astOrSource);
+    ? astOrSource
+    : parse(astOrSource);
   const source = typeof astOrSource === 'string'
-    ? astOrSource : (parsed.source || _node2string(parsed));
+    ? astOrSource
+    : (parsed.source || _node2string(parsed));
   const scope = scopes(parsed);
   const varDecls = __findVarDecls(scope);
   const targetsAndReplacements = [];

--- a/lively.ast/tests/query-test.js
+++ b/lively.ast/tests/query-test.js
@@ -16,7 +16,7 @@ describe('query', function() {
       var declsAndRefs = query.topLevelDeclsAndRefs(parsed);
 
       var varDecls = declsAndRefs.varDecls;
-      var varIds = chain(declsAndRefs.varDecls).pluck('declarations').flatten().pluck("id").pluck("name").value();
+      var varIds = chain(declsAndRefs.varDecls).pluck('declarations').flat().pluck("id").pluck("name").value();
       expect(["x", "y", "z"]).deep.equals(varIds, "var ids");
 
       var funcIds = chain(declsAndRefs.funcDecls).pluck('id').pluck('name').value();
@@ -95,7 +95,7 @@ describe('query', function() {
       expect(scope).to.containSubset(expected)
 
       // top level scope
-      var varNames = chain(scope.varDecls).pluck('declarations').flatten().value();
+      var varNames = chain(scope.varDecls).pluck('declarations').flat().value();
       expect(1).equals(varNames.length, 'root scope vars');
       var funcNames = chain(scope.funcDecls).pluck('id').pluck('name').value();
       expect(1).equals(scope.funcDecls.length, 'root scope funcs');
@@ -105,7 +105,7 @@ describe('query', function() {
       // sub scope
       expect(1).equals(scope.subScopes.length, 'subscope length');
       var subScope = scope.subScopes[0];
-      var varNames = chain(subScope.varDecls).pluck('declarations').flatten().value();
+      var varNames = chain(subScope.varDecls).pluck('declarations').flat().value();
       expect(2).equals(varNames.length, 'subscope vars');
       expect(0).equals(subScope.funcDecls.length, 'subscope funcs');
       expect(4).equals(subScope.refs.length, 'subscope refs');

--- a/lively.changesets/src/changeset.js
+++ b/lively.changesets/src/changeset.js
@@ -31,7 +31,7 @@ class ChangeSet {
 
   getBranches () { // () -> Promise<Array<Branch>>
     return localBranches().then(branches =>
-      arr.flatmap(Object.keys(branches), k => branches[k])
+      Object.keys(branches).flatMap(k => branches[k])
         .filter(b => b.name == this.name));
   }
 

--- a/lively.classes/util.js
+++ b/lively.classes/util.js
@@ -83,9 +83,9 @@ export function runtimeClassMembers (klass) {
 
 function runtimeClassMembersInProtoChain (klass) {
   return arr.uniq(
-    arr.flatmap(
-      arr.without(withSuperclasses(klass), Object),
-      ea => runtimeClassMembers(ea)));
+    arr.without(withSuperclasses(klass), Object)
+      .flatMap(ea => runtimeClassMembers(ea))
+  );
 }
 
 function runtimeNonStaticMembers (klass) {
@@ -114,9 +114,9 @@ function runtimeNonStaticMembers (klass) {
 
 function runtimeNonstaticClassMembersInProtoChain (klass) {
   return arr.uniq(
-    arr.flatmap(
-      arr.without(withSuperclasses(klass), Object),
-      ea => runtimeNonStaticMembers(ea)));
+    arr.without(withSuperclasses(klass), Object)
+      .flatMap(ea => runtimeNonStaticMembers(ea))
+  );
 }
 
 export function runtimeStaticClassMembers (klass) {
@@ -145,9 +145,9 @@ export function runtimeStaticClassMembers (klass) {
 
 export function runtimeStaticClassMembersInProtoChain (klass) {
   return arr.uniq(
-    arr.flatmap(
-      arr.without(withSuperclasses(klass), Object),
-      ea => runtimeStaticClassMembers(ea)));
+    arr.without(withSuperclasses(klass), Object)
+      .flatMap(ea => runtimeStaticClassMembers(ea))
+  );
 }
 
 /*

--- a/lively.components/tests/tree-test.js
+++ b/lively.components/tests/tree-test.js
@@ -63,7 +63,7 @@ describe('tree', function () {
   afterEach(() => tree && tree.remove());
 
   inBrowser('renders items without root', () => {
-    expect(arr.map(tree.document.lines.slice(0, tree.lineCount() - 1), l => l.textAndAttributes[4]))
+    expect(tree.document.lines.slice(0, tree.lineCount() - 1).map(l => l.textAndAttributes[4]))
       .equals(['child 1', 'child 2', 'child 3', 'child 3 - 1', 'child 3 - 2', 'child 4']);
   });
 

--- a/lively.components/tree.js
+++ b/lively.components/tree.js
@@ -256,8 +256,8 @@ export class Tree extends Text {
         displayedNode.fontColor = this.nonSelectionFontColor;
       }
 
-      if (arr.isArray(displayedNode)) {
-        displayedNode = arr.flatten(displayedNode);
+      if (Array.isArray(displayedNode)) {
+        displayedNode = displayedNode.flat();
         arr.pushAllAt(containerTextAndAttributes, displayedNode, j + 4);
         const increment = Math.max(0, displayedNode.length - 2);
         j += increment;
@@ -599,7 +599,7 @@ export class TreeData {
     tree.prewalk(this.root,
       (node, i, depth) => nodesWithIndex.push({ node, depth, i }),
       (node) => this.getChildrenIfUncollapsed(node));
-    return filterFn ? arr.filter(nodesWithIndex, filterFn) : nodesWithIndex;
+    return filterFn ? nodesWithIndex.filter(filterFn) : nodesWithIndex;
   }
 
   pathOf (node) {
@@ -837,7 +837,7 @@ var treeCommands = [
         let parents = arr.compact([td.parentNode(treeMorph.selectedNode)]);
         while (true) {
           if (!parents.length) break;
-          nodesToChange = arr.flatmap(parents, n => allNonLeafChildren(n));
+          nodesToChange = parents.flatMap(n => allNonLeafChildren(n));
           let needCollapseChange = nodesToChange.every(n => td.isCollapsed(n) === doCollapse);
           if (!needCollapseChange) break;
           parents = nodesToChange;
@@ -851,7 +851,7 @@ var treeCommands = [
       return true;
 
       function allNonLeafChildren (parent) {
-        return arr.filter(td.getChildrenIfUncollapsed(parent), n => !td.isLeaf(n));
+        return td.getChildrenIfUncollapsed(parent).filter(n => !td.isLeaf(n));
       }
 
       function collapseOrUncollapse (nodes, doCollapse) {

--- a/lively.components/widgets.js
+++ b/lively.components/widgets.js
@@ -75,7 +75,7 @@ class LeashEndpoint extends Ellipse {
       const side = ib[this.attachedSide]();
       const center = ib.center().addPt(ib.center().subPt(side));
       const line = Shapes.line(side.x, side.y, center.x, center.y);
-      const path = Shapes.polyline(arr.flatten(vs.map(({ x, y }) => [x, y])));
+      const path = Shapes.polyline(vs.map(({ x, y }) => [x, y]).flat());
       const { x, y } = arr.min(Intersection.intersect(path, line).points, ({ x, y }) => pt(x, y).dist(side));
       return pt(x, y).addPt(gb.topLeft());
     } else {

--- a/lively.freezer/index.js
+++ b/lively.freezer/index.js
@@ -317,7 +317,7 @@ function clearWorldSnapshot (snap) {
         if (isReference(v) && deletedIds.includes(v.id)) {
           delete snap.snapshot[id].props[key];
         }
-        if (arr.isArray(v)) {
+        if (Array.isArray(v)) {
           // also remove references that are stuck inside array values
           snap.snapshot[id].props[key].value = v.filter(v => !(isReference(v) && deletedIds.includes(v.id)));
         }
@@ -620,13 +620,12 @@ async function getRequiredModulesFromSnapshot (snap, frozenPart, includeDynamicP
   frozenPart.getAssetsFromSnapshot(snap);
 
   // flatten imports to all imports of the object package
-  imports = arr.flatten(
-    imports.map(modId =>
-      module(modId)
-        .requirements()
-        .map(mod => mod.id)
-        .filter(id => belongsToObjectPackage(id))
-        .concat(modId)));
+  imports = imports.map(modId =>
+    module(modId)
+      .requirements()
+      .map(mod => mod.id)
+      .filter(id => belongsToObjectPackage(id))
+      .concat(modId)).flat();
 
   findMasterComponentsInSnapshot(snap).forEach(url => requiredMasterComponents.add(url));
 
@@ -1322,13 +1321,13 @@ class LivelyRollup {
     });
 
     for (const stmts of Object.values(arr.groupBy(imports, imp => imp.source.value))) {
-      const toBeMerged = arr.filter(stmts, stmt => arr.all(stmt.specifiers, spec => spec.type == 'ImportSpecifier'));
+      const toBeMerged = stmts.filter(stmt => stmt.specifiers.every(spec => spec.type == 'ImportSpecifier'));
       if (toBeMerged.length > 1) {
         // merge statements
         // fixme: if specifiers are not named, these can not be merged
         // fixme: properly handle default export
         const mergedSpecifiers = arr.uniqBy(
-          arr.flatten(toBeMerged.map(stmt => stmt.specifiers)),
+          toBeMerged.map(stmt => stmt.specifiers).flat(),
           (spec1, spec2) =>
             spec1.type == 'ImportSpecifier' &&
             spec2.type == 'ImportSpecifier' &&

--- a/lively.graphics/color.js
+++ b/lively.graphics/color.js
@@ -433,13 +433,13 @@ class Gradient {
   }
 
   getStopsLighter (n) {
-    return arr.collect(this.stops, function (ea) {
+    return this.stops.map(function (ea) {
       return { offset: ea.offset, color: ea.color.lighter(n) };
     });
   }
 
   getStopsDarker (n) {
-    return arr.collect(this.stops, function (ea) {
+    return this.stops.map(function (ea) {
       return { offset: ea.offset, color: ea.color.darker(n) };
     });
   }

--- a/lively.halos/layout.js
+++ b/lively.halos/layout.js
@@ -490,7 +490,7 @@ export class GridLayoutHalo extends LayoutHalo {
       cells: {
         derived: true,
         get () {
-          return arr.flatten(this.target.col(0).items.map(c => c.row(0).items));
+          return this.target.col(0).items.map(c => c.row(0).items).flat();
         }
       },
       submorphs: {
@@ -554,7 +554,7 @@ export class GridLayoutHalo extends LayoutHalo {
     if (this.target.compensateOrigin) this.moveBy(this.container.origin.negated());
     this.extent = this.container.extent;
     this.addMissingGuides();
-    arr.reverse(this.guides).forEach(guide => guide.alignWithTarget());
+    this.guides.reverse().forEach(guide => guide.alignWithTarget());
   }
 
   addMissingGuides () {

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -700,6 +700,9 @@ class DragHaloItem extends HaloItem {
 
   init () {
     const target = this.halo.target;
+    
+    if (!target.owner) return;
+    
     const interferingLayout = target.owner.layout;
     target.undoStart('drag-halo');
 

--- a/lively.ide/component/editor.js
+++ b/lively.ide/component/editor.js
@@ -235,8 +235,8 @@ function insertProp (sourceCode, propertiesNode, key, valueExpr, sourceEditor = 
   // determine where to insert the new property
   // after name and type and before submorphs if present
   // fixme: ensure to be inserted after both type and name
-  const nameProp = arr.findIndex(propertiesNode.properties, prop => prop.key.name == 'name');
-  const typeProp = arr.findIndex(propertiesNode.properties, prop => prop.key.name == 'type');
+  const nameProp = propertiesNode.properties.findIndex(prop => prop.key.name == 'name');
+  const typeProp = propertiesNode.properties.findIndex(prop => prop.key.name == 'type');
   const afterProp = propertiesNode.properties[Math.max(typeProp, nameProp)];
   const keyValueExpr = ',\n' + key + ': ' + valueExpr;
   let insertationPoint;

--- a/lively.ide/diff/file-patch.js
+++ b/lively.ide/diff/file-patch.js
@@ -145,7 +145,7 @@ export class FilePatch {
   }
 
   changesByLines () {
-    return arr.flatten(arr.invoke(this.hunks, 'changesByLines'));
+    return arr.invoke(this.hunks, 'changesByLines').flat();
   }
 
   length () {

--- a/lively.ide/fabrik.js
+++ b/lively.ide/fabrik.js
@@ -60,14 +60,14 @@ export async function interactiveConnectGivenSourceAndTarget (sourceObj, sourceA
   }
 
   if (!sourceAttr) {
-    const sourceBindings = [{ isListItem: true, string: '[Enter custom attribute..]', value: { custom: true } }, ...arr.flatten(sourceObj.world().targetDataBindings(sourceObj)).map(ea => ({ isListItem: true, string: ea.signature || ea.name, value: ea }))];
+    const sourceBindings = [{ isListItem: true, string: '[Enter custom attribute..]', value: { custom: true } }, ...sourceObj.world().targetDataBindings(sourceObj).flat().map(ea => ({ isListItem: true, string: ea.signature || ea.name, value: ea }))];
     sourceAttr = await world.listPrompt(['Select Source Attribute\n', {}, 'Choose the attribute of the morph that is supposed to invoke the connection. This can be a method, property or a custom signal that is invoked upon the morph.', { paddingTop: '10px', fontSize: 14, textAlign: 'left', fontWeight: 'normal' }], sourceBindings, { filterable: true });
     if (sourceAttr.status == 'canceled') return;
     sourceAttr = sourceAttr.selected[0];
     sourceAttr = sourceAttr.custom ? 'sourceAttribute' : sourceAttr.name;
   }
 
-  const items = [{ isListItem: true, string: '[Enter custom attribute...]', value: { custom: true } }, ...arr.flatten(targetBindings).map(ea => ({ isListItem: true, value: ea, string: ea.signature || ea.name }))];
+  const items = [{ isListItem: true, string: '[Enter custom attribute...]', value: { custom: true } }, ...targetBindings.flat().map(ea => ({ isListItem: true, value: ea, string: ea.signature || ea.name }))];
 
   let res = await world.listPrompt(['Select Target Attribute\n', {}, 'Choose the attribute of the morph that is supposed to invoked once the connection is triggered. This can be either a method or a property of the morph. When selecting a property, keep in mind that the value of the source attribute will be assigned to the property or passed to the method as an argument.', { fontSize: 14, textAlign: 'left', fontWeight: 'normal', paddingTop: '10px' }], items, { filterable: true });
 

--- a/lively.ide/js/browser/commands.js
+++ b/lively.ide/js/browser/commands.js
@@ -433,7 +433,7 @@ export default function browserCommands (browser) {
         const what = (args && args.what) || 'setup'; // or: teardown
         const prop = what === 'setup' ? 'setupCalls' : 'teardownCalls';
         let nCalls = 0;
-        const beforeCode = arr.flatmap(testDescriptors, descr => {
+        const beforeCode = testDescriptors.flatMap(descr => {
           return descr[prop].map((beforeFn, i) => {
             nCalls++;
             return `await ((${lively.ast.stringify(beforeFn)})());`;

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -1016,7 +1016,7 @@ export class BrowserModel extends ViewModel {
   getDisplayedModuleNodes () {
     const columnView = this.ui.columnView;
     const moduleLists = columnView.submorphs.filter(m => ['directory', 'package'].includes(m._managedNode.type));
-    return arr.flatten(moduleLists.map(list => list.items.map(m => m.value)));
+    return moduleLists.map(list => list.items.map(m => m.value)).flat();
   }
 
   // this.selectModuleNamed('text/renderer.js')

--- a/lively.ide/js/inspector/context.js
+++ b/lively.ide/js/inspector/context.js
@@ -88,7 +88,7 @@ function propertyNamesOf (obj, partition) {
 }
 
 export function isMultiValue (foldableValue, propNames) {
-  return !arr.every(propNames.map(p => foldableValue[p]),
+  return !propNames.map(p => foldableValue[p]).every(
     v => obj.equals(v, foldableValue && foldableValue.valueOf()));
 }
 

--- a/lively.ide/js/objecteditor/index.js
+++ b/lively.ide/js/objecteditor/index.js
@@ -230,7 +230,7 @@ export class ObjectEditorModel extends ViewModel {
           const { classTree: tree, sourceEditor } = this.ui;
           const td = tree.treeData;
           const classNodes = td.getChildren(td.root).slice();
-          const items = arr.flatmap(classNodes.reverse(), node => {
+          const items = classNodes.reverse().flatMap(node => {
             const klass = node.target;
             const methods = td.getChildren(node);
 

--- a/lively.ide/md/modifier.js
+++ b/lively.ide/md/modifier.js
@@ -24,7 +24,7 @@ export class MarkdownModifier {
       depth: h.depth + delta,
       lineString: string.times('#', h.depth + delta) + ' ' + h.string
     }));
-    let changes = arr.flatmap(newHeadings, h => [
+    let changes = newHeadings.flatMap(h => [
       ['remove', { row: h.line, column: 0 }, { row: h.line, column: lines[h.line].length }],
       ['insert', { row: h.line, column: 0 }, h.lineString]
     ]);

--- a/lively.ide/shell/git.js
+++ b/lively.ide/shell/git.js
@@ -104,7 +104,7 @@ export async function fileStatus (dir, options = {}) {
   try {
     let mapping = await runGitCommands(commands, { cwd: dir });
     let lines = mapping && mapping.status.split('\n');
-    var fileObjects = arr.flatmap(lines || [], line => {
+    var fileObjects = (lines || []).flatMap(line => {
       if (!line) return [];
       let m; let results = [];
       if (m = line.match(/^(\s[A-Z]|[A-Z]{2})(.*)/)) results.push({ status: 'unstaged', statusString: m[0] });

--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -868,13 +868,13 @@ export class ComponentBrowserModel extends ViewModel {
       const term = searchInput.input;
       const parsedInput = this.parseInput();
       const rootUrls = componentFilesView.treeData.root.subNodes.map(m => m.url).slice(1); // ignore the popular stuff
-      const componentModules = arr.flatten(await Promise.all(rootUrls.map(url => {
+      const componentModules = Array.from(await Promise.all(rootUrls.map(url => {
         return resource(url).dirList(10, {
           exclude: (file) => {
             return file.isFile() && !file.url.endsWith('cp.js');
           }
         });
-      }))).filter(file => file.url.endsWith('cp.js'))
+      }))).flat().filter(file => file.url.endsWith('cp.js'))
         .map(file => file.url);
 
       // via system interface

--- a/lively.ide/studio/controls/shape.cp.js
+++ b/lively.ide/studio/controls/shape.cp.js
@@ -1,7 +1,7 @@
 import { ViewModel, add, without, part, component } from 'lively.morphic/components/core.js';
 import { Color, pt, rect } from 'lively.graphics';
 import { TilingLayout, Label } from 'lively.morphic';
-import { string, arr, num } from 'lively.lang';
+import { string, num } from 'lively.lang';
 import { NumberInput, PropertyLabel, PropertyLabelActive, DarkThemeList, EnumSelector, PropertyLabelHovered, AddButton } from '../shared.cp.js';
 import { disconnect, epiConnect } from 'lively.bindings';
 
@@ -37,7 +37,7 @@ export class ShapeControlModel extends ViewModel {
             { target: 'width input', signal: 'numberChanged', handler: 'changeWidth' },
             { target: 'height input', signal: 'numberChanged', handler: 'changeHeight' },
             { target: 'rotation input', signal: 'numberChanged', handler: 'changeRotation' },
-            ...arr.flatten(['', ' top left', ' top right', ' bottom right', ' bottom left'].map(d => [{
+            ...['', ' top left', ' top right', ' bottom right', ' bottom left'].map(d => [{
               target: 'radius input' + d,
               signal: 'numberChanged',
               handler: 'change' + string.camelCaseString('border radius ' + d),
@@ -47,7 +47,7 @@ export class ShapeControlModel extends ViewModel {
               signal: 'onMouseDown',
               handler: 'adjustCornerIndicator',
               converter: `() => "${string.camelCaseString(d)}"`
-            }])),
+            }]).flat(),
             { model: 'clip mode selector', signal: 'selection', handler: 'changeClipMode' },
             { target: 'proportional resize toggle', signal: 'onMouseDown', handler: 'changeResizeMode' },
             { target: 'independent corner toggle', signal: 'onMouseDown', handler: 'toggleBorderMultiVar' }

--- a/lively.ide/studio/interactive-tree.js
+++ b/lively.ide/studio/interactive-tree.js
@@ -818,11 +818,9 @@ export class MorphContainer extends InteractiveTreeContainer {
       return;
     }
 
-    label.textAndAttributes = [...iconPart, ...arr.flatten(
-      arr.interpose(
-        inBetween.map(x => [x, {}]), [term, { fontWeight: '900' }]
-      )
-    )];
+    label.textAndAttributes = [...iconPart, ...arr.interpose(
+      inBetween.map(x => [x, {}]), [term, { fontWeight: '900' }]
+    ).flat()];
     label.whenRendered().then(() => {
       label.fitIfNeeded();
     });

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -365,11 +365,9 @@ export class MorphNodeModel extends ViewModel {
       return;
     }
 
-    nameLabel.textAndAttributes = [...arr.flatten(
-      arr.interpose(
-        inBetween.map(x => [x, {}]), [term, { fontWeight: '900' }]
-      )
-    )];
+    nameLabel.textAndAttributes = [...arr.interpose(
+      inBetween.map(x => [x, {}]), [term, { fontWeight: '900' }]
+    ).flat()];
   }
 
   showPreviewOn (target) {

--- a/lively.ide/studio/styling.js
+++ b/lively.ide/studio/styling.js
@@ -848,7 +848,7 @@ class MasterComponentControl extends Morph {
     if (items.length == 0) return [];
     if (depth > 100) return [];
     const self = this;
-    return arr.flatten(Object.entries(arr.groupBy(items, c => c.path[depth - 1])).map(([name, entries]) => {
+    return Object.entries(arr.groupBy(items, c => c.path[depth - 1])).map(([name, entries]) => {
       const [components, categories] = arr.partition(entries, entry => entry.path.length <= depth);
       const subMenu = [
         name,
@@ -860,7 +860,7 @@ class MasterComponentControl extends Morph {
         }),
         ...subMenu[1].length ? [subMenu] : []
       ];
-    }), 1);
+    }).flat();
   }
 
   async getComponentSelectionMenu (state) {
@@ -906,7 +906,7 @@ class MasterComponentControl extends Morph {
     if (items.length == 0) return [];
     if (depth > 100) return [];
     const self = this;
-    return arr.flatten(Object.entries(arr.groupBy(items, c => c.path[depth - 1])).map(([name, entries]) => {
+    return Object.entries(arr.groupBy(items, c => c.path[depth - 1])).map(([name, entries]) => {
       const [components, categories] = arr.partition(entries, entry => entry.path.length <= depth);
       const subMenu = [
         name,
@@ -918,7 +918,7 @@ class MasterComponentControl extends Morph {
         }),
         ...subMenu[1].length ? [subMenu] : []
       ];
-    }), 1);
+    }).flat();
   }
 
   update () {

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -339,7 +339,7 @@ class SearchInputLine extends InputLine {
 
   fuzzyFilter (items, toString = item => item) {
     let parsedInput = this.parseInput();
-    return arr.filter(items, item => this.fuzzyMatch(toString(item), parsedInput));
+    return items.filter(item => this.fuzzyMatch(toString(item), parsedInput));
   }
 
   parseInput () {
@@ -471,7 +471,7 @@ class WorldDashboard extends Morph {
         // what defines a template ?
         return previews;
       case 'MY PROJECTS':
-        return arr.filter(previews, p => p._commit.author.name === user.name);
+        return previews.filter(p => p._commit.author.name === user.name);
       case 'PUBLISHED':
         return previews;
           // determine if the worlds are frozen or not

--- a/lively.ide/test-runner.js
+++ b/lively.ide/test-runner.js
@@ -441,7 +441,7 @@ export default class TestRunner extends HTMLMorph {
   collapseAll () {
     this.state.collapsedSuites = {};
     chain(this.state.loadedTests)
-      .pluck('tests').flatten().filter(ea => ea.type === 'suite' && ea.fullTitle)
+      .pluck('tests').flat().filter(ea => ea.type === 'suite' && ea.fullTitle)
       .forEach(suite => this.state.collapsedSuites[suite.fullTitle] = true);
     arr.pluck(this.state.loadedTests, 'file')
       .forEach(f => this.state.collapsedSuites[f] = true);

--- a/lively.ide/text/generic-code-commands.js
+++ b/lively.ide/text/generic-code-commands.js
@@ -112,7 +112,7 @@ export var commands = [
       const lines = morph.withSelectedLinesDo(line => line);
       const indent = arr.min([range.start.column].concat(
         chain(lines).map(line => line.match(/^\s*/))
-          .flatten().compact().pluck('length').value()));
+          .flat().compact().pluck('length').value()));
       const length = arr.max(lines.map(ea => ea.length)) - indent;
       const fence = Array(Math.ceil(length / 2) + 1).join('-=') + '-';
 

--- a/lively.ide/text/multi-select-commands.js
+++ b/lively.ide/text/multi-select-commands.js
@@ -1,4 +1,4 @@
-import { chain, arr, obj, string } from 'lively.lang';
+import { arr } from 'lively.lang';
 
 export var multiSelectCommands = [
 

--- a/lively.ide/text/ui.js
+++ b/lively.ide/text/ui.js
@@ -105,7 +105,7 @@ export class RichTextControl extends Morph {
               const top = padding.top();
               const right = padding.right();
               const bottom = padding.bottom();
-              const isMultiVar = !arr.every([left, top, right, bottom], side => side == left);
+              const isMultiVar = ![left, top, right, bottom].every(side => side == left);
 
               control.get('multi value indicator').visible = isMultiVar;
               connect(control.get('multi value indicator'), 'onMouseDown', control.get('padding field'), 'number', {

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -748,7 +748,7 @@ const commands = [
           plugin = new DiffEditorPlugin();
         } else {
           diffed = diff[format](a, b, opts);
-          content = arr.flatmap(diffed, ({ count, value, added, removed }) => {
+          content = diffed.flatMap(({ count, value, added, removed }) => {
             const attribute = removed
               ? { fontWeight: 'normal', textDecoration: 'line-through', fontColor: Color.red }
               : added

--- a/lively.installer/package-status.js
+++ b/lively.installer/package-status.js
@@ -1,27 +1,26 @@
-/*global System,$$world*/
-"format esm";
+/* global System,$$world */
+'format esm';
 
-import { join } from "./helpers.js";
-import { Package } from "./package.js";
-import { TextFlow } from "./morphic-helpers.js";
-import { resource } from "lively.resources";
-import { runCommand } from "../lively.ide/shell/shell-interface.js";
-import Terminal from "../lively.ide/shell/terminal.js";
-import { pt } from "lively.graphics";
-import { arr } from "lively.lang";
+import { join } from './helpers.js';
+import { Package } from './package.js';
+import { TextFlow } from './morphic-helpers.js';
+import { resource } from 'lively.resources';
+import { runCommand } from '../lively.ide/shell/shell-interface.js';
+import Terminal from '../lively.ide/shell/terminal.js';
+import { pt } from 'lively.graphics';
+import { arr } from 'lively.lang';
 
-
-var packageSpecFile = System.decanonicalize("lively.installer/packages-config.json");
+let packageSpecFile = System.decanonicalize('lively.installer/packages-config.json');
 
 // await readPackageSpec()
-export async function readPackageSpec() {
+export async function readPackageSpec () {
   return JSON.parse(await resource(packageSpecFile).read());
 }
 
 // await packages("/Users/robert/Lively/lively-dev/")
 // var baseDir = "/Users/robert/Lively/lively-dev/"
-export async function packages(baseDir) {
-  var specs = await readPackageSpec();
+export async function packages (baseDir) {
+  let specs = await readPackageSpec();
   return await Promise.all(
     specs.map(spec =>
       new Package(join(baseDir, spec.name), spec)
@@ -29,33 +28,32 @@ export async function packages(baseDir) {
         .then(p => p.readStatus())));
 }
 
+function printSummaryFor (p, packages) {
+  let report = `Package ${p.name} at ${p.directory}`;
+  if (!p.exists) return report + ' does not exist';
 
-function printSummaryFor(p, packages) {
-  var report = `Package ${p.name} at ${p.directory}`
-  if (!p.exists) return report + " does not exist"
+  let deps = p.findDependenciesIn(packages);
+  report += '\n  => dependencies:';
+  if (!deps.length) report += ' none';
+  else report += '\n    ' + deps.map(ea => ea.name).join('\n    ');
 
-  var deps = p.findDependenciesIn(packages);
-  report += "\n  => dependencies:";
-  if (!deps.length) report += " none";
-  else report += "\n    " + deps.map(ea => ea.name).join("\n    ")
+  report += '\n  => git status:\n';
 
-  report += "\n  => git status:\n";
-
-  if (!p.branch) report += "    not on a branch\n"
+  if (!p.branch) report += '    not on a branch\n';
   else report += `    on branch ${p.branch}\n`;
 
-  report += `    local changes to commit? ${(p.hasLocalChanges) ? "yes" : "no"}\n`;
-  report += `    local changes to push? ${(p.hasLocalChangesToPush) ? "yes" : "no"}\n`;
-  report += `    remote changes? ${(p.hasRemoteChanges) ? "yes" : "no"}\n`;
+  report += `    local changes to commit? ${(p.hasLocalChanges) ? 'yes' : 'no'}\n`;
+  report += `    local changes to push? ${(p.hasLocalChangesToPush) ? 'yes' : 'no'}\n`;
+  report += `    remote changes? ${(p.hasRemoteChanges) ? 'yes' : 'no'}\n`;
 
   return report;
 }
 
-export async function summaryForPackages(baseDir) {
-  var packages = await Promise.all((await readPackageSpec()).map(spec =>
-        new Package(join(baseDir, spec.name), spec).readConfig().readStatus())),
-      summaries = await Promise.all(packages.map(ea => printSummaryFor(ea, packages)));
-  return summaries.join("\n")
+export async function summaryForPackages (baseDir) {
+  let packages = await Promise.all((await readPackageSpec()).map(spec =>
+    new Package(join(baseDir, spec.name), spec).readConfig().readStatus()));
+  let summaries = await Promise.all(packages.map(ea => printSummaryFor(ea, packages)));
+  return summaries.join('\n');
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -66,15 +64,14 @@ export async function summaryForPackages(baseDir) {
 // var {remote, branch} = await reporter.packages[1].repo.localBranchInfo()
 
 export class ReporterWidget {
-
-  constructor(baseDir) {
+  constructor (baseDir) {
     this.baseDir = baseDir;
     this.textFlow = new TextFlow();
     this.packages = [];
   }
 
-  withLoadingIndicatorCatchingErrors(func, label = "please wait") {
-    var indicator;
+  withLoadingIndicatorCatchingErrors (func, label = 'please wait') {
+    let indicator;
     return lively.ide.withLoadingIndicatorDo(label)
       .then(i => indicator = i)
       .then(() => func())
@@ -83,18 +80,20 @@ export class ReporterWidget {
       .then(() => indicator.remove());
   }
 
-  renderMorphicSummaryForPackage(p) {
-    var reporter = this,
-        report = [[p.name, {fontWeight: "bold"}], `at ${p.directory}`];
+  renderMorphicSummaryForPackage (p) {
+    let reporter = this;
+    let report = [[p.name, { fontWeight: 'bold' }], `at ${p.directory}`];
 
     // Package name + status
-    if (!p.exists || !p.hasGitRepo) return report.concat(
-      this.textFlow.br,
-      !p.exists ? "  does not exist!" : "  is not a git repository!",
-      this.textFlow.button("install", () => {
-        reporter.withLoadingIndicatorCatchingErrors(
-          () => p.installOrUpdate(reporter.packages), `installing ${p.name}`)
-      }, {p, reporter}), this.textFlow.br, this.textFlow.br);
+    if (!p.exists || !p.hasGitRepo) {
+      return report.concat(
+        this.textFlow.br,
+        !p.exists ? '  does not exist!' : '  is not a git repository!',
+        this.textFlow.button('install', () => {
+          reporter.withLoadingIndicatorCatchingErrors(
+            () => p.installOrUpdate(reporter.packages), `installing ${p.name}`);
+        }, { p, reporter }), this.textFlow.br, this.textFlow.br); 
+    }
 
     // cd button
     // report = report.concat(this.textFlow.button("cd", () => {
@@ -102,111 +101,117 @@ export class ReporterWidget {
     //   }, {p}));
 
     // more... button
-    report = report.concat(this.textFlow.button("more...", () => {
-        lively.morphic.Menu.openAtHand(null, [
-          ["force re-install", () => {
-            reporter.withLoadingIndicatorCatchingErrors(
-              () => p.installOrUpdate(reporter.packages), `installing ${p.name}`)
-          }],
-          ["commit everything", () => {
-            $$world.prompt("Enter a commit message", {historyId: "lively.installer-commit-all-message"})
-              .then(msg => p.repo.commit(msg, true))
-              .then(cmd => $$world.inform(cmd.output))
-              .catch(err => $$world.inform(err.stack || err));
-          }],
-          ["push", () => {
-            Promise.resolve()
-              .then(msg => p.repo.push())
-              .then(cmd => $$world.inform(cmd.output))
-              .catch(err => $$world.inform(err.stack || err));
-          }]
-        ])
-      }, {p, reporter}), this.textFlow.br);
+    report = report.concat(this.textFlow.button('more...', () => {
+      lively.morphic.Menu.openAtHand(null, [
+        ['force re-install', () => {
+          reporter.withLoadingIndicatorCatchingErrors(
+            () => p.installOrUpdate(reporter.packages), `installing ${p.name}`);
+        }],
+        ['commit everything', () => {
+          $$world.prompt('Enter a commit message', { historyId: 'lively.installer-commit-all-message' })
+            .then(msg => p.repo.commit(msg, true))
+            .then(cmd => $$world.inform(cmd.output))
+            .catch(err => $$world.inform(err.stack || err));
+        }],
+        ['push', () => {
+          Promise.resolve()
+            .then(msg => p.repo.push())
+            .then(cmd => $$world.inform(cmd.output))
+            .catch(err => $$world.inform(err.stack || err));
+        }]
+      ]);
+    }, { p, reporter }), this.textFlow.br);
 
     // branch info
-    if (!p.currentBranch) report = report.concat("not on a branch");
+    if (!p.currentBranch) report = report.concat('not on a branch');
     else report = report.concat(`on branch ${p.currentBranch}`);
 
     // log button
     report = report.concat(
-      this.textFlow.button("log", () =>
+      this.textFlow.button('log', () =>
 
         Promise.resolve()
-        .then(() => p.hasRemoteChanges && runCommand(`cd ${p.directory};  git fetch --all`).whenDone())
-        .then(() => runCommand(`cd ${p.directory};  git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative -n 200 --all;`).whenDone())
-        .then(cmd =>
-          $$world.execCommand("open text window", {
-            title: `Commits of ${p.name}`,
-            content: cmd.output,
-            textMode: "text",
-            extent: pt(700,600)
-          })), {p}), this.textFlow.br);
+          .then(() => p.hasRemoteChanges && runCommand(`cd ${p.directory};  git fetch --all`).whenDone())
+          .then(() => runCommand(`cd ${p.directory};  git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative -n 200 --all;`).whenDone())
+          .then(cmd =>
+            $$world.execCommand('open text window', {
+              title: `Commits of ${p.name}`,
+              content: cmd.output,
+              textMode: 'text',
+              extent: pt(700, 600)
+            })), { p }), this.textFlow.br);
     
     // local changes + diff button
     report = report.concat(
-      "local changes to commit?",
-      p.hasLocalChanges ? "yes" : "no",
-      p.hasLocalChanges ? this.textFlow.button("diff", () =>
-        runCommand(`cd ${p.directory}; git diff`).whenDone()
-          .then(cmd =>
-            $$world.execCommand("open text window", {
-              title: `Diff ${p.name}`,
-              content: cmd.output,
-              textMode: "diff",
-              extent: pt(500,600)
-            }))
-          .catch(err => $$world.logError(err)), {p}) : this.textFlow.nothing, this.textFlow.br);
+      'local changes to commit?',
+      p.hasLocalChanges ? 'yes' : 'no',
+      p.hasLocalChanges
+        ? this.textFlow.button('diff', () =>
+          runCommand(`cd ${p.directory}; git diff`).whenDone()
+            .then(cmd =>
+              $$world.execCommand('open text window', {
+                title: `Diff ${p.name}`,
+                content: cmd.output,
+                textMode: 'diff',
+                extent: pt(500, 600)
+              }))
+            .catch(err => $$world.logError(err)), { p })
+        : this.textFlow.nothing, this.textFlow.br);
 
     report = report.concat(
-      "local changes to push?",
-      p.hasLocalChangesToPush ? "yes" : "no",
-      p.hasLocalChangesToPush ? this.textFlow.button("push", () =>
-        Terminal.runCommand(`cd! ${p.directory}; git push origin ${p.config.branch}`), {p}) :
-        this.textFlow.nothing, this.textFlow.br);
+      'local changes to push?',
+      p.hasLocalChangesToPush ? 'yes' : 'no',
+      p.hasLocalChangesToPush
+        ? this.textFlow.button('push', () =>
+          Terminal.runCommand(`cd! ${p.directory}; git push origin ${p.config.branch}`), { p })
+        : this.textFlow.nothing, this.textFlow.br);
 
     // remote changes + update button
     report = report.concat(
-      "remote changes?",
-      p.hasRemoteChanges ? "yes" : "no",
-      p.hasRemoteChanges ? this.textFlow.button("update", () => {
-        reporter.withLoadingIndicatorCatchingErrors(
-          () => p.installOrUpdate(reporter.packages), `updating ${p.name}`)
-      }, {p, reporter}) : this.textFlow.nothing,
-      p.hasRemoteChanges ? this.textFlow.button("show changes", () => {
-        p.repo.getRemoteAndLocalHeadRef(p.config.branch).then(({local, remote}) =>
-          Terminal.runCommand(`cd! ${p.directory}; git diff ${local}...${remote}`))
-      }, {p}) : this.textFlow.nothing,
+      'remote changes?',
+      p.hasRemoteChanges ? 'yes' : 'no',
+      p.hasRemoteChanges
+        ? this.textFlow.button('update', () => {
+          reporter.withLoadingIndicatorCatchingErrors(
+            () => p.installOrUpdate(reporter.packages), `updating ${p.name}`);
+        }, { p, reporter })
+        : this.textFlow.nothing,
+      p.hasRemoteChanges
+        ? this.textFlow.button('show changes', () => {
+          p.repo.getRemoteAndLocalHeadRef(p.config.branch).then(({ local, remote }) =>
+            Terminal.runCommand(`cd! ${p.directory}; git diff ${local}...${remote}`));
+        }, { p })
+        : this.textFlow.nothing,
       this.textFlow.br);
 
     // missing / outdated npm packages
-    var missingNpmPackages = p._npmPackagesThatNeedFixing;
+    let missingNpmPackages = p._npmPackagesThatNeedFixing;
     if (missingNpmPackages && missingNpmPackages.length) {
-    report = report.concat(
-      "missing npm packages:",
-      missingNpmPackages.join(", "),
-      this.textFlow.button("update / install", () =>
-        p.fixNPMPackages(missingNpmPackages)
-          .then(() => p.linkToDependencies(packages)), {p, missingNpmPackages, packages}),
-      this.textFlow.br);
+      report = report.concat(
+        'missing npm packages:',
+        missingNpmPackages.join(', '),
+        this.textFlow.button('update / install', () =>
+          p.fixNPMPackages(missingNpmPackages)
+            .then(() => p.linkToDependencies(packages)), { p, missingNpmPackages, packages }),
+        this.textFlow.br);
     }
 
     return report.concat(this.textFlow.br, this.textFlow.br);
   }
 
-  async morphicSummary(targetMorph) {
+  async morphicSummary (targetMorph) {
     // var pBar = $world.addProgressBar(null, "checking packages"), done = 0;
     try {
-      var specs = await readPackageSpec(),
-          packages = await Promise.all(
-          specs.map(spec =>
-            new Package(join(this.baseDir, spec.name), spec)
-              .readConfig()
-              .then(p => p.readStatus())
-              .then(p => {
-                // done++; pBar.setValue(done / specs.length);
-                return p;
-              })))
-
+      let specs = await readPackageSpec();
+      var packages = await Promise.all(
+        specs.map(spec =>
+          new Package(join(this.baseDir, spec.name), spec)
+            .readConfig()
+            .then(p => p.readStatus())
+            .then(p => {
+              // done++; pBar.setValue(done / specs.length);
+              return p;
+            })));
     } catch (e) {
       $$world.inform(String(e.stack || e));
     } finally {
@@ -214,31 +219,31 @@ export class ReporterWidget {
     }
 
     this.packages = packages.sortBy(ea =>
-      (!ea.exists ? 401 : 0) + (!ea.hasGitRepo ? 301 : 0) + (ea.hasRemoteChanges ? 200 : 0)+ (ea.hasLocalChangesToPush ? 80 : 0) + (ea.hasLocalChanges ? 100 : 0) + (ea._npmPackagesThatNeedFixing && ea._npmPackagesThatNeedFixing.length ? 50 : 0) + ea.name.charCodeAt(0)).reverse();
+      (!ea.exists ? 401 : 0) + (!ea.hasGitRepo ? 301 : 0) + (ea.hasRemoteChanges ? 200 : 0) + (ea.hasLocalChangesToPush ? 80 : 0) + (ea.hasLocalChanges ? 100 : 0) + (ea._npmPackagesThatNeedFixing && ea._npmPackagesThatNeedFixing.length ? 50 : 0) + ea.name.charCodeAt(0)).reverse();
 
-    var summaries = this.packages.map(p => this.renderMorphicSummaryForPackage(p)),
-        reporter = this,
-        report = [
-          this.textFlow.button("refresh",
-            function() { reporter.morphicSummary(this.owner); },
-            {reporter}),
-          this.textFlow.br, this.textFlow.br
-        ].concat(arr.flatten(summaries, 1));
+    let summaries = this.packages.map(p => this.renderMorphicSummaryForPackage(p));
+    let reporter = this;
+    let report = [
+      this.textFlow.button('refresh',
+        function () { reporter.morphicSummary(this.owner); },
+        { reporter }),
+      this.textFlow.br, this.textFlow.br
+    ].concat(summaries.flat());
 
     return this.textFlow.render(targetMorph, report);
   }
 
-  summaryMorph() {
-    var target = lively.morphic.newMorph({extent: lively.pt(600, 440), style: {fill: lively.Color.white, borderWidth: 0}});
-    var win = target.openInWindow(target.getPosition()).openInWorldCenter();
+  summaryMorph () {
+    let target = lively.morphic.newMorph({ extent: lively.pt(600, 440), style: { fill: lively.Color.white, borderWidth: 0 } });
+    let win = target.openInWindow(target.getPosition()).openInWorldCenter();
     win.setTitle(`lively.installer status for ${this.baseDir}`);
     win.comeForward();
     return win;
   }
 
-  async morphicSummaryAsMorph() {
-    var indicator = await lively.ide.withLoadingIndicatorDo("loading"),
-        morph = this.summaryMorph();
+  async morphicSummaryAsMorph () {
+    let indicator = await lively.ide.withLoadingIndicatorDo('loading');
+    let morph = this.summaryMorph();
     try {
       await this.morphicSummary(morph.targetMorph);
     } catch (e) {
@@ -248,5 +253,4 @@ export class ReporterWidget {
     }
     return morph;
   }
-
 }

--- a/lively.keyboard/CommandTrait.js
+++ b/lively.keyboard/CommandTrait.js
@@ -11,7 +11,7 @@ let CommandTrait = {
   },
 
   get commandsIncludingOwners () {
-    return lively.lang.arr.flatmap([this].concat(this.ownerChain()), morph =>
+    return [this].concat(this.ownerChain()).flatMap(morph =>
       lively.lang.arr.sortByKey(morph.commands, 'name')
         .map(command => ({ target: morph, command })));
   },

--- a/lively.lang/function.js
+++ b/lively.lang/function.js
@@ -9,7 +9,6 @@
 
 import { merge as objectMerge, safeToString } from './object.js';
 import Closure from './closure.js';
-import * as arr from './array.js';
 
 // -=-=-=-=-=-=-=-=-
 // static functions
@@ -581,7 +580,7 @@ function flip (f) {
 function withNull (func) {
   func = func || function () {};
   return function (/* args */) {
-    const args = arr.from(arguments);
+    const args = Array.from(arguments);
     func.apply(null, [null].concat(args));
   };
 }

--- a/lively.lang/index.js
+++ b/lively.lang/index.js
@@ -52,8 +52,8 @@ const GLOB = typeof window !== 'undefined'
 const isNode = typeof process !== 'undefined' && process.env && typeof process.exit === 'function';
 
 const globalInterfaceSpec = [
-  { action: 'installMethods', target: 'Array', sources: ['arr'], methods: ['from', 'genN', 'range', 'withN'] },
-  { action: 'installMethods', target: 'Array.prototype', sources: ['arr'], methods: ['all', 'any', 'batchify', 'clear', 'clone', 'collect', 'compact', 'delimWith', 'detect', 'doAndContinue', 'each', 'equals', 'filterByKey', 'findAll', 'first', 'flatten', 'grep', 'groupBy', 'groupByKey', 'histogram', 'include', 'inject', 'intersect', 'invoke', 'last', 'mapAsync', 'mapAsyncSeries', 'mask', 'max', 'min', 'mutableCompact', 'nestedDelay', 'partition', 'pluck', 'pushAll', 'pushAllAt', 'pushAt', 'pushIfNotIncluded', 'reMatches', 'reject', 'rejectByKey', 'remove', 'removeAt', 'replaceAt', 'rotate', 'shuffle', 'size', 'sortBy', 'sortByKey', 'sum', 'swap', 'toArray', 'toTuples', 'union', 'uniq', 'uniqBy', 'without', 'withoutAll', 'zip'], alias: [['select', 'filter']] },
+  { action: 'installMethods', target: 'Array', sources: ['arr'], methods: ['genN', 'range', 'withN'] },
+  { action: 'installMethods', target: 'Array.prototype', sources: ['arr'], methods: ['batchify', 'clear', 'clone', 'compact', 'doAndContinue', 'equals', 'filterByKey', 'filter', 'first', 'flat', 'flatMap', 'grep', 'groupBy', 'groupByKey', 'histogram', 'intersect', 'invoke', 'last', 'mask', 'map', 'max', 'min', 'mutableCompact', 'nestedDelay', 'partition', 'pluck', 'pushAll', 'pushAllAt', 'pushAt', 'pushIfNotIncluded', 'reMatches', 'reject', 'rejectByKey', 'remove', 'removeAt', 'replaceAt', 'rotate', 'shuffle', 'slice', 'sortBy', 'sortByKey', 'sum', 'swap', 'toTuples', 'union', 'uniq', 'uniqBy', 'uniqByKey', 'without', 'withoutAll', 'zip'], alias: [['select', 'filter']] },
   { action: 'installMethods', target: 'Date', sources: ['date'], methods: [/* "parse" */] },
   { action: 'installMethods', target: 'Date.prototype', sources: ['date'], methods: ['equals', 'format', 'relativeTo'] },
   { action: 'installMethods', target: 'Function', sources: ['fun'], methods: ['fromString'] },
@@ -123,7 +123,7 @@ export function chain (object) {
 function createChain (interfaceObj, obj) {
   return Object.keys(interfaceObj).reduce(function (chained, methodName) {
     chained[methodName] = function (/* args */) {
-      const args = Array.prototype.slice.call(arguments);
+      const args = Array.from(arguments);
       const result = interfaceObj[methodName].apply(null, [obj].concat(args));
       return chain(result);
     };

--- a/lively.lang/messenger.js
+++ b/lively.lang/messenger.js
@@ -187,7 +187,7 @@ child_process.fork is unified.
 var messengers = [];
 var messengerSpec = {
   send: function(msg, onSendDone) {
-    var err = null, recv = arr.detect(messengers, function(ea) {
+    var err = null, recv = messengers.find(function(ea) {
           return ea.id() === msg.target; });
     if (recv) recv.onMessage(msg);
     else err = new Error("Could not find receiver " + msg.target);

--- a/lively.lang/object.js
+++ b/lively.lang/object.js
@@ -4,7 +4,7 @@
  */
 
 import { fromString as functionFromString, asScriptOf, argumentNames } from './function.js';
-import { deepEquals as arrayDeepEquals, isSubset, flatten } from './array.js';
+import { deepEquals as arrayDeepEquals, isSubset } from './array.js';
 
 // -=-=-=-=-=-=-=-=-
 // internal helper
@@ -517,7 +517,7 @@ function sortKeysWithBeforeAndAfterConstraints (properties, throwErrorOnMissing 
     resolvedGroups.push(resolvedGroup);
   }
 
-  return flatten(resolvedGroups, 1);
+  return resolvedGroups.flat();
 }
 
 // -=-=-=-=-=-=-

--- a/lively.lang/tree.js
+++ b/lively.lang/tree.js
@@ -2,7 +2,6 @@
  * Methods for traversing and transforming tree structures.
  */
 
-import { flatten } from './array.js';
 
 function prewalk (treeNode, iterator, childGetter, counter = { i: 0 }, depth = 0) {
   let i = counter.i++;
@@ -40,9 +39,9 @@ function filter (treeNode, testFunc, childGetter) {
   let result = [];
   if (testFunc(treeNode)) result.push(treeNode);
   return result.concat(
-    flatten((childGetter(treeNode) || []).map(function (n) {
+    (childGetter(treeNode) || []).map(function (n) {
       return filter(n, testFunc, childGetter);
-    })));
+    }).flat());
 }
 
 function map (treeNode, mapFunc, childGetter, depth = 0) {
@@ -50,8 +49,8 @@ function map (treeNode, mapFunc, childGetter, depth = 0) {
   // return values of all mapFunc calls is the result. `childGetter` is a
   // function to retrieve the children from a node.
   return [mapFunc(treeNode, depth)].concat(
-    flatten((childGetter(treeNode) || [])
-      .map(n => map(n, mapFunc, childGetter, depth + 1))));
+    (childGetter(treeNode) || [])
+      .map(n => map(n, mapFunc, childGetter, depth + 1)).flat());
 }
 
 function mapTree (treeNode, mapFunc, childGetter, depth = 0) {

--- a/lively.modules/src/export-lookup.js
+++ b/lively.modules/src/export-lookup.js
@@ -87,8 +87,7 @@ export default class ExportLookup {
     Object.keys(exportsByModule).forEach(id =>
       this.resolveExportsOfModule(id, exportsByModule));
 
-    return arr.flatmap(Object.keys(exportsByModule),
-      id => exportsByModule[id] ? exportsByModule[id].resolvedExports || exportsByModule[id].rawExports : []);
+    return Object.keys(exportsByModule).flatMap(id => exportsByModule[id] ? exportsByModule[id].resolvedExports || exportsByModule[id].rawExports : []);
   }
 
   async rawExportsByModule (options) {
@@ -185,7 +184,7 @@ export default class ExportLookup {
       'moduleId', 'isMain', 'packageName', 'packageURL',
       'packageVersion', 'pathInPackage']);
 
-    data.resolvedExports = arr.flatmap(data.rawExports.exports, ({ type, exported, local, fromModule }) => {
+    data.resolvedExports = data.rawExports.exports.flatMap(({ type, exported, local, fromModule }) => {
       if (type !== 'all') return [{ ...base, type, exported, local, fromModule }];
 
       // resolve "* from"

--- a/lively.modules/src/import-modification.js
+++ b/lively.modules/src/import-modification.js
@@ -154,7 +154,7 @@ export class ImportInjector {
   }
 
   modifyExistingImport (imports, standaloneImport) {
-    const specifiers = arr.flatmap(imports, ({ specifiers }) => specifiers || []);
+    const specifiers = imports.flatMap(({ specifiers }) => specifiers || []);
     if (!specifiers.length) return null;
 
     const [[defaultSpecifier], [normalSpecifier]] =
@@ -333,7 +333,7 @@ export class ImportRemover {
     const parsed = optModuleAst || fuzzyParse(moduleSource);
 
     // 1.get imports with specifiers
-    const imports = arr.flatmap(parsed.body, ea => {
+    const imports = parsed.body.flatMap(ea => {
       if (ea.type !== 'ImportDeclaration' || !ea.specifiers.length) return [];
       return ea.specifiers.map(spec => ({ local: spec.local, importStmt: ea }));
     });
@@ -376,7 +376,7 @@ export class ImportRemover {
       ? fuzzyParse(moduleSourceOrAst)
       : moduleSourceOrAst;
 
-    const imports = arr.flatmap(parsed.body, ea => {
+    const imports = parsed.body.flatMap(ea => {
       if (ea.type !== 'ImportDeclaration' || !ea.specifiers.length) return [];
       return ea.specifiers.map(spec =>
         ({ local: spec.local, from: ea.source ? ea.source.value : '', importStmt: ea }));

--- a/lively.modules/src/module.js
+++ b/lively.modules/src/module.js
@@ -559,7 +559,7 @@ class ModuleInterface {
       'createOrExtendES6ClassForLively',
       'lively.capturing-declaration-wrapper'];
     const rec = this.recorder;
-    if (arr.include(ignored, key)) return;
+    if (ignored.includes(key)) return;
     this._observersOfTopLevelState.forEach(fn => fn(key, rec[key]));
   }
 

--- a/lively.modules/src/packages/package.js
+++ b/lively.modules/src/packages/package.js
@@ -544,7 +544,7 @@ class Package {
         .catch(err => {
           console.error(`Error searching module ${m.name}:\n${err.stack}`);
           return [];
-        }))).then(res => arr.flatten(res, 1));
+        }))).then(res => res.flat());
   }
 }
 

--- a/lively.modules/src/system.js
+++ b/lively.modules/src/system.js
@@ -116,7 +116,7 @@ function systems () {
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 function nameOfSystem (System) {
-  return Object.keys(systems()).detect(name => systems()[name] === System);
+  return Object.keys(systems()).some(name => systems()[name] === System);
 }
 
 function getSystem (nameOrSystem, config) {
@@ -570,7 +570,7 @@ function searchLoadedModules (System, searchStr, options) {
   return Promise.all(
     obj.values(loadedModules(System))
       .map(m => m.search(searchStr, options)))
-    .then(res => arr.flatten(res, 1));
+    .then(res => res.flat());
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -1424,7 +1424,7 @@ export class ProportionalLayout extends Layout {
     } else if (typeof selector === 'string') {
       morphs = container.submorphs.filter(ea => ea.name === selector);
     } else if (Array.isArray(selector)) {
-      morphs = arr.flatmap(selector, sel => this._morphsMatchingSelector(container, sel));
+      morphs = selector.flatMap(sel => this._morphsMatchingSelector(container, sel));
     }
     return morphs;
   }
@@ -3171,9 +3171,9 @@ export class GridLayout extends Layout {
    * @param {...LayoutAxis} axes - Set of columns or rows that we will go through and measure the morphs they control.
    */
   measureMorphsIn (...axes) {
-    const groupsToMeasure = arr.flatten(arr.compact(axes).map(axis => {
+    const groupsToMeasure = arr.compact(axes).map(axis => {
       return axis.items.map(item => item.group);
-    }));
+    }).flat();
     groupsToMeasure.forEach(({ morph: m, resize }) => {
       if (!m) return;
       const node = this.getNodeFor(m);

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1432,7 +1432,7 @@ export class Morph {
   }
 
   submorphBounds (filterFn = () => true) {
-    const morphs = arr.filter(this.submorphs, filterFn);
+    const morphs = this.submorphs.filter(filterFn);
     if (morphs.length < 1) return this.innerBounds();
     return morphs.map(submorph => submorph.bounds())
       .reduce((a, b) => a.union(b));
@@ -2593,7 +2593,7 @@ export class Morph {
   }
 
   get commandsIncludingOwners () {
-    return arr.flatmap([this].concat(this.ownerChain()), morph =>
+    return [this].concat(this.ownerChain()).flatMap(morph =>
       arr.sortByKey(morph.commands, 'name').map(command => ({ target: morph, command })));
   }
 

--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -187,7 +187,7 @@ export class PropertyAnimation {
         this.morph.withAllSubmorphsDo(m => m.isText && m.invalidateTextLayout(true, true)));
     }
     this.needsAnimation[type] = false;
-    if (!arr.any(obj.values(this.needsAnimation), Boolean)) {
+    if (!obj.values(this.needsAnimation).some(Boolean)) {
       this.queue.removeAnimation(this);
       this.resolveCallback ? this.resolveCallback() : this.onFinish();
     }

--- a/lively.morphic/rendering/dom-helper.js
+++ b/lively.morphic/rendering/dom-helper.js
@@ -120,7 +120,7 @@ export function defaultDOMEnv () {
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 function setCSSDef (node, cssDefString, doc) {
-  arr.from(node.childNodes).forEach(c => node.removeChild(c));
+  Array.from(node.childNodes).forEach(c => node.removeChild(c));
   const rules = document.createTextNode(cssDefString);
   if (node.styleSheet) node.styleSheet.cssText = rules.nodeValue;
   else node.appendChild(rules);

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -194,7 +194,7 @@ export class Renderer {
 
     if (orderChanged) {
       const scrolls = new WeakMap();
-      const nodes = arr.compact(arr.flatten(fixedMorphs.map(m => m.withAllSubmorphsDo(m => this.getNodeForMorph(m)))));
+      const nodes = arr.compact(fixedMorphs.map(m => m.withAllSubmorphsDo(m => this.getNodeForMorph(m))).flat());
       nodes.forEach(node => scrolls.set(node, node.scrollTop));
       currentFixedMorphNodes.map(n => n && n.parentNode && n.parentNode.removeChild(n));
       nodes.forEach(node => {

--- a/lively.morphic/serialization.js
+++ b/lively.morphic/serialization.js
@@ -248,7 +248,7 @@ export function packagesOfSnapshot (snapshot) {
   const packageMap = {}; const depMap = snapshot.packageDepMap;
   if (!depMap) return packages;
   for (const p of packages) packageMap[p.url] = p;
-  return arr.flatten(graph.sortByReference(depMap)).map(url => packageMap[url]);
+  return graph.sortByReference(depMap).flat().map(url => packageMap[url]);
 }
 
 export async function loadPackagesAndModulesOfSnapshot (snapshot) {

--- a/lively.morphic/sizzle.js
+++ b/lively.morphic/sizzle.js
@@ -16,7 +16,7 @@ export class SizzleExpression {
     for (let token of rule.split(' ')) {
       this.compiledRule.push(this.createMatcher(token));
     }
-    if (arr.any(this.compiledRule, matcher => !matcher)) {
+    if (this.compiledRule.some(matcher => !matcher)) {
       // throw new Error('Can not compile ' + rule);
       this.compileError = true;
     }
@@ -115,10 +115,10 @@ class ClassMatcher extends Matcher {
 
   matches (morph) {
     const { 
-         removed, added, animation 
-      } = morph._animatedStyleClasses || {removed: [], added: []},
-      applied = arr.every(this.token, sc => morph.styleClasses.includes(sc)),
-      revoked = !applied && arr.every(this.token, sc => [...morph.styleClasses, ...removed].includes(sc));
+      removed, added, animation 
+    } = morph._animatedStyleClasses || { removed: [], added: [] };
+    const applied = this.token.every(sc => morph.styleClasses.includes(sc));
+    const revoked = !applied && this.token.every(sc => [...morph.styleClasses, ...removed].includes(sc));
     // first test if classes match ignoring the added and removed
     // these are the "unchanged"
     return {
@@ -288,8 +288,9 @@ export class StylingVisitor extends SizzleVisitor {
   }
 
   retrieveExpressions (morph) {
-    if (morph.styleSheets.length < 1) return false;
-    return morph.styleSheets.map(ss => ss.applicableRules());
+    const styleSheets = Array(morph.styleSheets);
+    if (styleSheets.length < 1) return false;
+    return styleSheets.map(ss => ss.applicableRules());
   }
 
   visitMorph (morph, styleSheetPatches) {
@@ -336,6 +337,6 @@ export class StylingVisitor extends SizzleVisitor {
   }
 
   getChildren (morph) {
-    return arr.filter(morph.submorphs, m => m.needsRerender());
+    return morph.submorphs.filter(m => m.needsRerender());
   }
 }

--- a/lively.morphic/style-sheets.js
+++ b/lively.morphic/style-sheets.js
@@ -85,7 +85,7 @@ export class StyleSheet {
       }
       if (v) {
         const { top, left, right, bottom } = v;
-        if (arr.all([top, left, right, bottom], (a) => a && obj.equals(a, v.top))) {
+        if ([top, left, right, bottom].every((a) => a && obj.equals(a, v.top))) {
           return continueInspectFn(v.top);
         }
       }

--- a/lively.morphic/tests/undo-test.js
+++ b/lively.morphic/tests/undo-test.js
@@ -63,7 +63,7 @@ describe('undo', () => {
     m3.fill = Color.yellow;
     m1.undoStop('test');
 
-    expect(arr.uniq(arr.flatmap(env.undoManager.undos, ({ changes }) => arr.pluck(changes, 'target'))))
+    expect(arr.uniq(env.undoManager.undos.flatMap(({ changes }) => arr.pluck(changes, 'target'))))
       .equals([m1, m2]);
   });
 
@@ -75,7 +75,7 @@ describe('undo', () => {
     m3.fill = Color.yellow;
     m1.undoStop('test');
 
-    expect(arr.uniq(arr.flatmap(env.undoManager.undos, ({ changes }) => arr.pluck(changes, 'target'))))
+    expect(arr.uniq(env.undoManager.undos.flatMap(({ changes }) => arr.pluck(changes, 'target'))))
       .equals([m1, m2, m3]);
   });
 });

--- a/lively.morphic/text/commands.js
+++ b/lively.morphic/text/commands.js
@@ -894,7 +894,7 @@ const commands = [
         arr.range(rows.first, rows.last)
           .map(row => morph.getLine(row))
           .join('\n'), { keepEmptyLines: true });
-      const newString = chain(paragraphs.map(fitParagraph)).flatten().value().join('\n');
+      const newString = chain(paragraphs.map(fitParagraph)).flat().value().join('\n');
 
       morph.undoManager.group();
       morph.replace(range, newString);

--- a/lively.morphic/text/document.js
+++ b/lively.morphic/text/document.js
@@ -126,7 +126,7 @@ class TreeNode {
       }
     }
 
-    report.push(...arr.flatmap(children, ea => ea.consistencyCheck()));
+    report.push(...children.flatMap(ea => ea.consistencyCheck()).filter(Boolean));
     return report;
   }
 }

--- a/lively.morphic/text/document.js
+++ b/lively.morphic/text/document.js
@@ -182,7 +182,8 @@ class InnerTreeNode extends TreeNode {
       const child = this.children[i];
       const childHeight = child.height;
       if (y <= childHeight) {
-        return this.isLeaf ? { line: child, offset: y, y: lineY, row }
+        return this.isLeaf
+          ? { line: child, offset: y, y: lineY, row }
           : child.findLineByVerticalOffset(y, lineY, row);
       }
       y = y - childHeight;
@@ -765,7 +766,8 @@ class InnerTreeNode extends TreeNode {
     const { isLeaf, size, width, height, children } = this;
     return `node (${isLeaf ? 'leaf, ' : ''}` +
          `${isLeaf && children.length
-               ? `rows: ${children[0].row}-${arr.last(children).row} ` : ''}` +
+               ? `rows: ${children[0].row}-${arr.last(children).row} `
+: ''}` +
          `size: ${size} ${width}x${height})`;
   }
 }
@@ -930,7 +932,8 @@ export class Line extends TreeNode {
     let text = '';
     for (let i = 0; i < textAndAttributes.length; i = i + 2) {
       text = text + (typeof textAndAttributes[i] === 'string'
-        ? textAndAttributes[i] : objectReplacementChar);
+        ? textAndAttributes[i]
+        : objectReplacementChar);
     }
     return this.changeText(text, textAndAttributes);
   }
@@ -944,7 +947,8 @@ export class Line extends TreeNode {
 
     function printTextAttrTuple ([content, attrs]) {
       return (typeof content === 'string'
-        ? `"${content}"` : String(content)) + `,${JSON.stringify(attrs)}`;
+        ? `"${content}"`
+        : String(content)) + `,${JSON.stringify(attrs)}`;
     }
   }
 
@@ -1427,7 +1431,8 @@ export default class Document {
 
     if (row === endRow) {
       return column === endColumn
-        ? '' : this.getLineString(row).slice(column, endColumn);
+        ? ''
+        : this.getLineString(row).slice(column, endColumn);
     }
 
     let line = this.getLine(row);

--- a/lively.morphic/text/icons.js
+++ b/lively.morphic/text/icons.js
@@ -15,7 +15,7 @@ Show all icons:
 
 $world.openInWindow(morph({
   extent: pt(300,800), clipMode: "auto", type: "text", fontSize: 20, padding: Rectangle.inset(4),
-  textAndAttributes: lively.lang.arr.flatmap(Object.keys(Icons), name =>
+  textAndAttributes: Object.keys(Icons).flatMap(name =>
     [`${Icons[name].code} ${name}\n`, {fontFamily: "", textStyleClasses: ["fa"]}])
 }), {title: "icons"}).activate();
 

--- a/lively.morphic/text/input-line.js
+++ b/lively.morphic/text/input-line.js
@@ -397,7 +397,7 @@ export default class InputLine extends Text {
           const { selected } = await inputLine.world().filterableListPrompt(
             'Choose items to delete:', items, { multiSelect: true });
 
-          arr.sort(selected).reverse().forEach(index => {
+          selected.reverse().forEach(index => {
             if (index < hist.index) hist.index--;
             hist.items.splice(index, 1);
           });

--- a/lively.morphic/text/layout.js
+++ b/lively.morphic/text/layout.js
@@ -18,14 +18,14 @@ export default class TextLayout {
   restore (serializedLineBounds, morph) {
     const decompress = (compressedBounds) => {
       let x = 0; const y = 0;
-      return arr.flatten(arr.histogram(compressedBounds, compressedBounds.length / 3).map(([count, width, height]) => {
+      return arr.histogram(compressedBounds, compressedBounds.length / 3).map(([count, width, height]) => {
         const batch = [];
         for (let i = 0; i < count; i++) {
           batch.push(rect(x, y, width, height));
           x += width;
         }
         return batch;
-      }));
+      }).flat();
     };
 
     for (const [row, compressedBounds] of serializedLineBounds) {
@@ -150,7 +150,7 @@ export default class TextLayout {
     if (!debug &&
         morph.lineCount() < 10 &&
         morph.document.stringSize < 3000 &&
-        !arr.any(morph.textAndAttributes, attr => attr && attr.fontFamily != undefined)) {
+        !morph.textAndAttributes.some(attr => attr && attr.fontFamily != undefined)) {
       const directRenderLineFn = textRenderer.directRenderLineFn(morph);
       const linesBounds = fontMetric.manuallyComputeBoundsOfLines(
         morph, lines, 0, 0, {

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -824,7 +824,7 @@ export class Text extends Morph {
         }
       }
       if (prevRect) compactBounds.push([sameRectCount, num.roundTo(prevRect.width || 0, 0.001), prevRect.height || 0]);
-      cachedLineBounds.push([line.row, arr.flatten(compactBounds)]);
+      cachedLineBounds.push([line.row, compactBounds.flat()]);
     }
 
     snapshot.cachedLineBounds = cachedLineBounds;

--- a/lively.morphic/text/occur.js
+++ b/lively.morphic/text/occur.js
@@ -168,7 +168,7 @@ export class Occur {
       'box-sizing': 'border-box',
       'box-shadow': '0 0 4px rgb(91, 255, 50)'
     };
-    const ranges = arr.flatmap(this._document._occurMatchingLines, ({ ranges }, row) =>
+    const ranges = this._document._occurMatchingLines.flatMap(({ ranges }, row) =>
       ranges.map(({ start: { column }, end: { column: endColumn } }) =>
         ({ start: { column, row }, end: { column: endColumn, row } })));
 

--- a/lively.morphic/undo.js
+++ b/lively.morphic/undo.js
@@ -56,7 +56,7 @@ class Undo {
   addUndos (undos) {
     undos = arr.sortBy(undos.concat(this).filter(ea => ea.recorded()), ({ no }) => no);
     if (!undos.length) return;
-    this.changes = arr.flatmap(undos, ({ changes }) => changes);
+    this.changes = undos.flatMap(({ changes }) => changes);
     this.timestamp = undos[0].timestamp;
     this.no = undos[0].no;
     this.name = undos.map(({ name }) => name).join('-');

--- a/lively.serializer2/debugging.js
+++ b/lively.serializer2/debugging.js
@@ -450,7 +450,7 @@ export class ObjectGraphVisualizer extends HTMLMorph {
 
     // nodes.push({group: "nodes", data: {id: "morph"}})
 
-    var edges = arr.flatmap(Object.keys(g), id => g[id].map(id2 => {
+    var edges = Object.keys(g).flatMap(id => g[id].map(id2 => {
       return {group: "edges", data: {source: id, target: id2}};
     }));
 

--- a/lively.server/server.js
+++ b/lively.server/server.js
@@ -1,5 +1,5 @@
-import { promise, arr, obj } from "lively.lang";
-import * as http from "http";
+import { promise, arr, obj } from 'lively.lang';
+import * as http from 'http';
 
 // Array.from(LivelyServer.servers.keys())
 // var s = LivelyServer.ensure({hostname: "0.0.0.0", port: "9011"})
@@ -9,47 +9,46 @@ import * as http from "http";
 // s.findPlugin("l2l").l2lNamespace
 // s.findPlugin("socketio").io.path()
 
-export async function start(opts = {}) {
+export async function start (opts = {}) {
   // opts = {port, hostname, ...}
-  opts = {plugins: [], ...opts};
-  var server = LivelyServer.ensure(opts);
+  opts = { plugins: [], ...opts };
+  let server = LivelyServer.ensure(opts);
   await server.whenStarted();
   return server;
 }
 
 export default class LivelyServer {
-
-  static canonicalizeOptions(opts) {
+  static canonicalizeOptions (opts) {
     return {
-      hostname: "localhost",
+      hostname: 'localhost',
       port: 9101,
       debug: false,
       ...opts
-    }
+    };
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // server instance storage
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  static get servers() {
+  static get servers () {
     return this._servers || (this._servers = new Map());
   }
 
-  static _key(opts) {
-    var {hostname, port} = this.canonicalizeOptions(opts);
+  static _key (opts) {
+    let { hostname, port } = this.canonicalizeOptions(opts);
     return `${hostname}:${port}`;
   }
 
-  static _register(server) { this.servers.set(this._key(server), server); }
-  static _unregister(server) { this.servers.delete(this._key(server)); }
+  static _register (server) { this.servers.set(this._key(server), server); }
+  static _unregister (server) { this.servers.delete(this._key(server)); }
 
-  static find(opts) { return this.servers.get(this._key(opts)); }
-  static ensure(opts) { return this.find(opts) || new this(opts).start(); }
+  static find (opts) { return this.servers.get(this._key(opts)); }
+  static ensure (opts) { return this.find(opts) || new this(opts).start(); }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  constructor(opts) {
+  constructor (opts) {
     opts = this.constructor.canonicalizeOptions(opts);
     this.hostname = opts.hostname;
     this.port = opts.port;
@@ -57,79 +56,78 @@ export default class LivelyServer {
     this.options = opts;
 
     // state = "not started", "listening", "starting", "closed"
-    this._state = "not started";
+    this._state = 'not started';
     this._requestFn = null;
 
     this.plugins = [];
     if (opts.plugins) this.addPlugins(opts.plugins);
   }
 
-  isListening() { return this._state === "listening"; }
+  isListening () { return this._state === 'listening'; }
 
-  isClosed() { return this._state !== "starting" && this._state !== "listening"; }
+  isClosed () { return this._state !== 'starting' && this._state !== 'listening'; }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // lifetime
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  whenStarted(timeout = 30*1000) {
+  whenStarted (timeout = 30 * 1000) {
     return promise.waitFor(timeout, () => this.isListening()).then(() => this);
   }
 
-  whenClosed(timeout = 30*1000, callback) {
-    if (!callback && typeof timeout === "function") {
+  whenClosed (timeout = 30 * 1000, callback) {
+    if (!callback && typeof timeout === 'function') {
       callback = timeout;
-      timeout = 30*1000;
+      timeout = 30 * 1000;
     }
     return promise.waitFor(timeout, () => this.isClosed()).then(() => {
-      if (typeof callback === "function") callback();
+      if (typeof callback === 'function') callback();
       return true;
     });
-
   }
 
-  start() {
-    if (this._state === "starting") { console.log(`${this} already starting`); return this; }
+  start () {
+    if (this._state === 'starting') { console.log(`${this} already starting`); return this; }
     if (this.isListening()) return this;
 
     this.constructor._register(this);
 
-    this._state = "starting";
+    this._state = 'starting';
 
-    var {debug, hostname, port} = this,
-    server = http.createServer();
+    let { debug, hostname, port } = this;
+    let server = http.createServer();
 
     this.server = server;
 
     this._requestFn = (req, res) => this.handleRequest(req, res);
-    server.on("request", this._requestFn);
+    server.on('request', this._requestFn);
 
     server.listen(port, hostname, () => {
-      this._state = "listening";
+      this._state = 'listening';
       this.debug && console.log(`[lively.server] ${this} listening`);
     });
 
-    server.once("close", () => {
-      this._state = "closed";
+    server.once('close', () => {
+      this._state = 'closed';
       this.debug && console.log(`[lively.server] ${this} closed`);
     });
 
-    return this
+    return this;
   }
 
-  async close(serverState = {}) {
+  async close (serverState = {}) {
     if (this.isClosed()) return this;
 
     debug && console.log(`[lively.server] initialize shutdown of ${this}`);
 
-    var {debug, server} = this;
+    var { debug, server } = this;
     server.close();
-    server.removeListener("request", this._requestFn);
+    server.removeListener('request', this._requestFn);
 
     this.whenClosed(() => this.constructor._unregister(this));
 
     for (let p of this.plugins) {
-      try { typeof p.close === "function" && await p.close(); } catch (e) {
+      try { typeof p.close === 'function' && await p.close(); } catch (e) {
         console.error(`[ ${this}] Error in shutdown of plugin ${p.pluginId}:\n${e.stack}`);
       }
     }
@@ -137,19 +135,18 @@ export default class LivelyServer {
     return this;
   }
 
-
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // http handling
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  handleRequest(req, res) {
-    var handlers = this.plugins.filter(ea => typeof ea.handleRequest === "function");
+  handleRequest (req, res) {
+    let handlers = this.plugins.filter(ea => typeof ea.handleRequest === 'function');
     handlers.reduceRight(
       (next, plugin) => () => {
         try {
       	   plugin.handleRequest(req, res, next);
         } catch (e) {
-      	   var msg = `Error in handleRequest of ${plugin.pluginId}:\n${e.stack}`;
+      	   let msg = `Error in handleRequest of ${plugin.pluginId}:\n${e.stack}`;
       	   console.error(msg);
       	   res.writeHead(500);
       	   res.end(msg);
@@ -157,34 +154,32 @@ export default class LivelyServer {
       }, () => this.defaultHandleRequest(req, res))();
   }
 
-  defaultHandleRequest(req, res) {
+  defaultHandleRequest (req, res) {
     res.writeHead(200);
-    res.end("lively.server");
+    res.end('lively.server');
   }
-
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // plugin helpers
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  findPlugin(id) {
+  findPlugin (id) {
     return this.plugins.find(ea => ea.pluginId === id || ea.constructor.name === id);
   }
 
-  async addPlugin(plugin) { await this.addPlugins([plugin]); return plugin; }
+  async addPlugin (plugin) { await this.addPlugins([plugin]); return plugin; }
 
-  async addPlugins(plugins) {
+  async addPlugins (plugins) {
     if (!plugins.length) return;
 
-    if (!plugins.every(p => p.pluginId))
-      throw new Error("Plugin needs pluginId!");
+    if (!plugins.every(p => p.pluginId)) { throw new Error('Plugin needs pluginId!'); }
 
     // 1. Find plugins that are new
-    var toInstall = plugins.filter(p => !this.plugins.includes(p));
+    let toInstall = plugins.filter(p => !this.plugins.includes(p));
 
     // 2. if plugins with same id are isntalled, remove those
-    var ids = toInstall.map(ea => ea.pluginId),
-       	toRemove = this.plugins.filter(ea => ids.includes(ea.pluginId));
+    let ids = toInstall.map(ea => ea.pluginId);
+       	let toRemove = this.plugins.filter(ea => ids.includes(ea.pluginId));
 
     this.removePlugins(toRemove);
 
@@ -192,81 +187,77 @@ export default class LivelyServer {
     this.plugins = this.orderPlugins([...this.plugins, ...toInstall]);
 
     // 4. ensure that setup callback of plugins gets called
-    var toInstallOrdered = this.plugins.filter(p => toInstall.includes(p));
+    let toInstallOrdered = this.plugins.filter(p => toInstall.includes(p));
     for (let p of toInstallOrdered) {
       try {
-        if (typeof p.setOptions === "function" && this.options.hasOwnProperty(p.pluginId))
-          p.setOptions(this.options[p.pluginId])
-        if (typeof p.setup === "function")
-        	 await promise.timeout(10*1000, Promise.resolve(p.setup(this)));
+        if (typeof p.setOptions === 'function' && this.options.hasOwnProperty(p.pluginId)) { p.setOptions(this.options[p.pluginId]); }
+        if (typeof p.setup === 'function') { await promise.timeout(10 * 1000, Promise.resolve(p.setup(this))); }
       } catch (e) {
-       console.error(`Error in setup of plugin ${p.pluginId}:\n${e.stack}`)
+        console.error(`Error in setup of plugin ${p.pluginId}:\n${e.stack}`);
       }
     }
 
-    this.debug && console.log(`[lively.server] ${this}, installed plugins: ${toInstallOrdered.map(ea => ea.pluginId).join(", ")}`);
+    this.debug && console.log(`[lively.server] ${this}, installed plugins: ${toInstallOrdered.map(ea => ea.pluginId).join(', ')}`);
   }
 
-  removePlugin(plugin) {
+  removePlugin (plugin) {
     this.removePlugins([plugin]);
   }
 
-  removePlugins(pluginsOrIds) {
+  removePlugins (pluginsOrIds) {
     if (!pluginsOrIds.length) return;
 
-    var ids = pluginsOrIds.map(ea => typeof ea === "string" ? ea : ea.pluginId),
-    toRemove = this.plugins.filter(ea => ids.includes(ea.pluginId));
+    let ids = pluginsOrIds.map(ea => typeof ea === 'string' ? ea : ea.pluginId);
+    let toRemove = this.plugins.filter(ea => ids.includes(ea.pluginId));
 
     toRemove.forEach(p => {
-      try { typeof p.close === "function" && p.close(); }
-      catch (e) { console.error(`Error when shutting down plugin ${p.pluginId}:\n${e.stack}`)}
+      try { typeof p.close === 'function' && p.close(); } catch (e) { console.error(`Error when shutting down plugin ${p.pluginId}:\n${e.stack}`); }
     });
 
     this.plugins = arr.withoutAll(this.plugins, toRemove);
 
-    this.debug && console.log(`[${this}] Removed plugins: ${toRemove.map(ea => ea.pluginId).join(", ")}`);
+    this.debug && console.log(`[${this}] Removed plugins: ${toRemove.map(ea => ea.pluginId).join(', ')}`);
   }
 
-  orderPlugins(plugins) {
+  orderPlugins (plugins) {
     // Orders a list of handlers like
     //   {pluginId: "foo", after: ["bar"], before: ["zork"]}
     // so that before / after requirements are fullfilled
 
     // 1. Group handlers by pluginId
-    var byId = arr.groupByKey(plugins, "pluginId");
+    let byId = arr.groupByKey(plugins, 'pluginId');
     // Multiple handlers with same name not allowed!
-    var nonUniqId = byId.toArray().find(ea => ea.length !== 1);
-    if (nonUniqId)
-      throw new Error(`Found non-uniquely named handlers: ${obj.inspect(nonUniqId, {maxDepth: 2})}`)
+    let nonUniqId = byId.toArray().find(ea => ea.length !== 1);
+    if (nonUniqId) { throw new Error(`Found non-uniquely named handlers: ${obj.inspect(nonUniqId, { maxDepth: 2 })}`); }
     byId = byId.mapGroups((id, [plugin]) => plugin);
 
     // 2. convert "before" requirement into "after" and check if all plugins
     // mentioned in after/before are actually there
-    var requirements = byId.mapGroups((id, {before, after}) => {
+    let requirements = byId.mapGroups((id, { before, after }) => {
     	  before = before || [];
     	  after = after || [];
-    	  var missing = before.concat(after).filter(id => !byId[id]);
-    	  if (missing.length)
-    	    throw new Error(`Error in ${this} orderPlugins: Plugin ${id} requires ${missing.join(", ")} but ${missing.length === 1 ? "this plugin" : "those plugins"} cannot be found.`)
-    	  return {before, after}
+    	  let missing = before.concat(after).filter(id => !byId[id]);
+    	  if (missing.length) { throw new Error(`Error in ${this} orderPlugins: Plugin ${id} requires ${missing.join(', ')} but ${missing.length === 1 ? 'this plugin' : 'those plugins'} cannot be found.`); }
+    	  return { before, after };
     	});
 
-    var remaining = obj.values(byId);
-    remaining.forEach(({pluginId, before}) =>
+    let remaining = obj.values(byId);
+    remaining.forEach(({ pluginId, before }) =>
       requirements[pluginId].before.forEach(otherId =>
       	 requirements[otherId].after.push(pluginId)));
 
     // compute order
-    var resolvedGroups = [],
-        resolvedIds = [],
-        lastLength = remaining.length + 1;
+    let resolvedGroups = [];
+    let resolvedIds = [];
+    let lastLength = remaining.length + 1;
 
     while (remaining.length) {
-      if (lastLength === remaining.length)
-        throw new Error("Circular dependencies in handler order, could not resolve handlers "
-			  + remaining.map(ea => ea.pluginId).join(", "))
+      if (lastLength === remaining.length) {
+        throw new Error('Circular dependencies in handler order, could not resolve handlers ' +
+			  remaining.map(ea => ea.pluginId).join(', ')); 
+      }
       lastLength = remaining.length;
-      var resolvedNow = remaining.filter(({pluginId}) => isSubset(requirements[pluginId].after, resolvedIds));
+      let resolvedNow = remaining.filter(({ pluginId }) => isSubset(requirements[pluginId].after, resolvedIds));
 
       resolvedIds.push(...resolvedNow.map(ea => ea.pluginId));
       resolvedGroups.push(resolvedNow);
@@ -277,11 +268,11 @@ export default class LivelyServer {
 
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-    function isSubset(list1, list2) {
+    function isSubset (list1, list2) {
       // are all elements in list1 in list2?
-      for (var i = 0; i < list1.length; i++)
-        if (!list2.includes(list1[i]))
-        	  return false;
+      for (let i = 0; i < list1.length; i++) {
+        if (!list2.includes(list1[i])) { return false; } 
+      }
       return true;
     }
   }
@@ -289,62 +280,61 @@ export default class LivelyServer {
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // susbervers
 
-  async _getSubserverModuleAndInstance(pathToModule) {
+  async _getSubserverModuleAndInstance (pathToModule) {
     let mod = lively.modules.module(pathToModule);
     let exports = await mod.load();
-    if (!exports.default) throw new Error(`Subserver module is expected to have a default export`);
+    if (!exports.default) throw new Error('Subserver module is expected to have a default export');
     let SubserverClass = exports.default;
-    if (typeof SubserverClass !== "function") throw new Error(`Subserver export does not seem to be a class`);    
-    let subserver = new SubserverClass(),
-        id = subserver.pluginId;
+    if (typeof SubserverClass !== 'function') throw new Error('Subserver export does not seem to be a class');    
+    let subserver = new SubserverClass();
+    let id = subserver.pluginId;
     subserver.isSubserver = true;
-    if (typeof id !== "string") throw new Error(`Subserver has no pluginId`);
-    return {module: mod, subserver}
+    if (typeof id !== 'string') throw new Error('Subserver has no pluginId');
+    return { module: mod, subserver };
   }
 
-  async addSubservers(pathToModules) {
+  async addSubservers (pathToModules) {
     let subservers = await Promise.all(pathToModules.map(async ea => {
       try {
-        let {module, subserver} = await this._getSubserverModuleAndInstance(ea);
+        let { module, subserver } = await this._getSubserverModuleAndInstance(ea);
         return subserver;
-      } catch(err) { console.error(`Error starting subserver ${ea}`); }
+      } catch (err) { console.error(`Error starting subserver ${ea}`); }
     }));
     subservers = subservers.filter(Boolean);
     this.addPlugins(subservers);
     return subservers;
   }
 
-  async addSubserver(pathToModule) {
-    let {module, subserver} = await this._getSubserverModuleAndInstance(pathToModule),
-        {pluginId} = subserver.pluginId;
+  async addSubserver (pathToModule) {
+    let { module, subserver } = await this._getSubserverModuleAndInstance(pathToModule);
+    let { pluginId } = subserver.pluginId;
     try {
       await this.addPlugin(subserver);
     } catch (err) { this.removePlugin(pluginId); throw err; }
     return subserver;
   }
 
-  async removeSubserver(pathToModuleOrId) {
-    let pluginId, pathToModule,
-        plugin = this.plugins.find(ea => ea.pluginId === pathToModuleOrId);
+  async removeSubserver (pathToModuleOrId) {
+    let pluginId; let pathToModule;
+    let plugin = this.plugins.find(ea => ea.pluginId === pathToModuleOrId);
 
     if (plugin) {
-      let {package: p, pathInPackage} = plugin.constructor[Symbol.for("lively-module-meta")];
-      pathToModule = (p && p.name ? p.name + "/" : "") + pathInPackage
-    } else pathToModule = pathToModuleOrId
+      let { package: p, pathInPackage } = plugin.constructor[Symbol.for('lively-module-meta')];
+      pathToModule = (p && p.name ? p.name + '/' : '') + pathInPackage;
+    } else pathToModule = pathToModuleOrId;
 
-    if (!lively.modules.isModuleLoaded(pathToModule)) return {removed: false, subserver: null};
-    let {module, subserver} = await this._getSubserverModuleAndInstance(pathToModule);
+    if (!lively.modules.isModuleLoaded(pathToModule)) return { removed: false, subserver: null };
+    let { module, subserver } = await this._getSubserverModuleAndInstance(pathToModule);
     let found = this.findPlugin(subserver.pluginId);
-    if (!found) return {removed: false, subserver: null};
+    if (!found) return { removed: false, subserver: null };
     await this.removePlugin(subserver.pluginId);
-    return {removed: true, subserver};
+    return { removed: true, subserver };
   }
   
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  toString() {
-    var {_state, hostname, port} = this;
+  toString () {
+    let { _state, hostname, port } = this;
     return `LivelyServer(${hostname}:${port} ${_state})`;
   }
-
 }

--- a/lively.server/server.js
+++ b/lively.server/server.js
@@ -264,7 +264,7 @@ export default class LivelyServer {
       remaining = arr.withoutAll(remaining, resolvedNow);
     }
 
-    return arr.flatten(resolvedGroups, 1);
+    return resolvedGroups.flat();
 
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 

--- a/lively.source-transform/capturing.js
+++ b/lively.source-transform/capturing.js
@@ -225,7 +225,7 @@ export function rewriteToRegisterModuleToCaptureSetters (parsed, assignToObj, op
       if (stmt.type !== 'ExpressionStatement' ||
        stmt.expression.type !== 'AssignmentExpression' ||
        stmt.expression.left.type !== 'Identifier' ||
-       arr.include(options.exclude, stmt.expression.left.name)) return stmt;
+       options.exclude.includes(stmt.expression.left.name)) return stmt;
 
       const id = stmt.expression.left;
       const rhs = options.declarationWrapper
@@ -825,7 +825,7 @@ function putFunctionDeclsInFront (parsed, options) {
 function computeDefRanges (parsed, options) {
   const topLevel = topLevelDeclsAndRefs(parsed);
   return chain(topLevel.scope.varDecls)
-    .pluck('declarations').flatten().value()
+    .pluck('declarations').flat().value()
     .concat(topLevel.scope.funcDecls.filter(ea => ea.id))
     .reduce((defs, decl) => {
       if (!defs[decl.id.name]) defs[decl.id.name] = [];


### PR DESCRIPTION
This has been quite a wild ride, but I am optimistic that it has come to an end now. The reasons for these changes being in a PR are:

1. Make it known what changes, since these changes could be described as breaking.
2. Allow to "test drive" these changes for a while, to confirm that everything works as expected.

The changes basically retire a bunch of methods/polyfills for Arrays which are no longer necessary, because in the mean time they have been implemented in all major browser and node for a while. **All places where these were in active use should have be changed with these commits!** I might have missed some places were larger amounts of code are commented out.

The methods that have been removed are:

- from (use Array.from instead)
- detect
- flatten (use flat)
- flatmap (use flatMap)
- delimWith
- each
- all
- any
- collect
- findAll
- inject
- mapAsyncSeries
- mapAsync

and some others that are probably less critical.

I made sure that the chaining provided by `lively.lang` still works for the following methods (by providing stubs in array.js, but never using them directly):

- flat
- filter
- find
- map
- flatMap
- slice.
 
These are all that are currently in use in chains in the system and some more that I thought might be handy to chain. If you can think of more that should be stubbed, let me know!

I ran the tests for this branch and compared with the last test run on main from last night and have fixed all discrepancies.

@merryman I propose that I continue to work with the system in this state some more and if I do not run in problems I'll merge this. What do you think? 