### PR TITLE
Fix/polygon origin adjustment and master

### DIFF
--- a/lively.ide/styling/color-stops.cp.js
+++ b/lively.ide/styling/color-stops.cp.js
@@ -77,7 +77,6 @@ const ColorCell = component({
   borderWidth: 2,
   clipMode: 'hidden',
   extent: pt(20, 20),
-  position: pt(2, 2),
   submorphs: [
     part(CheckerPattern, { name: 'checker pattern', extent: pt(25.3, 25.3) }),
     {
@@ -102,7 +101,10 @@ const ColorStop = component({
   borderWidth: 1,
   draggable: true,
   extent: pt(24, 28.7),
-  submorphs: [part(ColorCell, { name: 'color cell' })],
+  submorphs: [part(ColorCell, {
+    name: 'color cell',
+    position: pt(2, 2)
+  })],
   vertices: [({ position: pt(15.900091422187336, 24.046753447613565), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(12.388537571189591, 28.736349637681194), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(9.05093221433844, 24.003533970295216), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(1.9148586677257027, 24.02187830995731), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(0, 22.053582048279853), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(0.05972529570411431, 1.4675981539758662), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(1.8326500131114984, 0), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(22.327151653198584, 0.06612585476395774), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(23.96388479762493, 1.7146839330382813), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(23.937061469131315, 22.31992067473174), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(22.024226083928863, 24.061687615284562), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } }), ({ position: pt(15.926023108578342, 24.053142413825835), isSmooth: false, controlPoints: { next: pt(0, 0), previous: pt(0, 0) } })]
 });
 

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1391,14 +1391,16 @@ export class Morph {
   }
 
   adjustOrigin (newOrigin) {
-    const oldOrigin = this.origin;
-    const oldPos = this.globalBounds().topLeft();
-    this.origin = newOrigin;
-    this.submorphs.forEach((m) =>
-      m.position = m.position.subPt(newOrigin.subPt(oldOrigin)));
-    const newPos = this.globalBounds().topLeft();
-    const globalDelta = oldPos.subPt(newPos);
-    this.globalPosition = this.globalPosition.addPt(globalDelta);
+    this.withMetaDo({ metaInteraction: true }, () => {
+      const oldOrigin = this.origin;
+      const oldPos = this.globalBounds().topLeft();
+      this.origin = newOrigin;
+      this.submorphs.forEach((m) =>
+        m.position = m.position.subPt(newOrigin.subPt(oldOrigin)));
+      const newPos = this.globalBounds().topLeft();
+      const globalDelta = oldPos.subPt(newPos);
+      this.globalPosition = this.globalPosition.addPt(globalDelta);
+    });
   }
 
   setBounds (bounds) {


### PR DESCRIPTION
I observed this with the color stops that are used in the color picker. Before they would look like this:
<img width="95" alt="misaligned tile" src="https://user-images.githubusercontent.com/1296388/191278763-00238c34-b48b-4f99-8ce4-66ee69cf291d.png">
This was due to the polygon origin adjustment code always overridding the position prop of the elements in the morph that were actually styled by master components. Turning this origin adjustement into a meta operation, prevents this action from being able to override master component styling.
I believe this is acceptable behavior, since the origin adjustment is more of a convenience that polygon morphs provide out of the box. It is not essential "Polygon" behavior.