### PR TITLE
🎨: fix nested components overriding each other

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -740,6 +740,10 @@ export class PolicyApplicator extends StylePolicy {
         const synthesizedSpec = this.synthesizeSubSpec(submorphName, targetMorph, false);
         if (obj.isEmpty(synthesizedSpec)) return;
         if (synthesizedSpec.isPolicy) {
+          if (morphInScope._skipMasterReplacement) {
+            delete morphInScope._skipMasterReplacement;
+            return;
+          }
           morphInScope.setProperty('master', synthesizedSpec); // might be redundant
           synthesizedSpec.targetMorph = morphInScope;
         } else this.applySpecToMorph(morphInScope, synthesizedSpec, isRoot); // this step enforces the master distribution

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -85,6 +85,7 @@ export class Morph {
           if (this.master?.isPolicyApplicator && this.master?.parent[Symbol.for('lively-module-meta')]?.path.length) {
             // how about we only do this with inline policies?
             this.master.spec.master = policy;
+            this._skipMasterReplacement = true;
           } else {
             this.setProperty('master', policy);
             if (policy?.isPolicyApplicator) policy.attach(this); // FIXME: remove that

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -664,6 +664,14 @@ describe('components', () => {
     expect(alice.fill).to.equal(Color.black);
   });
 
+  it('does not drop assigned master for nested components', () => {
+    const instC2 = part(c2);
+    instC2.master = d3;
+    instC2.get('alice').master = c4;
+    instC2.master.applyIfNeeded(true);
+    expect(instC2.get('alice').master.overriddenMaster.parent).eql(c4.stylePolicy);
+  });
+
   it('properly applies overridden masters', async () => {
     const inst4 = part(c4);
     const cp4 = edit(c4);


### PR DESCRIPTION
Fixes an issue reported by https://github.com/engageLively/galyleo-dashboard/issues/95.
Concretely, when assigning new masters to various morphs in a nested submorph hierarchy,
the enclosing masters can end up overriding the newly assigned masters, leading to
unexpected behavior.