### PR TITLE
🎛️: align scrubbed value on drag end

### DIFF
--- a/lively.components/widgets.js
+++ b/lively.components/widgets.js
@@ -417,7 +417,7 @@ export class ValueScrubber extends Text {
 
   onDragEnd (evt) {
     const { offset, scale } = this.getScaleAndOffset(evt);
-    this.value = this.getCurrentValue(offset, scale);
+    this.scrubbedValue = this.value = this.getCurrentValue(offset, scale);
     this.factorLabel.softRemove();
     evt.hand.extent = pt(1, 1);
     evt.hand.reactsToPointer = false;


### PR DESCRIPTION
Fixes a problem that I overlooked previously in #526 where the base value would not be adjusted after a scrub-drag was fully performed. So that would lead to the scrubber to always start from the very initial value, instead of starting the next scrub from the recently adjusted value.