### PR TITLE
🧰: correctly reuse browser windows that opened from code search

### DIFF
--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -1171,6 +1171,7 @@ const commands = [
       if (browser && browser.isBrowser) {
         if (browser.associatedSearchPanel) {
           li.remove();
+          browser.associatedSearchPanel.browser = browser;
           return browser.associatedSearchPanel.getWindow().activate();
         }
       } else browser = null;


### PR DESCRIPTION
Previously, opening a code search, searching, double-clicking a result, clicking the search icon in the opened browser and again double-clicking a result would open two browser windows.

This is now fixed and thus consistent with the way the code search behaves when opened directly from a browser window.