### PR TITLE
🧰: exclude activeSidebars form serialization

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -75,6 +75,7 @@ export class LivelyWorld extends World {
         }
       },
       activeSideBars: {
+        serialize: false,
         initialize () { this.activeSideBars = []; }
       },
       hiddenComponents: {


### PR DESCRIPTION
Fixes an issue where saving a world with open sidebars would prevent the reloaded world from opening those sidebars again.