### PR TITLE
Fix problems with Canvas

### DIFF
--- a/lively.components/canvas.js
+++ b/lively.components/canvas.js
@@ -12,6 +12,8 @@ export class Canvas extends Morph {
       extent: { defaultValue: pt(200, 200) },
       fill: { defaultValue: Color.transparent },
       contextType: { defaultValue: '2d' },
+      // https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
+      willReadFrequently: { defaultValue: false },
 
       preserveContents: { defaultValue: true },
 
@@ -33,7 +35,7 @@ export class Canvas extends Morph {
 
   // get canvasBounds() { return this._canvas && this.canvasExtent.extentAsRectangle(); }
   get context () {
-    if (this._canvas) { return this._canvas.getContext(this.contextType); } else if (!this.world() || !this.env.renderer.getNodeForMorph(this)) {
+    if (this._canvas) { return this._canvas.getContext(this.contextType, { willReadFrequently: this.willReadFrequently }); } else if (!this.world() || !this.env.renderer.getNodeForMorph(this)) {
       console.warn('Context not yet rendered. Please ensure that the Canvas Morph has been rendered first before accessing the context. This can be achieved by waiting for the whenRendered() promise before you proceed accessing the context property.');
     }
     return null;

--- a/lively.ide/text/map.js
+++ b/lively.ide/text/map.js
@@ -17,7 +17,9 @@ export default class TextMap extends Canvas {
       relativeBoundsInTextMorph: {},
       extent: { defaultValue: pt(60, 50) },
       markers: {},
-      draggable: { defaultValue: true }
+      draggable: { defaultValue: true },
+      // https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
+      willReadFrequently: { defaultValue: true }
     };
   }
 

--- a/lively.ide/text/map.js
+++ b/lively.ide/text/map.js
@@ -103,7 +103,12 @@ export default class TextMap extends Canvas {
     let { document: doc, textLayout, markers, selections } = textMorph;
     let { startRow, endRow } = textLayout.whatsVisible(textMorph);
 
-    if (!ctx) this.whenRendered().then(() => this.update());
+    if (!ctx) {
+      this.whenRendered().then(() => this.update());
+      // waiting for `whenRendered` does not guarantee us to be actually rendered, as it is more of a waiting heuristic
+      // not returning in the case that we were not rendered lead to errors, when `fillStyle` of `undefined` was read
+      return;
+    }
 
     this.clear(null);
 


### PR DESCRIPTION
This PR fixes some small annoyances that became apparent with the option to enable the `TextMap` all the time, which lead to a `Canvas` element it being open way more often.

The `willReadFrequently` option is an optimization that Chrome suggested in the console :grin:.

All in all, this should stop the endless stream of warnings/errors when having a `Console` as well as a `TextMap` open. 