### PR TITLE
👔🧰: fix test runner error handling in subserver

### DIFF
--- a/lively.ide/test-runner.js
+++ b/lively.ide/test-runner.js
@@ -430,7 +430,9 @@ export default class TestRunner extends HTMLMorph {
 
   async runTestsInPackage (packageName) {
     const pkgsConf = await packagesConfig();
-    const wantsServerInterface = pkgsConf.find(pkg => pkg.name === packageName).wantsServerInterface;
+    const pkg = pkgsConf.find(pkg => pkg.name === packageName);
+    if (!pkg) throw new Error('Cannot find package for name: ' + packageName);
+    const wantsServerInterface = pkg.wantsServerInterface;
     this.updateEvalBackendForPackage(wantsServerInterface);
     const testModuleURLs = await findTestModulesInPackage(this.systemInterface, packageName);
     const results = [];

--- a/lively.server/plugins/test-runner.js
+++ b/lively.server/plugins/test-runner.js
@@ -20,7 +20,7 @@ export default class TestRunner {
     JSON.stringify(results)
     `)
     } catch (err) {
-      results = {'error': err}
+      results = JSON.stringify({'error': err.message});
     }
     finally {
       this.headlessSession.dispose()


### PR DESCRIPTION
The test runner now properly channels through the error message in case an error is thrown during the test execution.