### PR TITLE
Robust artifact checker

### DIFF
--- a/scripts/check-build-status.py
+++ b/scripts/check-build-status.py
@@ -44,10 +44,14 @@ for dependant in need_to_check_deps:
             if not modified_deps:
                 print(f"✅ Build of {dependant} is up to date!\n")
                 continue
+            print("ℹ️ Collecting commit informations...")
             # Figure out the last commit that changed all modified dependencies
             # https://stackoverflow.com/a/32774290
             commits_of_dep_modification = [
-                s.git(f"rev-list -1 HEAD {file}").run().stdout for file in modified_deps
+                # the `--` is important, as it allows the specification of paths
+                # even if they do no longer exist in the current working tree
+                # see https://stackoverflow.com/a/9604647
+                s.git(f"rev-list -1 HEAD -- {file}").run().stdout for file in modified_deps 
             ]
             commits_of_dep_modification = [
                 commit for arr in commits_of_dep_modification for commit in arr

--- a/scripts/check-build-status.py
+++ b/scripts/check-build-status.py
@@ -63,6 +63,7 @@ for dependant in need_to_check_deps:
                 .run()
                 .stdout[0]
             )
+            installed = False
             for commit in commits_of_dep_modification:
                 # We use `os` instead of `sultan` here, since `sultan` does not allow for failing commands...
                 # This figures out if `commit_of_build` is an ancestor of `commit`
@@ -77,9 +78,11 @@ for dependant in need_to_check_deps:
                 if test == 256:
                     # Last hope that we do not need to commit a new build: Rebuilding would not change the bundle!\
                     # Build it!
-                    print(f"ℹ️ Checking if rebuilding {dependant} would cause changes...")
-                    print(f"ℹ️ Installing lively...")
-                    install = os.system("./install.sh >/dev/null 2>&1")
+                    print(f"ℹ️ Checking if rebuilding {dependant} would cause changes (due to {commit})...")
+                    if not installed:
+                        print("ℹ️ Installing lively...")
+                        os.system("./install.sh >/dev/null 2>&1")
+                        installed = True
                     s.npm(f"--prefix {dependant} run build").run()
                     # Check whether we could commit a changed bundle file.
                     git_status = s.git("status").run().stdout


### PR DESCRIPTION
The problem occurred due to the way we invoked `git rev-list` previously. With just one argument, that can either be a revision or a filename. With no-longer-existing files, git assumes it is a revision, does not find that neither and crashes. `--` separates revisions and filenames and now we are fine, even when files got deleted.