### PR TITLE
👤: prevent server from crashing on test run

### DIFF
--- a/lively.user/server/server.js
+++ b/lively.user/server/server.js
@@ -118,7 +118,7 @@ export default class LivelyAuthServer {
     server.close();
     server.removeListener("request", this._requestFn);
 
-    this.whenClosed(() => this.constructor._unregister(this));
+    this.whenClosed(() => this.constructor._unregister(this)).catch((err) => {});
 
     return this;
   }


### PR DESCRIPTION
Prevents the lively server from crashing when running the `lively.user` tests.