### PR TITLE
🧰: Improve output of the `blame selection` command to be human readable

### DIFF
--- a/lively.ide/text/code-evaluation-commands.js
+++ b/lively.ide/text/code-evaluation-commands.js
@@ -45,7 +45,10 @@ export const codeEvaluationCommands = [
       baseDir = baseDir.replace('http://localhost:9011/', '').replace('/lively.server', '');
       fileToBlame = fileToBlame.replace('http://localhost:9011/', '').replace('file://', '');
 
-      const command = 'git blame -L ' + rangeStart + ',' + rangeEnd + ' --porcelain --line-porcelain ' + fileToBlame;
+      const command = `git blame --date=short -L ${rangeStart},${rangeEnd} ${fileToBlame} | while read hash others;
+        do
+          echo $(git log -1 --pretty=%s $hash) " -- " $others
+        done`;
 
       let cmd = runCommand(command, { cwd: baseDir });
       await cmd.whenDone();
@@ -73,7 +76,7 @@ export const codeEvaluationCommands = [
       baseDir = baseDir.replace('http://localhost:9011/', '').replace('/lively.server', '');
       fileToBlame = fileToBlame.replace('http://localhost:9011/', '').replace('file://', '');
 
-      const command = 'git blame -L ' + lineNumber + ',' + lineNumber + ' --porcelain ' + fileToBlame;
+      const command = 'git blame --date=short -L ' + lineNumber + ',' + lineNumber + ' --porcelain ' + fileToBlame;
 
       let cmd = runCommand(command, { cwd: baseDir });
       await cmd.whenDone();


### PR DESCRIPTION
Logically, specifying `--porcelain` does not provide the porcelain output, but the one intended for plumbing.
This is now fixed, providing sensible output when blaming multiple lines.

![image](https://user-images.githubusercontent.com/14252419/176875781-82d56518-c973-4e79-be7e-8f8e8be20725.png)
