### PR TITLE
🧰: fix copy and paste of morph

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -13,6 +13,7 @@ import { createMorphSnapshot } from 'lively.morphic/serialization.js';
 import { Color, pt, rect, Rectangle, LinearGradient } from 'lively.graphics';
 import { obj, string, Path as PropertyPath, promise, properties, num, arr } from 'lively.lang';
 import { connect, signal, disconnect, disconnectAll, once } from 'lively.bindings';
+import * as moduleManager from 'lively.modules';
 
 import { showAndSnapToGuides, showAndSnapToResizeGuides, removeSnapToGuidesOf } from './drag-guides.js';
 
@@ -1185,7 +1186,7 @@ class CopyHaloItem extends HaloItem {
     halo.remove(); // we do not want to copy the halo
     try {
       for (const m of modifiedMorphsToCopy) {
-        const snap = await createMorphSnapshot(m, { addPreview: false, testLoad: false });
+        const snap = await createMorphSnapshot(m, { addPreview: false, testLoad: false, moduleManager });
         snap.copyMeta = { offset: m.worldPoint(pt(0, 0)).subPt(origin) };
         snapshots.push(snap);
         html += m.renderPreview();

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -26,6 +26,7 @@ import { loadObjectFromPartsbinFolder, loadPart } from 'lively.morphic/partsbin.
 import { uploadFile } from 'lively.morphic/events/html-drop-handler.js';
 
 import { prompts } from 'lively.components';
+import * as moduleManager from 'lively.modules';
 
 import * as LoadingIndicator from 'lively.components/loading-indicator.cp.js';
 import { Halo, MorphHighlighter, ProportionalLayoutHalo, GridLayoutHalo, FlexLayoutHalo } from 'lively.halos';
@@ -497,7 +498,7 @@ export class LivelyWorld extends World {
         if (!Array.isArray(snapshots)) snapshots = [snapshots];
         li = LoadingIndicator.open('pasting morphs...');
         for (const s of snapshots) {
-          const morph = await loadMorphFromSnapshot(s);
+          const morph = await loadMorphFromSnapshot(s, { moduleManager });
           morph.openInWorld(evt.hand.position);
           if (s.copyMeta && s.copyMeta.offset) {
             const { x, y } = s.copyMeta.offset;
@@ -505,6 +506,7 @@ export class LivelyWorld extends World {
           }
           morphs.push(morph);
         }
+        this.halos().forEach(h => h.remove());
         this.showHaloFor(morphs);
       }
     } catch (e) {


### PR DESCRIPTION
Fixes an issue when copy and pasting a morph via clipboard.