### PR TITLE
🎨: do not fail when binding target is removed from component

### DIFF
--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -358,7 +358,7 @@ export class ViewModel {
           updater
         });
       } catch (err) {
-        console.warn('Failed to reify biniding: ', target, model, signal, handler);
+        if (System.debug) console.warn('Failed to reify binding: ', target, model, signal, handler);
       }
     }
   }


### PR DESCRIPTION
This is an interesting problem that I ran into. I am very positive that we need to find a nice solution to the underlying problem - if this solution is, it I am not so sure about. Thus, this is a RFC as well as a PR :D

**What is the underlying problem to solve**: 

Generally, one great thing about component systems where view and behavior are separated (besides all the non-coder boogaloo :slightly_smiling_face:) is that they allow for great reuse of code, especially on the model side, i.e., I can build several different front ends that serve similar purposes in different contexts and just attach the same model.

Concretely, I stumbled upon this problem when building a kind of "rich text formatting halo", that should provide a subset of the functionality of the text controls currently contained in the sidebar. Therefore, all functionality is already implemented in the text control model, so I just threw together the UI elements, and as long as one uses the same names as in the original component, one can reuse the model, which is great. However, removing/not including an element which is part of bindings in the `ViewModel`, will lead to an error when the bindings get reified.

I think there should be the possibility to not have this error occurring. 