### PR TITLE
Add support for running lively in a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:17-buster
+RUN apt update
+RUN apt install -y \
+    python3-pip \
+    brotli
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt install -y ./google-chrome-stable_current_amd64.deb
+
+ENV CONTAINERIZED=true
+
+RUN pip3 install sultan

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apt install -y \
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN apt install -y ./google-chrome-stable_current_amd64.deb
+RUN apt install -y chromium
 
 ENV CONTAINERIZED=true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:17-buster
+
 RUN apt update
 RUN apt install -y \
     python3-pip \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks
 
 docker-build:
+	# Force permissions again, as newly created files (such as caches) since last build will not have the correct permissions which will break the image build 
+	sudo chmod a+rwx -R * || true
 	# Builds the image our containers are based on, including all dependencies which are not installed via flatn
 	docker build -t lively:latest .
 	# Delete old lively.next container in case we previously had containers on this system

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clear-esm-cache start install hooks
+.PHONY: clear-esm-cache start install hooks docker-build docker-start docker-watch docker-bash docker-stop
 clear-esm-cache:
 	rm -rf esm_cache
 	mkdir esm_cache
@@ -9,3 +9,22 @@ start:
 hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks
 
+docker-build:
+	docker rm lively.next || true
+	docker build -t lively:latest .
+	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next lively:latest ./install.sh
+	docker commit lively.next lively:latest
+	docker rm lively.next || true
+	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next  lively:latest ./start.sh
+
+docker-start:
+	docker start lively.next
+
+docker-watch:
+	docker exec lively.next cat /proc/1/fd/1
+
+docker-bash:
+	docker exec -ti lively.next bash
+
+docker-stop:
+	docker stop lively.next

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,17 @@ hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks
 
 docker-build:
-	docker rm lively.next || true
+	# Builds the image our containers are based on, including all dependencies which are not installed via flatn
 	docker build -t lively:latest .
+	# Delete old lively.next container in case we previously had containers on this system
+	docker rm lively.next || true
+	# Mounts the lively root directory inside of a container and runs the install script, which installs flatns deps
+	# Since we are CONTAINERIZED, the last step of the install script will be running chmod a+rwx on all files in the lively folder
 	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next lively:latest ./install.sh
+	# Convert the changes resulting from the lines above back into the lively image
+	# Not doing this results in problems when running headless sessions inside of the docker containers 
 	docker commit lively.next lively:latest
+	# Build a new lively container which is bound to start.sh which will be used for all future operations
 	docker rm lively.next || true
 	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next  lively:latest ./start.sh
 

--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,16 @@ hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks
 
 docker-build:
-	# Force permissions again, as newly created files (such as caches) since last build will not have the correct permissions which will break the image build 
-	sudo chmod a+rwx -R * || true
 	# Builds the image our containers are based on, including all dependencies which are not installed via flatn
 	docker build -t lively:latest .
 	# Delete old lively.next container in case we previously had containers on this system
 	docker rm lively.next || true
 	# Mounts the lively root directory inside of a container and runs the install script, which installs flatns deps
-	# Since we are CONTAINERIZED, the last step of the install script will be running chmod a+rwx on all files in the lively folder
-	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next lively:latest ./install.sh
-	# Convert the changes resulting from the lines above back into the lively image
-	# Not doing this results in problems when running headless sessions inside of the docker containers 
-	docker commit lively.next lively:latest
-	# Build a new lively container which is bound to start.sh which will be used for all future operations
-	docker rm lively.next || true
-	docker run -p 127.0.0.1:9011:9011 -v $(CURDIR):/lively.next:z -w /lively.next --name lively.next  lively:latest ./start.sh
+	# Using the host user and group id leads to correct permissions on files created inside of the container
+	# Fot not entirely clear reasons it is important that the absolute path to lively is the same on the host and inside of containers
+	# Otherwise, DAV dirLists might produce nonsense 
+	docker run -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --user $(shell id -u):$(shell id -g) lively:latest ./install.sh
+	docker run -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --name lively.next --user $(shell id -u):$(shell id -g)  lively:latest ./start.sh
 
 docker-start:
 	docker start lively.next

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Having `docker`, `git` (,and `make`) installed are the only prerequisites.
 #### Installation Instructions
 
 1. Clone this repository
