### PR TITLE
🧰: Reenable highlighting of TODO and FIXME comments

### DIFF
--- a/lively.ide/themes/dark.js
+++ b/lively.ide/themes/dark.js
@@ -34,17 +34,10 @@ class DarkTheme {
   get 'variable-2' () { return { fontColor: '#e06c75' }; }
   get 'variable-3' () { return { fontColor: '#085' }; }
   get 'comment' () { return { fontColor: '#7F848E' }; }
-  get 'todo-comment' () {
+  get 'commentHighlight' () {
     return {
       backgroundColor: '#FFFF00',
       fontColor: '#7F848E'
-    };
-  }
-
-  get 'fixme-comment' () {
-    return {
-      backgroundColor: Color.rgba(255, 76, 76, 0.8),
-      fontColor: Color.white
     };
   }
 

--- a/lively.ide/themes/default.js
+++ b/lively.ide/themes/default.js
@@ -32,16 +32,9 @@ class DefaultTheme {
   get 'variable-2' () { return { fontColor: '#05a' }; }
   get 'variable-3' () { return { fontColor: '#085' }; }
   get 'comment' () { return { fontColor: '#666' }; }
-  get 'todo-comment' () {
+  get 'commentHighlight' () {
     return {
       backgroundColor: '#FFFF00',
-      fontColor: '#666'
-    };
-  }
-
-  get 'fixme-comment' () {
-    return {
-      backgroundColor: Color.rgba(255, 76, 76, 0.53),
       fontColor: '#666'
     };
   }


### PR DESCRIPTION
This solution is improved over the older variant that we had and is taken from here: https://discuss.codemirror.net/t/highlighting-fixme/171/3.
When we update mode.js from a newer CodeMirror version, we need to think of this and reconcile this part manually.