### PR TITLE
🎨: fix embedding of morphs in textAndAttributes of component defs

### DIFF
--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -61,13 +61,14 @@ export class ComponentDescriptor {
    * calls that occur in our generatorFunction()
    */
   static extractSpec (generatorFunction) {
-    evaluateAsSpec = true;
+    morph.evaluateAsSpec = evaluateAsSpec = true;
+
     let spec = {};
     try {
       spec = generatorFunction();
       if (!spec.isPolicy) { spec = new PolicyApplicator(spec); } // make part calls return the synthesized spec
     } finally {
-      evaluateAsSpec = false; // always disable this flag after spec initialization is finished
+      morph.evaluateAsSpec = evaluateAsSpec = false; // always disable this flag after spec initialization is finished
     }
     return spec;
   }

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -330,7 +330,8 @@ export class StylePolicy {
       };
 
       const mergeSpecs = (parentSpec, localSpec) => {
-        if (localSpec.textAndAttributes && parentSpec.textAndAttributes) {
+        if (localSpec.textAndAttributes && parentSpec.textAndAttributes &&
+            localSpec.textAndAttributes.length === parentSpec.textAndAttributes.length) {
           localSpec.textAndAttributes = arr.zip(
             localSpec.textAndAttributes,
             parentSpec.textAndAttributes).map(([localAttr, parentAttr]) => {
@@ -340,7 +341,7 @@ export class StylePolicy {
             if (parentAttr?.__isSpec__) {
               return mergeInHierarchy({ ...parentAttr }, localAttr, mergeSpecs, true, handleRemove, handleAdd);
             }
-            return localAttr || parentAttr; // local takes precedence over the parent attr
+            return localAttr;
           });
         }
         // ensure the presence of all nodes

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -340,7 +340,7 @@ export class StylePolicy {
             if (parentAttr?.__isSpec__) {
               return mergeInHierarchy({ ...parentAttr }, localAttr, mergeSpecs, true, handleRemove, handleAdd);
             }
-            return parentAttr;
+            return localAttr || parentAttr; // local takes precedence over the parent attr
           });
         }
         // ensure the presence of all nodes

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -435,7 +435,7 @@ export class StylePolicy {
       if (specOrPolicy.textAndAttributes) {
         specOrPolicy.textAndAttributes = specOrPolicy.textAndAttributes.map(textOrAttr => {
           if (textOrAttr?.__isSpec__) return morph(tree.mapTree(textOrAttr, extractBuildSpecs, node => node.submorphs)); // ensure sub build specs...
-          if (textOrAttr?.isPolicy) return morph(textOrAttr.asBuildSpec());
+          if (textOrAttr?.isPolicy) return textOrAttr.instantiate();
           return textOrAttr;
         });
       }

--- a/lively.morphic/helpers.js
+++ b/lively.morphic/helpers.js
@@ -76,8 +76,8 @@ export function clearStylePropertiesForClassesIn (moduleId) {
   });
 }
 
-function getPropSettings(type) {
-   const klass = (!type || obj.isString(type)) ? getClassForName(type || 'default') : type;
+function getPropSettings (type) {
+  const klass = (!type || obj.isString(type)) ? getClassForName(type || 'default') : type;
   const { package: pkg, pathInPackage } = klass[Symbol.for('lively-module-meta')];
   const { properties: props } = klass[Symbol.for('lively.classes-properties-and-settings')];
   return { props, moduleId: string.joinPath(pkg.name, pathInPackage) };
@@ -99,10 +99,9 @@ export function getStylePropertiesFor (type) {
   return styleProps;
 }
 
-
 export function getDefaultValueFor (type, propName) {
   if (CachedDefaultValues.has(type)) return CachedDefaultValues.get(type)[propName];
-  const {props} = getPropSettings(type);
+  const { props } = getPropSettings(type);
   const defaultValues = {};
   for (let prop in props) {
     if (props[prop].isStyleProp && 'defaultValue' in props[prop]) {
@@ -120,6 +119,8 @@ export function morph (props = {}, opts = { restore: false }) {
     if (typeof props.type === 'object') klass = locateClass(props.type);
     else if (typeof props.type === 'string') { klass = nameToClassMapping[props.type.toLowerCase()] || klass; }
   }
+
+  if (morph.evaluateAsSpec) return { ...props, __isSpec__: true };
 
   return opts.restore
     ? new klass({ [Symbol.for('lively-instance-restorer')]: true }).initFromJSON(props)

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -200,6 +200,7 @@ const c4 = ComponentDescriptor.for(() => component(c3, {
 
 const c5 = ComponentDescriptor.for(() => component({
   type: 'text',
+  name: 'c5',
   submorphs: [
     part(c4, { name: 'lively', fill: Color.lively })
   ],
@@ -208,6 +209,26 @@ const c5 = ComponentDescriptor.for(() => component({
     part(c4, { name: 'holly' }), null,
     'or: ', null,
     morph({ name: 'wood', fill: Color.orange }), null
+  ]
+}));
+
+const c6 = ComponentDescriptor.for(() => component(c5, {
+  name: 'c6',
+  textAndAttributes: [
+    'Something: ', {},
+    {
+      name: 'holly',
+      fill: Color.red,
+      submorphs: [{
+        name: 'foo',
+        submorphs: [{
+          name: 'alice',
+          fill: Color.lively
+        }]
+      }]
+    }, null,
+    'or: ', null,
+    { name: 'wood', fill: Color.blue }, null
   ]
 }));
 
@@ -807,7 +828,7 @@ describe('components', () => {
 
   it('attaches the proper style policies to embedded morphs', () => {
     const m = part(c5);
-    expect(m.get('lively').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
+    expect(m.get('lively').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style policies');
     expect(m.get('holly').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
     expect(c5.stylePolicy.getSubSpecFor('holly')).to.be.instanceof(StylePolicy);
     expect(c5.stylePolicy.getSubSpecFor('wood')).to.be.instanceof(Object);
@@ -831,5 +852,12 @@ describe('components', () => {
     expect(m.get('wood').fill).to.eql(Color.orange);
     expect(m.get('lively').fill).to.eql(Color.lively);
     expect(m.get('holly').fill).to.eql(Color.orange);
+  });
+
+  it('properly merges submorphs embedded in text attributes', () => {
+    const m = part(c6);
+    expect(m.get('wood').fill).to.eql(Color.blue);
+    expect(m.get('holly').fill).to.eql(Color.red);
+    expect(m.get('holly').getSubmorphNamed('alice').fill).to.eql(Color.lively);
   });
 });

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -198,6 +198,16 @@ const c4 = ComponentDescriptor.for(() => component(c3, {
   ]
 }));
 
+const c5 = ComponentDescriptor.for(() => component({
+  type: 'text',
+  textAndAttributes: [
+    'Something: ', {},
+    part(c4, { name: 'holly' }), null,
+    'or: ', null,
+    morph({ name: 'wood', fill: Color.orange }), null
+  ]
+}));
+
 describe('spec based components', () => {
   afterEach(() => {
     detach(e2);
@@ -782,5 +792,13 @@ describe('components', () => {
     expect(instOverridden.master.getSubSpecFor('alice').spec).has.keys('name', 'submorphs', 'master');
     expect(instOverridden.master.getSubSpecFor('alice').spec.master).to.eql(TLB.stylePolicy);
     expect(copied2.master.getSubSpecFor('alice').spec).has.keys('name', 'submorphs', 'master');
+  });
+
+  it('initializes embedded morphs in textAndAttributes correctly', () => {
+    const m = part(c5);
+    const m1 = part(c5);
+    expect(m.get('holly')).not.to.be.null;
+    expect(m1.get('wood')).not.to.be.null;
+    expect(m.get('wood')).not.to.be.null;
   });
 });

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -805,11 +805,31 @@ describe('components', () => {
     expect(m.get('wood')).not.to.be.null;
   });
 
-  it('attaches the proper style polcies to embedded morphs', () => {
+  it('attaches the proper style policies to embedded morphs', () => {
     const m = part(c5);
     expect(m.get('lively').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
     expect(m.get('holly').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
     expect(c5.stylePolicy.getSubSpecFor('holly')).to.be.instanceof(StylePolicy);
     expect(c5.stylePolicy.getSubSpecFor('wood')).to.be.instanceof(Object);
+  });
+
+  it('applies style policies correctly to embedded morphs', () => {
+    const m = morph({
+      type: 'text',
+      textAndAttributes: [
+        'Something: ', {},
+        morph({ name: 'holly', fill: Color.blue }), null,
+        'or: ', null,
+        morph({ name: 'wood', fill: Color.yellow }), null
+      ],
+      submorphs: [
+        { name: 'lively', fill: Color.red }
+      ]
+    });
+    m.master = c5;
+    m.master.applyIfNeeded(true);
+    expect(m.get('wood').fill).to.eql(Color.orange);
+    expect(m.get('lively').fill).to.eql(Color.lively);
+    expect(m.get('holly').fill).to.eql(Color.orange);
   });
 });

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -200,6 +200,9 @@ const c4 = ComponentDescriptor.for(() => component(c3, {
 
 const c5 = ComponentDescriptor.for(() => component({
   type: 'text',
+  submorphs: [
+    part(c4, { name: 'lively', fill: Color.lively })
+  ],
   textAndAttributes: [
     'Something: ', {},
     part(c4, { name: 'holly' }), null,
@@ -800,5 +803,13 @@ describe('components', () => {
     expect(m.get('holly')).not.to.be.null;
     expect(m1.get('wood')).not.to.be.null;
     expect(m.get('wood')).not.to.be.null;
+  });
+
+  it('attaches the proper style polcies to embedded morphs', () => {
+    const m = part(c5);
+    expect(m.get('lively').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
+    expect(m.get('holly').master.parent.parent).equals(c4.stylePolicy, 'properly assigns style polcies');
+    expect(c5.stylePolicy.getSubSpecFor('holly')).to.be.instanceof(StylePolicy);
+    expect(c5.stylePolicy.getSubSpecFor('wood')).to.be.instanceof(Object);
   });
 });

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -398,7 +398,7 @@ export class Text extends Morph {
       textAndAttributes: {
         group: 'text',
         derived: true,
-        after: ['document'],
+        after: ['document', 'submorphs'],
         get () {
           return this.document.textAndAttributes;
         },


### PR DESCRIPTION
StylePolicies were still not able to properly handle embedded morphs within the `textAndAttributes`. This PR will extend the style management to those morphs as well.