### PR TITLE
Fix/terminal window status message

### DIFF
--- a/lively.halos/components/messages.js
+++ b/lively.halos/components/messages.js
@@ -86,9 +86,16 @@ export class StatusMessage extends ViewModel {
 
     view.bringToFront();
 
-    view.width = forMorph.bounds().width;
+    let targetBounds = forMorph.bounds();
+    if (forMorph.isWindow) {
+      targetBounds = targetBounds.insetBy(7.5);
+    }
 
-    if (forMorph.world()) { view.position = forMorph.owner.worldPoint(forMorph.bounds().bottomLeft()); }
+    view.width = targetBounds.width;
+
+    if (forMorph.world()) {
+      view.position = forMorph.owner.worldPoint(targetBounds.bottomLeft());
+    }
 
     const visibleBounds = world.visibleBounds();
     const bounds = view.bounds();

--- a/lively.ide/shell/terminal.js
+++ b/lively.ide/shell/terminal.js
@@ -3,7 +3,7 @@ import { connect } from 'lively.bindings';
 import { arr, obj } from 'lively.lang';
 import { defaultDirectory } from './shell-interface.js';
 import { GridLayout } from 'lively.morphic/layout.js';
-import { Morph, World, config, InputLine } from 'lively.morphic';
+import { Morph, Text, World, config, InputLine } from 'lively.morphic';
 import ShellEditorPlugin from './editor-plugin.js';
 import DiffEditorPlugin from '../diff/editor-plugin.js';
 import EditorPlugin, { guessTextModeName } from '../editor-plugin.js';
@@ -18,6 +18,12 @@ import { DarkButton } from '../js/browser/ui.cp.js';
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // 2016-11-21 FIXME, move this to a common location
+
+class TerminalView extends Text {
+  setStatusMessage (...args) {
+    return this.getWindow().setStatusMessage(...args);
+  }
+}
 
 export default class Terminal extends Morph {
   static open (options = {}) {
@@ -59,7 +65,7 @@ export default class Terminal extends Morph {
         initialize () {
           this.submorphs = [
             {
-              type: 'text',
+              type: TerminalView,
               name: 'output',
               lineWrapping: false,
               textString: '',


### PR DESCRIPTION
This fixes a problem where the status message would always align with the text morph but not with the window.
This caused the input line of the terminal to be overlapped like so:
<img width="300" alt="overlap issue" src="https://user-images.githubusercontent.com/1296388/191461128-c9d74b38-0806-4ca9-a933-b15c6303a76a.png">
This is a suggested and fairly simple solution which requires a custom class for the terminal's text morph in order to instrument the default behavior of `setStatusMessage()`. An alternative would be to just migrate the entire Terminal to a viewModel implementation and work with bindings instead.