### PR TITLE
🛠️: Install lively before trying to rebuild artifact

### DIFF
--- a/scripts/check-build-status.py
+++ b/scripts/check-build-status.py
@@ -74,6 +74,8 @@ for dependant in need_to_check_deps:
                     # Last hope that we do not need to commit a new build: Rebuilding would not change the bundle!\
                     # Build it!
                     print(f"ℹ️ Checking if rebuilding {dependant} would cause changes...")
+                    print(f"ℹ️ Installing lively...")
+                    install = os.system("./install.sh >/dev/null 2>&1")
                     s.npm(f"--prefix {dependant} run build").run()
                     # Check whether we could commit a changed bundle file.
                     git_status = s.git("status").run().stdout


### PR DESCRIPTION
We need to install lively before checking if the artifact might be unchanged despite file changes, since otherwise the build of the artifact will fail due to missing dependencies. I only tested it locally and there it worked ofc. 

I am a bit unsure if this is a problematic solution, since we depend on the installer here. However, we only run into this case, if the installer has not been modified. This means, that the previous installer version which was commited will be used, and due to our checks is working.
If the premise, that the installer was not modified does not hold, we might fail, but in that case a red check is what we would want anyways.

Thus, I think this is OK but just wanted to check with you...