### PR TITLE
Fix/dynamic property reset

### DIFF
--- a/lively.ide/studio/controls/body.cp.js
+++ b/lively.ide/studio/controls/body.cp.js
@@ -202,7 +202,7 @@ export class DynamicPropertyModel extends ViewModel {
       bindings: {
         get () {
           return [
-            { model: 'effect selector', signal: 'selection', handler: 'selectProperty' },
+            { model: 'effect selector', signal: 'selection', handler: 'selectProperty', converter: () => true },
             { target: 'open popup', signal: 'onMouseDown', handler: 'togglePopup' },
             { target: 'remove', signal: 'onMouseDown', handler: 'remove' }];
         }
@@ -213,11 +213,11 @@ export class DynamicPropertyModel extends ViewModel {
   /**
    * Programatically sets the selected property of this dynamic property.
    */
-  choose (prop, reset = true) {
+  choose (prop, resetValue = true) {
     noUpdate(() => {
       this.ui.effectSelector.selection = prop;
     });
-    this.selectProperty(reset);
+    this.selectProperty(resetValue);
   }
 
   /**
@@ -232,9 +232,14 @@ export class DynamicPropertyModel extends ViewModel {
    * Sets the selected property based on the selection in the UI
    * controlled by the user.
    */
-  selectProperty (reset) {
-    if (this.selectedProp && this.selectedProp !== this.ui.effectSelector.selection && reset) { this.resetToDefaultValue(); }
-    this.selectedProp = this.ui.effectSelector.selection;
+  selectProperty (resetValue) {
+    const { effectSelector } = this.ui;
+    if (resetValue &&
+        this.selectedProp &&
+        this.selectedProp !== effectSelector.selection) {
+      this.resetToDefaultValue(); // only when we do that interactively
+    }
+    this.selectedProp = effectSelector.selection;
   }
 
   /**

--- a/lively.ide/studio/controls/body.cp.js
+++ b/lively.ide/studio/controls/body.cp.js
@@ -140,7 +140,7 @@ export class BodyControlModel extends PropertySectionModel {
   activate () {
     this.view.layout = this.view.layout.with({ padding: rect(0, 10, 0, 10) });
     this.view.master = this.activeSectionComponent; // eslint-disable-line no-use-before-define
-    this.addDynamicProperty(false, false);
+    this.addDynamicProperty(null, false);
   }
 
   /**

--- a/lively.ide/studio/controls/body.cp.js
+++ b/lively.ide/studio/controls/body.cp.js
@@ -1,7 +1,7 @@
 import { TilingLayout, component, ViewModel, part } from 'lively.morphic';
 import { Color, rect, pt } from 'lively.graphics';
 import { obj, arr } from 'lively.lang';
-import { once, connect } from 'lively.bindings';
+import { once, noUpdate, connect } from 'lively.bindings';
 
 import { ShadowPopup, OpacityPopup, FlipPopup, TiltPopup, CursorPopup, BlurPopup, InsetShadowPopup } from './popups.cp.js';
 import { PropertySection, PropertySectionInactive, PropertySectionModel } from './section.cp.js';
@@ -122,12 +122,9 @@ export class BodyControlModel extends PropertySectionModel {
     const { targetMorph, propConfig } = this;
     const control = this.view.addMorph(part(this.dynamicPropertyComponent, { viewModel: { targetMorph, propConfig } }));
     this.view.layout.setResizePolicyFor(control, { height: 'fixed', width: 'fill' });
+    if (!selectedProp) selectedProp = this.availableItems[0];
+    control.choose(selectedProp, false);
     control.refreshItems(this.availableItems);
-    if (selectedProp) control.choose(selectedProp);
-    else {
-      control.chooseDefault();
-      if (refresh) this.refreshItemLists();
-    }
     if (this.availableItems.length === 0) {
       this.disableAddEffectButton();
     }
@@ -216,9 +213,11 @@ export class DynamicPropertyModel extends ViewModel {
   /**
    * Programatically sets the selected property of this dynamic property.
    */
-  choose (prop) {
-    this.ui.effectSelector.selection = prop;
-    this.selectProperty();
+  choose (prop, reset = true) {
+    noUpdate(() => {
+      this.ui.effectSelector.selection = prop;
+    });
+    this.selectProperty(reset);
   }
 
   /**
@@ -233,8 +232,8 @@ export class DynamicPropertyModel extends ViewModel {
    * Sets the selected property based on the selection in the UI
    * controlled by the user.
    */
-  selectProperty () {
-    if (this.selectedProp && this.selectedProp !== this.ui.effectSelector.selection) { this.resetToDefaultValue(); }
+  selectProperty (reset) {
+    if (this.selectedProp && this.selectedProp !== this.ui.effectSelector.selection && reset) { this.resetToDefaultValue(); }
     this.selectedProp = this.ui.effectSelector.selection;
   }
 


### PR DESCRIPTION
Fixes accidental resets of values that are caused when we add/remove dynamic properties in the properties panel. E.g. Try to add an opacity effect and then an additional drop shadow effect. The opacity will magically reset to 1, although that was not intended.