### PR TITLE
🖌️: Don't use black for Color.transparent

### DIFF
--- a/lively.graphics/color.js
+++ b/lively.graphics/color.js
@@ -226,7 +226,7 @@ export class Color {
       darkGray: Color.rgb(102, 102, 102),
       lightGray: Color.rgb(230, 230, 230),
       veryLightGray: Color.rgb(243, 243, 243),
-      transparent: Color.rgba(0, 0, 0, 0),
+      transparent: Color.rgba(69, 85, 134, 0),
       lively: Color.rgb(245, 124, 0)
     };
   }


### PR DESCRIPTION
Using black there lead to the ColorPicker being in the lower left corner when opening it, which lead to the hue being lost in the internal representation which uses RGB.
Thus, changing the hue in the ColorPicker UI had no observable effect.

Color transparent now uses some kind of blue with a transparent alpha.
This video shows that imo, color animations still work as intended

https://user-images.githubusercontent.com/14252419/176926010-5433d82c-8d99-42a4-9e53-2e8978175d36.mp4

.