### PR TITLE
New Options in Search Widget

### DIFF
--- a/lively.morphic/text/search.cp.js
+++ b/lively.morphic/text/search.cp.js
@@ -221,7 +221,7 @@ const SearchWidget = component({
     opacity: 0.5,
     submorphs: [{
       name: 'label',
-      tooltip: 'Match with Regular Expressions',
+      tooltip: 'Match with Regular Expressions.\n Either directly type your regular expression,\n or use JS slash syntax if you want to use RegEx flags.',
       textAndAttributes: Icon.textAttribute('circle-question')
     }]
   }), part(IconButton, {

--- a/lively.morphic/text/search.js
+++ b/lively.morphic/text/search.js
@@ -124,7 +124,8 @@ export class SearchWidgetModel extends ViewModel {
             position: null,
             inProgress: null,
             last: null,
-            caseMode: false
+            caseMode: false,
+            regexMode: false
           };
         }
       },
@@ -132,8 +133,14 @@ export class SearchWidgetModel extends ViewModel {
       input: {
         get () {
           const text = this.ui.searchInput.textString;
-          const reMatch = text.match(/^\/(.*)\/([a-z]*)$/);
-          return reMatch ? new RegExp(reMatch[1], reMatch[2]) : text;
+          if (this.state.regexMode) {
+            const reMatch = text.match(/^\/(.*)\/([a-z]*)$/);
+            if (reMatch) {
+              return RegExp(reMatch[1], reMatch[2]);
+            }
+            return new RegExp(text);
+          }
+          return text;
         },
         set (v) { this.ui.searchInput.textString = String(v); }
       },
@@ -159,6 +166,7 @@ export class SearchWidgetModel extends ViewModel {
             { target: 'replaceButton', signal: 'fire', handler: 'execCommand', converter: () => 'replace and go to next' },
             { target: 'replaceAllButton', signal: 'fire', handler: 'execCommand', converter: () => 'replace all' },
             { target: 'caseModeButton', signal: 'fire', handler: 'toggleCaseMode' },
+            { target: 'regexModeButton', signal: 'fire', handler: 'toggleRegexMode' },
             { signal: 'onBlur', handler: 'onBlur', override: true }
           ];
         }
@@ -183,6 +191,14 @@ export class SearchWidgetModel extends ViewModel {
         }
       }
     ]);
+  }
+
+  toggleRegexMode () {
+    this.state.regexMode = !this.state.regexMode;
+    this.ui.regexModeButton.opacity = this.state.regexMode ? 1 : 0.5;
+
+    this.cleanup();
+    this.search();
   }
 
   toggleCaseMode () {


### PR DESCRIPTION
![Screenshot_20220628_142309](https://user-images.githubusercontent.com/14252419/176179311-d512761e-1034-4daf-9a2b-f42e9fe7ba56.png)


This PR introduces two new buttons into the Search Widget. 

The left one toggles between case-sensitive and case-insensitive search.

The right one can be used to toggle between textual and regex based search. In regex mode, one can either provide a regex literal enclosed in slashes (optionally followed by flags) or the regex as a string. Literal regexes are no longer working as a regex when regex mode is not activated.

Both of these modes are deactivated by default.

**By the way, I am super open about changing the icons for the buttons, any ideas welcome!**
