### PR TITLE
🧰🎛️: fix window fitting to world bounds on openInWindow()

### DIFF
--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -215,13 +215,22 @@ export default class Window extends Morph {
     wrapper.extent = this.extent;
   }
 
+  ensureNotBeyondBottom () {
+    const world = this.world();
+    if (!world) return;
+    let bounds = this.globalBounds();
+    if (bounds.bottom() > world.visibleBounds().bottom()) {
+      this.resizeBy(pt(0, bounds.bottom() - world.visibleBounds().bottom()).negated());
+    }
+  }
+
   ensureNotOverTheTop () {
     const world = this.world();
     if (!world) return;
-    const bounds = this.globalBounds();
+    let bounds = this.globalBounds();
     world.withTopBarDo(tb => {
-      if (bounds.top() < tb.height) {
-        this.moveBy(pt(0, tb.height - bounds.top()));
+      if (bounds.top() < tb.view.height) {
+        this.moveBy(pt(0, tb.view.height - bounds.top()));
       }
     });
   }

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -132,6 +132,7 @@ export class LivelyWorld extends World {
       targetMorph: morph
     }).openInWorld();
     win.ensureNotOverTheTop();
+    win.ensureNotBeyondBottom();
     return win;
   }
 
@@ -609,7 +610,7 @@ export class LivelyWorld extends World {
   /**
    * Removes the specified `commentToRemove` that was made on `morph`.
    * @param {Morph} morph
-   * @param {CommentData} commentToRemove 
+   * @param {CommentData} commentToRemove
    */
   removeCommentFor (morph, commentToRemove) {
     const commentBrowser = $world.getSubmorphNamed('Comment Browser');


### PR DESCRIPTION
Fixes an issue where windows would overlap the visible window bounds when opened, making certain parts of the window controls inaccessible.
<img width="1259" alt="alignment" src="https://user-images.githubusercontent.com/1296388/190181360-df7ff485-531c-4de3-ab7e-1a7ea849598f.png">