-2. Run `make docker-build` from the root of this repository. Since docker uses the `root` user inside of containers, we will need to adapt file permissions inside of the lively repository. You will be prompted for `sudo` authentication.
+2. Run `make docker-build` from the root of this repository. 
 
 This process takes a while, ending with a running lively server at [http://localhost:9011](http://localhost:9011).
 When opting for the docker based approach, you can still use `git` as usual from your file system.

--- a/README.md
+++ b/README.md
@@ -4,26 +4,55 @@
     
 This is the repository of the [lively.next project](https://lively-next.org).
 
-## Requirements
+## Setup
 
-*Please note* Currently the Lively server runs best on MacOS, Linux or the Windows Linux subsystem. Getting it going on pure Windows is possible but will require additional tweaks.
+You can install lively.next "natively" on your system or use Docker for your development environment.
+Please note, that these instructions currently are are not recommended for openly deploying lively.next in the web!
 
+### Native Installation
+
+Currently, the MacOS, Linux, and the Linux Subsystem for Windows are supported.
 Make sure you have the following software installed.
 
-1. node.js version 17 or later.
+1. node.js version 17 or later
 2. git
 
-## Installation and Setup
+For some more advanced development operations (bulk testing from the command line), you will also need 
 
-1. Clone this repository and run the `install.sh` script. This will install the necessary dependencies and sync the Lively Partsbin with lively-next.org. Please note that this process will take a few minutes.
+- `sed` or `gsed` on MacOs
+- `ss` or `netstat` on MacOs
+- `perl`
+- `python3` with `sultan` installed
+- `brotli`.
+
+#### Installation Instructions
+
+1. Clone this repository and run the `install.sh` script. This will install the necessary dependencies. Please note, that this process will take a few minutes.
 2. Run the `start.sh` script.
 3. Lively will now be running on your local computer at [http://localhost:9011](http://localhost:9011).
 
-## Docker Image
-A docker image exists for this to try it out in the environment of your choice.
-1. Download [chrome.json](https://raw.githubusercontent.com/LivelyKernel/lively.next/main/chrome.json) and take note of where it is saved
-2. Run the docker command as follows (replacing the seccomp section with the location above where the file was saved): `docker run -d --restart=unless-stopped --init --security-opt seccomp=/path/to/chrome.json --name lively-next -p 127.0.0.1:9011:9011 engagelively/lively-next:alpha4.5.0`
-3. Once completely started, navigate to [http://localhost:9011 ](http://localhost:9011)
+Usually, running `start.sh` will now be enough to get you going again. When changes resulted in changed dependencies, you will need to run `install.sh` again, making it a good first step when troubleshooting.
+
+### Docker Development Environment
+
+For a more platform agnostic variant and less need for local dependencies, you can also use a setup based on docker.
+Having `docker`, `git` (,and `make`) installed are the only prerequisites.
+
+#### Installation Instructions
+
+1. Clone this repository
+2. Run `make docker-build` from the root of this repository.
+
+This process takes a while, ending with a running lively server at [http://localhost:9011](http://localhost:9011).
+When opting for the docker based approach, you can still use `git` as usual from your file system.
+
+Afterwards, you can stop the lively server with `make docker-stop`.
+
+`docker-build` has the same role as `install.sh` above. To just start your server in the future, you can execute `make docker-start`.
+
+Since this will lead to a running server without logging in your shell by default, you can use `make docker-watch` to see the current output of your lively server.
+
+`make docker-bash` will open a shell inside of the container running your server.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Since this will lead to a running server without logging in your shell by defaul
 
 `make docker-bash` will open a shell inside of the container running your server.
 
+### Compatability
+
+On Linux and Windows machines, both of the aforementioned options should usually coexist happily.
+This means, that you can use `start.sh` and `make docker-start` both, independent of the initial means of installation.
+
+**On macs with Apple Silicon, this does not hold.** When switching on such a machine, you will need to remove the `next-node_modules/leveldown` directory and run `install.sh`/`make docker-build` again.
+
 ## Documentation
 
 Some hints and documentation can be found in the [project wiki](https://github.com/LivelyKernel/lively.next/wiki).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Having `docker`, `git` (,and `make`) installed are the only prerequisites.
 #### Installation Instructions
 
 1. Clone this repository
-2. Run `make docker-build` from the root of this repository.
+2. Run `make docker-build` from the root of this repository. Since docker uses the `root` user inside of containers, we will need to adapt file permissions inside of the lively repository. You will be prompted for `sudo` authentication.
 
 This process takes a while, ending with a running lively server at [http://localhost:9011](http://localhost:9011).
 When opting for the docker based approach, you can still use `git` as usual from your file system.

--- a/install.sh
+++ b/install.sh
@@ -13,3 +13,8 @@ mkdir esm_cache
 
 node --no-warnings --experimental-loader $lv_next_dir/flatn/resolver.mjs \
      lively.installer/bin/install.cjs $PWD \
+
+if [ "$CONTAINERIZED" ]; 
+  then
+     chmod a+rwx -R *
+  fi

--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,3 @@ mkdir esm_cache
 
 node --no-warnings --experimental-loader $lv_next_dir/flatn/resolver.mjs \
      lively.installer/bin/install.cjs $PWD \
-
-if [ "$CONTAINERIZED" ]; 
-  then
-     chmod a+rwx -R *
-  fi

--- a/lively.headless/index.js
+++ b/lively.headless/index.js
@@ -52,7 +52,7 @@ export class HeadlessSession {
   async ensureBrowser () {
       const newBrowser = (this.constructor.browser = await puppeteer.launch({
          userDataDir: packagePath + 'chrome-data-dir',
-         ...containerized ? { executablePath: 'google-chrome-stable' } : {},
+         ...containerized ? { executablePath: 'chromium' } : {},
          args: [
           // these are necessary to run headless chrome inside of docker containers
           // be aware, that disabling sandboxing comes with heavy security implications


### PR DESCRIPTION
This has the following benefits:

- It is not longer necessary to have node / other dependencies installed (although docker is needed)
- Should run on Windows without headaches.

Any changes made to source code in the running lively instance are visible in the file-system as usual, so the usual workflows are unaffected.

Running on windows is still slightly annoying/requires the same amount of work as without docker, since docker needs either WSL or HyperV on Windows and usage of lively.next would be equally possible with just WSL.

**I still propose to merge this, for the following reasons:**

1. It allows us to get a "source of truth" environment that can be used to make sure that no environment mess-ups of personal configs are the source of weird behavior when investigating/reporting bugs in lively.
2. We had some problems with different bash versions, GNU packages,... in the past where the available versions between linux/mac were different. Using docker solves this and we can just ship dependencies that we might introduce to other CLI tools in the future.

@merryman We should probably try to get this running on your system before merging. :slightly_smiling_face:  