### PR TITLE
Fix inspector widgets

### DIFF
--- a/lively.components/menus.js
+++ b/lively.components/menus.js
@@ -228,6 +228,10 @@ export class Menu extends Morph {
     super.onChange(change);
   }
 
+  close () {
+    this.remove();
+  }
+
   async remove () {
     await this.animate({ opacity: 0, duration: 300 });
     if (!this._waitingForFinish) this.completeFinish();

--- a/lively.ide/js/inspector/context.js
+++ b/lively.ide/js/inspector/context.js
@@ -562,7 +562,6 @@ class PropertyNode extends InspectionNode {
 
     if (!this.isInternalProperty && !spec.readOnly) {
       connect(w, 'propertyValue', this, 'refreshProperty', { updater: ($upd, val) => $upd(val, true) });
-      connect(w, 'openWidget', this.root, 'onWidgetOpened', { converter: widget => ({ widget, node: this.sourceObj }) });
     }
 
     return w;

--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -377,10 +377,12 @@ export class PropertyControl extends DraggableTreeLabel {
   }
 
   static renderRectangleControl (args) {
-    const { value, keyString, valueString, target, node } = args;
+    const { keyString, valueString, target, node, tree } = args;
+    const inspector = tree.owner.viewModel;
     const handler = async (evt) => {
       // fixme: add rectangle popup!
       const editor = part(PaddingPopup, { hasFixedPosition: true });
+      inspector.openWidget = editor;
       editor.viewModel.startPadding(target[keyString]);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
       connect(editor.viewModel, 'paddingChanged', (padding) => {
@@ -409,7 +411,8 @@ export class PropertyControl extends DraggableTreeLabel {
   }
 
   static renderNumberControl (args) {
-    const { value, spec, keyString, valueString, fastRender, node, target, tree } = args;
+    const { value, spec, keyString, node, target, tree } = args;
+    const inspector = tree.owner.viewModel;
     const widgetState = {};
     if ('max' in spec && 'min' in spec &&
         spec.min !== -Infinity && spec.max !== Infinity) {
@@ -435,6 +438,7 @@ export class PropertyControl extends DraggableTreeLabel {
         baseFactor: widgetState.baseFactor,
         floatingPoint: widgetState.floatingPoint
       }));
+      inspector.openWidget = editor;
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
       connect(editor.viewModel, 'value', (num) => {
         target[keyString] = num;
@@ -453,10 +457,12 @@ export class PropertyControl extends DraggableTreeLabel {
   }
 
   static renderShadowControl (args) {
-    const { keyString, valueString, value, target, node } = args;
+    const { keyString, value, target, node, tree } = args;
+    const inspector = tree.owner.viewModel;
     const handler = async (evt) => {
       // if already open, return
       const editor = part(ShadowPopup, { hasFixedPosition: true });
+      inspector.openWidget = editor;
       editor.viewModel.shadowValue = target[keyString];
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
       connect(editor.viewModel, 'value', (shadowValue) => {
@@ -471,10 +477,12 @@ export class PropertyControl extends DraggableTreeLabel {
   }
 
   static renderPointControl (args) {
-    let propertyControl; const { keyString, valueString, value, fontColor, target, node } = args;
+    const { keyString, value, target, node, tree } = args;
+    const inspector = tree.owner.viewModel;
     const numberColor = valueWidgets.NumberWidget.properties.fontColor.defaultValue;
     const handler = async (evt) => {
       const editor = part(PositionPopupLight, { hasFixedPosition: true });
+      inspector.openWidget = editor;
       editor.setPoint(target[keyString]);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
       connect(editor.viewModel, 'value', (pointValue) => {
@@ -497,7 +505,7 @@ export class PropertyControl extends DraggableTreeLabel {
       ...this.renderGrabbableKey(args),
       ` ${value ? valueString : 'No Layout'}`, {
         onMouseDown: (evt) => {
-
+          // TODO: add layout popup?!
         }
       }];
   }
@@ -505,12 +513,14 @@ export class PropertyControl extends DraggableTreeLabel {
   static renderColorControl (args) {
     let propertyControl; const {
       node, gradientEnabled, fastRender,
-      valueString, keyString, value, target
+      valueString, keyString, value, target, tree
     } = args;
+    const inspector = tree.owner;
     const handler = async (evt) => {
       const editor = part(ColorPicker, {
         hasFixedPosition: true
       });
+      inspector.openWidget = editor;
       editor.solidOnly = !gradientEnabled;
       editor.focusOnMorph(target, value);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
@@ -626,7 +636,7 @@ export class Inspector extends ViewModel {
 
       expose: {
         get () {
-          return ['isInspector', 'onWindowClose', 'commands', 'keybindings'];
+          return ['isInspector', 'onWindowClose', 'commands', 'keybindings', 'openWidget'];
         }
       },
 
@@ -882,6 +892,7 @@ export class Inspector extends ViewModel {
 
   closeOpenWidget () {
     this.openWidget.close();
+    this.openWidget = null;
   }
 
   onWidgetOpened ({ widget }) {

--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -659,6 +659,13 @@ export class Inspector extends ViewModel {
         get () { return inspectorCommands; }
       },
 
+      openWidget: {
+        set (widget) {
+          this.openWidget?.close();
+          this.setProperty('openWidget', widget);
+        }
+      },
+
       bindings: {
         get () {
           return [

--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -378,7 +378,7 @@ export class PropertyControl extends DraggableTreeLabel {
 
   static renderRectangleControl (args) {
     const { keyString, valueString, target, node, tree } = args;
-    const inspector = tree.owner.viewModel;
+    const inspector = tree.owner;
     const handler = async (evt) => {
       // fixme: add rectangle popup!
       const editor = part(PaddingPopup, { hasFixedPosition: true });
@@ -412,7 +412,7 @@ export class PropertyControl extends DraggableTreeLabel {
 
   static renderNumberControl (args) {
     const { value, spec, keyString, node, target, tree } = args;
-    const inspector = tree.owner.viewModel;
+    const inspector = tree.owner;
     const widgetState = {};
     if ('max' in spec && 'min' in spec &&
         spec.min !== -Infinity && spec.max !== Infinity) {
@@ -458,7 +458,7 @@ export class PropertyControl extends DraggableTreeLabel {
 
   static renderShadowControl (args) {
     const { keyString, value, target, node, tree } = args;
-    const inspector = tree.owner.viewModel;
+    const inspector = tree.owner;
     const handler = async (evt) => {
       // if already open, return
       const editor = part(ShadowPopup, { hasFixedPosition: true });
@@ -478,7 +478,7 @@ export class PropertyControl extends DraggableTreeLabel {
 
   static renderPointControl (args) {
     const { keyString, value, target, node, tree } = args;
-    const inspector = tree.owner.viewModel;
+    const inspector = tree.owner;
     const numberColor = valueWidgets.NumberWidget.properties.fontColor.defaultValue;
     const handler = async (evt) => {
       const editor = part(PositionPopupLight, { hasFixedPosition: true });

--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -356,6 +356,7 @@ export class PropertyControl extends DraggableTreeLabel {
           node.rerender();
         }
       })));
+      tree.owner.openWidget = menu;
     };
     return [
       ...this.renderGrabbableKey(args),

--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -670,7 +670,7 @@ export class Inspector extends ViewModel {
         get () {
           return [
             { target: 'target picker', signal: 'onMouseUp', handler: 'selectTarget', override: false },
-            { target: 'property tree', signal: 'onScroll', handler: 'repositionOpenWidget', override: false },
+            { target: 'property tree', signal: 'onScroll', handler: 'closeOpenWidget' },
             { target: 'resizer', signal: 'onDrag', handler: 'adjustProportions', override: false },
             { target: 'terminal toggler', signal: 'onMouseDown', handler: 'toggleCodeEditor', override: false },
             { model: 'unknowns', signal: 'trigger', handler: 'filterProperties', override: false },
@@ -866,6 +866,7 @@ export class Inspector extends ViewModel {
   }
 
   async selectTarget () {
+    this.closeOpenWidget();
     let newTarget;
     if (this.view.env.eventDispatcher.isKeyPressed('Shift')) {
       [newTarget] = await $world.execCommand('select morph', { justReturn: true });
@@ -895,7 +896,7 @@ export class Inspector extends ViewModel {
   }
 
   closeOpenWidget () {
-    this.openWidget.close();
+    this.openWidget?.close();
     this.openWidget = null;
   }
 


### PR DESCRIPTION
This resolves some minor UX problems that occured presumably since we switched to the new PopUp Widgets.

Namely, now:

- only one widget can be open at any time,
- scrolling or switching the inspectors target will close any open widgets,
- closing the window of the inspector will close any open widgets.
