### PR TITLE
🛠️: Add CI check that lively loads successfully in browser

### DIFF
--- a/.github/workflows/check_world_loading.yml
+++ b/.github/workflows/check_world_loading.yml
@@ -1,0 +1,31 @@
+name: Check if lively boots
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check if lively boots
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17.8.0'
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install lively.next 
+        run:  |
+         chmod a+x ./install.sh
+         ./install.sh
+      - name: Start the lively server
+        run: |
+          chmod a+x ./start.sh
+          ./start.sh > /dev/null 2>&1 &
+          # wait until server is guaranteed to be running
+          sleep 30
+      - name: Run boot check script
+        run: node scripts/check_boot.js

--- a/scripts/check_boot.js
+++ b/scripts/check_boot.js
@@ -1,0 +1,35 @@
+const puppeteer = require('puppeteer');
+
+const aliveTimeout = 300 * 1000;
+const aliveRepeatTimeout = 300;
+let page;
+
+(async () => {
+  const browser = await puppeteer.launch({args: [
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    '--disable-setuid-sandbox',
+    '--no-sandbox',
+  ]});
+  page = await browser.newPage();
+
+  try {
+    console.log('ℹ️ Began Loading lively.');
+    await page.goto('http://localhost:9011/worlds/load?name=__newWorld__&showsUserFlap=false');
+    const startTime = Date.now();
+    while (true) {
+      if (Date.now() - startTime > aliveTimeout) {
+        process.exit(1);
+      }
+      if (await page.evaluate(`$world.name == 'aLivelyWorld'`)) break;
+      await new Promise((resolve) => setTimeout(resolve, aliveRepeatTimeout));
+    };
+    console.log('✅ Lively loaded successfully.');
+    process.exit(0);
+  } catch (err) {
+    console.log(err);
+    console.log('❌ Error loading lively.');
+    process.exit(1);
+  }
+})();
+


### PR DESCRIPTION
This action would currently run upon **pull request approval**.
I chose that since it is a) guaranteed to happen with our current setup and b) should happen exactly **once** (at least currently).
Because this action needs to install lively again (and I do not see a good way of sharing this installation between our different actions atm) it takes a while and burns resources. I decided this should not happen more often than necessary (think of the :polar_bear:)