### PR TITLE
Fix/scene graph drop

### DIFF
--- a/lively.components/inputs.cp.js
+++ b/lively.components/inputs.cp.js
@@ -92,7 +92,7 @@ const SearchField = component({
   }, {
     type: Label,
     name: 'placeholder icon',
-    autofit: false,
+    autofit: true,
     fontColor: Color.rgb(204, 204, 204),
     fontSize: 14,
     nativeCursor: 'pointer',

--- a/lively.components/inputs.js
+++ b/lively.components/inputs.js
@@ -110,7 +110,7 @@ export class SearchFieldModel extends ViewModel {
             if (this.filterFunction === this.fuzzyFilterFunction) { this.filterFunction = this.defaultFilterFunction; }
           } else {
             if (!this.sortFunction) this.sortFunction = this.fuzzySortFunction;
-            if (this.filterFunction == this.defaultFilterFunction) { this.filterFunction = this.fuzzyFilterFunction; }
+            if (this.filterFunction === this.defaultFilterFunction) { this.filterFunction = this.fuzzyFilterFunction; }
           }
         }
       },
@@ -222,7 +222,7 @@ export class SearchFieldModel extends ViewModel {
   clearInput () {
     this.input = '';
     signal(this, 'searchInput', this.parseInput());
-    this.onBlur();
+    this.onInputBlur();
   }
 
   matches (string) {
@@ -232,7 +232,6 @@ export class SearchFieldModel extends ViewModel {
 
   onInputChange (change) {
     const inputChange = change.selector === 'replace';
-    const validInput = this.view.isFocused() && this.input;
     if (this.ui.placeholderIcon) { this.ui.placeholderIcon.visible = !!this.input; }
     if (this.input.includes('\n')) {
       this.input = this.input.replace('\n', '');

--- a/lively.components/tree.js
+++ b/lively.components/tree.js
@@ -472,7 +472,7 @@ export class Tree extends Text {
         ? this.uncollapse(clickedNode)
         : this.collapse(clickedNode);
     } else {
-      if (this.selectedIndex != row + 1) { this.selectedIndex = row + 1; }
+      if (this.selectedIndex != row + 1) { this.selectedIndex = row + 1; } else signal(this, 'reselectedCurrentSelection', this.selectedNode);
     }
     // check for defined onMouseDown in attributes
     let { onMouseDown } = this.textAttributeAt({ row, column }) || {};

--- a/lively.halos/drag-guides.js
+++ b/lively.halos/drag-guides.js
@@ -226,7 +226,7 @@ function findAlignedMorphs (refMorph, submorphs, eps = 15, distCutoff = Infinity
  * @param { number } [maxDist=100] - The maximum distance of morphs to be considered guide worthy.
  */
 export function showAndSnapToGuides (target, showGuides = true, snap = true, eps = 10, maxDist = 100) {
-  if (!showGuides && !snap) return;
+  if ((!showGuides && !snap) || !target.owner) return;
 
   let owner = target.owner;
   let world = owner.world();
@@ -657,7 +657,7 @@ export function showAndSnapToResizeGuides (
       else { guide = morph(guideSpecs[i]); dragGuides.push(guide); }
       if (!guide.owner) world.addMorph(guide);
     }
-    
+
     dragGuides.slice(i).forEach(ea => ea.remove());
 
     fun.debounceNamed(target.id + '-drag-guides-cleanup', 1300, () => {

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -663,7 +663,7 @@ class GrabHaloItem extends HaloItem {
     MorphHighlighter.removeHighlighters(halo);
     halo.target.undoStop('grab-halo');
     this.opacity = 1;
-    if (halo.target.owner.layout) {
+    if (halo.target.owner?.layout) {
       halo.opacity = 0; // hide the glitch
       halo.target.whenRendered().then(() => {
         halo.alignWithTarget();

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -733,6 +733,7 @@ class DragHaloItem extends HaloItem {
   }
 
   update (delta, grid = false, snapToGuides = false) {
+    if (!this.actualPos) return;
     let newPos = this.actualPos.addPt(this.targetTransform.transformDirection(delta));
     this.actualPos = newPos;
     if (grid) {

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -193,6 +193,11 @@ export class NewSceneGraphTree extends SceneGraphTree {
     });
   }
 
+  showDropPreviewFor (aMorph) {
+    super.showDropPreviewFor(aMorph);
+    this.removeMarker('hovered node');
+  }
+
   highlightLineAtCursor (evt, style) {
     const pos = this.textPositionFromPoint(evt.positionIn(this));
     this.removeMarker('hovered node');
@@ -411,9 +416,8 @@ export class MorphNodeModel extends ViewModel {
   }
 
   onDragOutside () {
-    // if (this._draggedOutside) return;
-    // this._draggedOutside = true;
     if (!this.queue) {
+      const { tree } = this;
       this.queue = fun.createQueue('container-hover-queue', async (self, thenDo) => {
         const {
           opacity: originalOpacity,
@@ -426,6 +430,8 @@ export class MorphNodeModel extends ViewModel {
         self.target._data = self._data;
         self.remove();
         self.target.position = pt(0, 0);
+        tree.treeData.remove(this.tree._previewNode);
+        tree.update(true);
         await self.target.animate({
           opacity: originalOpacity,
           scale: originalScale,

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -25,6 +25,9 @@ export class MorphPanelModel extends ViewModel {
               target: 'scene graph', signal: 'selectedNode', handler: 'showHaloFor'
             },
             {
+              target: 'scene graph', signal: 'reselectedCurrentSelection', handler: 'showHaloFor'
+            },
+            {
               model: 'search field', signal: 'searchInput', handler: 'filterMorphs'
             },
             {

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -436,8 +436,10 @@ export class MorphNodeModel extends ViewModel {
     } else {
       this.target.addMorph(child.target);
     }
-    if (child._data.globalTargetPosition) {
-      child.target.position = this.target.localize(child._data.globalTargetPosition);
+    if (child._data.globalTargetPosition) child.target.position = this.target.localize(child._data.globalTargetPosition);
+    else {
+      child.target.center = $world.center;
+      child.target.show();
     }
   }
 

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -271,11 +271,9 @@ export class MorphNodeModel extends ViewModel {
             { signal: 'onContextMenu', handler: 'onContextMenu' },
             { signal: 'onBeingDroppedOn', handler: 'onBeingDroppedOn', override: true },
             { signal: 'wantsToBeDroppedOn', handler: 'wantsToBeDroppedOn', override: true },
-            { signal: 'onDoubleMouseDown', handler: 'startRenaming' },
             { signal: 'onGrab', handler: 'onGrab', override: true },
             { signal: 'onHoverIn', handler: 'showControls' },
             { signal: 'onHoverOut', handler: 'hideControls' },
-            { target: 'name input', signal: 'onBlur', handler: 'finishRenaming' },
             { target: 'visibility icon', signal: 'onMouseDown', handler: 'toggleVisibility' }
           ];
         }
@@ -301,21 +299,6 @@ export class MorphNodeModel extends ViewModel {
 
   hideControls () {
     this.ui.visibilityIcon.visible = !this.target.visible;
-  }
-
-  startRenaming () {
-    const { nameLabel, nameInput } = this.ui;
-    nameLabel.visible = false;
-    nameInput.visible = true;
-    nameInput.focus();
-  }
-
-  finishRenaming () {
-    const { nameLabel, nameInput } = this.ui;
-    nameLabel.visible = true;
-    nameInput.visible = false;
-    this.target.name = nameInput.textString;
-    this.refresh();
   }
 
   async refresh () {

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -479,7 +479,7 @@ export class MorphNodeModel extends ViewModel {
     if (recipient.isTree) {
       recipient.insertAtPlaceholder(this.view).then(after);
     } else if (recipient.isContainer) {
-      recipient.insertAsChild(this).then(after);
+      recipient.insertAsChild(this.view).then(after);
     } else {
       after();
     }

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -443,7 +443,7 @@ export class MorphNodeModel extends ViewModel {
       child.target.globalPosition = posBackup;
     }
     if (child._data.globalTargetPosition) child.target.position = this.target.localize(child._data.globalTargetPosition);
-    else {
+    else if (this.target.isWorld) {
       child.target.center = $world.center;
       child.target.show();
     }

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -432,12 +432,15 @@ export class MorphNodeModel extends ViewModel {
   onChildAdded (child) {
     const nextIndex = this.node.children.indexOf(child.node || child._data) + 1;
     const neighbor = this.node.children[nextIndex];
+    const posBackup = child.target.position;
     child.target.remove();
     if (neighbor) {
       const actualIndex = this.target.submorphs.indexOf(neighbor.container.target);
       this.target.addMorphAt(child.target, actualIndex);
+      child.target.globalPosition = posBackup;
     } else {
       this.target.addMorph(child.target);
+      child.target.globalPosition = posBackup;
     }
     if (child._data.globalTargetPosition) child.target.position = this.target.localize(child._data.globalTargetPosition);
     else {

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -389,7 +389,7 @@ export class TopBarModel extends ViewModel {
   handleShapeCreation (evt) {
     if (this._customDrag) {
       this._customDrag = false;
-      this.world().halos()[0].onDragEnd();
+      this.world().halos()[0]?.onDragEnd();
     }
 
     const target = this.primaryTarget || this.world();

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1141,6 +1141,11 @@ export class LivelyWorld extends World {
     }]);
 
     items.push(['Remove Morph', () => self.abandon(true)]);
+    items.push(['Rename Morph', async () => {
+      const newName = await $world.prompt('Enter new Name for Morph', { input: self.name });
+      if (!newName) return;
+      self.name = newName;
+    }]);
     items.push(['Open Inspector', () => self.inspect()]);
 
     items.push({ isDivider: true });

--- a/lively.morphic/world.js
+++ b/lively.morphic/world.js
@@ -426,6 +426,7 @@ export class Hand extends Morph {
       morph.reactsToPointer = false;
       morph.dropShadow = true;
       this.addMorph(morph);
+      this.bringToFront();
     });
     signal(this, 'grab', morph);
   }


### PR DESCRIPTION
Fixes a bunch of issues:

- thrown errors on drag-and-drop out of or inside of the scene graph
- do not put morphs dragged into the scene graph at 0,0 but at the center of the world
- keep morphs global position whey they are made submorphs of another morph via sidebar
- when clicking a node in the sidebar, always show the halo for the clicked morph.
