### PR TITLE
🛠️: improve pre-commit hook checking commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -7,8 +7,8 @@ test -n "$(grep -i '^[[:blank:]]*cleanup[[:blank:]]*$' "${1}")" && {
 }
 
 firstLine=$(sed -n '1p' "${1}")
-test -n "$(grep -E '^.*[[:upper:]].*+$' <<< "$firstLine")" && {
-        printf >&2 "❌  Do not use upper case letters in the first line of your commit message.\n"
+test -n "$(grep -E '^.*: [[:upper:]].*+$' <<< "$firstLine")" && {
+        printf >&2 "❌  Do not use upper case letter to start your commit message.\n"
         exit 1
 }
 


### PR DESCRIPTION
The previous version of this was too lazy...
Now, we reject messages like "🛠️: Make a change on whenRendered" but "🛠️: make a change on whenRendered" would be ok.