### PR TITLE
🎛️: attach Popup style classes to lists open in world

### DIFF
--- a/lively.components/list.js
+++ b/lively.components/list.js
@@ -1976,6 +1976,7 @@ export class DropDownListModel extends ButtonModel {
         list.epiMorph = true;
         list.hasFixedPosition = true;
         list.setTransform(view.getGlobalTransform());
+        list.styleClasses = ['Popups'];
         bounds = view.globalBounds();
       } else {
         bounds = view.innerBounds();


### PR DESCRIPTION
A small adjustment to #524. Dropdowns that are part of a popup now also need to install the Popup style class on the lists since those are opened in the world as well. If that is not done, the Popup overlaps the lists, making them inaccessible (see the color picker for instance).