### PR TITLE
Fix/native eslint import

### DIFF
--- a/lively.ast/lib/acorn-decorators.cjs
+++ b/lively.ast/lib/acorn-decorators.cjs
@@ -101,6 +101,8 @@ module.exports = function extendParser (Parser) {
         case acorn.tokTypes.star:
         case acorn.tokTypes.bracketL:
         case acorn.tokTypes.name:
+        case acorn.tokTypes._extends:
+        case acorn.tokTypes._break: // some people use this too
         case acorn.tokTypes._with: // this seems to get confused when we use javascript keywords
         case acorn.tokTypes._delete: // dito...
           let node = super.parseClassElement(constructorAllowsSuper);

--- a/lively.ast/lib/mozilla-ast-visitors.js
+++ b/lively.ast/lib/mozilla-ast-visitors.js
@@ -437,6 +437,15 @@ class ScopeVisitor extends Visitor {
     // // key is of types Expression
     // node["key"] = visitor.accept(node["key"], scope, path.concat(["key"]));
     // value is of types FunctionExpression
+
+    if (node.computed) {
+      let curr = node.key;
+      while (curr.type === 'MemberExpression') curr = curr.object;
+      if (curr.type === 'Identifier') {
+        scope.refs.push(node.key);
+      }
+    }
+   
     node.value = visitor.accept(node.value, scope, path.concat(['value']));
     return node;
   }

--- a/lively.ast/lib/visitors.js
+++ b/lively.ast/lib/visitors.js
@@ -1,10 +1,5 @@
 import Visitor from '../generated/estree-visitor.js';
-import _ASTQ from 'astq';
-
-// Importing ASTQ in SystemJS 0.21 on node.js fails is it was not loaded natively before.
-// This causes issues with setups where we can not possible load astq, such as the install bundle.
-// To make these scripts work, we backtrack to import via native require instead.
-let ASTQ = _ASTQ || System._nodeRequire('astq');
+import { queryNodes } from './query.js';
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // simple ast traversing
@@ -106,12 +101,9 @@ class ReplaceVisitor extends Visitor {
   }
 }
 
-const astq = new ASTQ();
-astq.adapter('mozast');
-
 export class QueryReplaceManyVisitor extends ReplaceManyVisitor {
   static run (parsed, query, replacer) {
-    const matchingNodes = astq.query(parsed, query);
+    const matchingNodes = queryNodes(parsed, query);
     const filteredReplacer = (node) => {
       if (matchingNodes.includes(node)) return replacer(node);
       else return node;

--- a/lively.classes/class-to-function-transform.js
+++ b/lively.classes/class-to-function-transform.js
@@ -129,8 +129,7 @@ function replaceDirectSuperCall (node, state, path, options) {
   // like super()
   console.assert(node.type === 'CallExpression');
   console.assert(node.callee.type === 'Super');
-
-  return funcCall(
+  const f = funcCall(
     member(
       funcCall(
         member(options.functionNode, '_get'),
@@ -138,7 +137,8 @@ function replaceDirectSuperCall (node, state, path, options) {
         funcCall(member('Symbol', 'for'), literal('lively-instance-initialize')),
         id('this')),
       'call'),
-    id('this'), ...node.arguments);
+    id('this'), ...node.arguments)
+  return assign(id('_this'), f);
 }
 
 function replaceSuperGetter (node, state, path, options) {

--- a/lively.ide/js/linter.js
+++ b/lively.ide/js/linter.js
@@ -2,16 +2,8 @@
  * Methods for running eslint on JS code as well as the linter configuration used in lively.next.
  */
 
-import { importModuleViaNative } from 'lively.resources';
 import config from 'esm://cache/eslint-config-standard@16.0.3';
-
-let eslint;
-
-(async () => {
-  // fixme: this can become a normal import once we update babel to babel
-  // this might also allow using the custom esm:// cache
-  eslint = await importModuleViaNative('https://jspm.dev/eslint@7.32.0');
-})();
+import eslint from 'esm://cache/eslint@7.32.0';
 
 const rules = {
   // These are all rules from the default ruleset that are fixable
@@ -121,7 +113,7 @@ config.rules = rules;
  */
 
 /**
- * For given source code snippet, returns a linted version of the source code 
+ * For given source code snippet, returns a linted version of the source code
  * together with a set of generated warnings or violations of the linting rules.
  * We can further provide a custom set of rules that overrides the default
  * rule set for the analysis of the given source code.

--- a/lively.lang/function.js
+++ b/lively.lang/function.js
@@ -21,6 +21,18 @@ function False () { /* `function() { return false; }` */ return function () { re
 function True () { /* `function() { return true; }` */ return function () { return true; }; }
 function notYetImplemented () { return function () { throw new Error('Not yet implemented'); }; }
 
+
+/**
+ * Returns wether or not a given function is a "built in".
+ * Built in functions are native to the runtime and their
+ * implementation can not be inspected from Javascript.
+ * @param { function } fn - The function to check for.
+ * @returns { boolean }
+ */
+function isNativeFunction(fn) {
+  return Function.toString.call(fn).indexOf("[native code]") !== -1;
+}
+
 // -=-=-=-=-=-
 // accessing
 // -=-=-=-=-=-
@@ -1175,6 +1187,8 @@ function webkitStack () {
 }
 
 export {
+  isNativeFunction,
+
   Empty, K, Null, False, True, notYetImplemented, withNull,
 
   all, own,

--- a/lively.source-transform/capturing.js
+++ b/lively.source-transform/capturing.js
@@ -302,6 +302,22 @@ function replaceRefs (parsed, options) {
      refsToReplace.includes(node.key) &&
      node.shorthand) { return prop(id(node.key.name), node.value); }
 
+    if (node.type === 'MethodDefinition' && node.computed) {
+      const { key } = node;
+      if (refsToReplace.includes(key)) {
+        if (key.type === 'MemberExpression') {
+          const newNode = { ...node, key: { ...key } };
+          let curr = newNode.key;
+          while(curr.object?.type === 'MemberExpression') {
+            curr.object = { ...curr.object };
+            curr = curr.object;
+          }
+          curr.object = member(options.captureObj, curr.object);
+          return newNode;
+        }
+      }
+    }
+
     // don't replace var refs in expressions such as "export { x }" or "export var x;"
     // We make sure that those var references are defined in insertDeclarationsForExports()
     if (node.type === 'ExportNamedDeclaration') {


### PR DESCRIPTION
This fixes several issues in `lively.classes` class transformation, which prevented `eslint` from being imported via our module system.