### PR TITLE
🧰: Fix failing combination of delete halo and color picker usage

### DIFF
--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -38,8 +38,9 @@ export class FillControlModel extends ViewModel {
     if (prop === 'targetMorph') this.update();
   }
 
+  // fixme (lh 2022-07-04): this makes it so that it is possible to open multiple halos with ctrl-click
   ensureHalo () {
-    $world.showHaloFor(this.targetMorph);
+    if (this.targetMorph.world()) $world.showHaloFor(this.targetMorph);
   }
 
   confirm () {


### PR DESCRIPTION
Previously, when selecting a morph with opened property panel, opening the color picker for fill, closing it and then deleting the morph with its remove halo, an error occured.
This change fixes that.
The removed call changed the fill of the ColorPicker view, which caused more causes via connections. Those were problematic, since the propertie panel was already being cleaned up since the previous target morph was to be deleted.