### PR TITLE
🧰: disable keyboard navigation in browser columns on window fader

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -616,8 +616,9 @@ export class BrowserModel extends ViewModel {
             { model: 'tabs', signal: 'becameInvisible', handler: 'relayout' },
 
             { signal: 'onWindowActivated', handler: 'allowKeyboardNavigation' },
-            { signal: 'onWindowDeactivated', handler: 'prohibitKeyboardNavigation' }
-          ];
+            { signal: 'onWindowDeactivated', handler: 'prohibitKeyboardNavigation' },
+            { signal: 'toggleFader', handler: 'updateKeyboardNavigation' }
+            ];
         }
       }
     };
@@ -805,6 +806,10 @@ export class BrowserModel extends ViewModel {
 
   updateUnsavedChangeIndicator () {
     this[this.hasUnsavedChanges() ? 'indicateUnsavedChanges' : 'indicateNoUnsavedChanges']();
+  }
+
+  updateKeyboardNavigation () {
+    this.view._faderTriggered ? this.prohibitKeyboardNavigation() : this.allowKeyboardNavigation();
   }
 
   prohibitKeyboardNavigation () {


### PR DESCRIPTION
Previously, it was possible to a) navigate inside of the browser columns while one would have wanted to navigate in the list of the fader and b) the focus was quite often not in the search bar in the fader.