### PR TITLE
Fix/auto layout hug and fill

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -960,6 +960,14 @@ async function browse (browseSpec = {}, browserOrProps = {}, optSystemInterface)
   return browser.browse(browseSpec, optSystemInterface);
 }
 
+function browserForFile (fileName) {
+  const browsers = $world.getWindows()
+    .map(win => win.targetMorph).filter(ea => ea.isBrowser);
+  const browserWithFile = browsers.find(({ selectedModule }) =>
+    selectedModule && selectedModule.url === fileName);
+  return browserWithFile;
+}
+
 async function open () {
   const browser = part(SystemBrowser);
   await browser.viewModel.toggleWindowStyle(false);
@@ -977,5 +985,5 @@ export {
   BrowserDirectoryControls,
   BrowserPackageControls,
   SystemBrowser,
-  open, browse
+  open, browse, browserForFile
 };

--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -169,14 +169,14 @@ const LivelyVersionChecker = component({
   fill: Color.rgba(0, 0, 0, 0.6),
   hasFixedPosition: true,
   layout: new TilingLayout({
-    axis: 'column',
+    axis: 'row',
     axisAlign: 'left',
     align: 'left',
     orderByIndex: true,
     autoResize: true,
     hugContentsHorizontally: true,
     hugContentsVertically: true,
-    wrapSubmorpsh: false,
+    wrapSubmorphs: false,
     padding: {
       height: 0,
       width: 0,
@@ -184,7 +184,6 @@ const LivelyVersionChecker = component({
       y: 5
     },
     reactToSubmorphAnimations: false,
-    renderViaCSS: false,
     resizeSubmorphs: false,
     spacing: 5
   }),

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -466,11 +466,12 @@ export class TilingLayout extends Layout {
 
   /**
    * If set to true, the container auto adjusts its height to fit the content.
-   * Warning: This property is inactive when wrapping is enabled AND the axis are columns.
+   * Warning: This property is inactive when wrapping is enabled AND the axis are columns. It also is inactive when none of the layoutable submorphs are set for their height to be fixed. The reason is that then there is no way for the layout to determine what height to hug to.
    * @type {Boolean}
    */
   get hugContentsVertically () {
     if (this.wrapSubmorphs && this.axis === 'column') return false;
+    if (!this.resizePolicies.some(([_, { height }]) => height === 'fixed')) return false;
     return this._hugContentsVertically;
   }
 
@@ -481,11 +482,12 @@ export class TilingLayout extends Layout {
 
   /**
    * If set to true, the container auto adjusts its width to fit the content.
-   * Warning: This property is inactive when wrapping is enabled AND the axis are rows.
+   * Warning: This property is inactive when wrapping is enabled AND the axis are rows. It also is inactive when none of the layoutable submorphs are set for their width to be fixed. The reason is that then there is no way for the layout to determine what width to hug to.
    * @type {Boolean}
    */
   get hugContentsHorizontally () {
     if (this.wrapSubmorphs && this.axis === 'row') return false;
+    if (!this.resizePolicies.some(([_, { width }]) => width === 'fixed')) return false;
     return this._hugContentsHorizontally;
   }
 
@@ -521,12 +523,12 @@ export class TilingLayout extends Layout {
    */
   getResizeHeightPolicyFor (aLayoutableSubmorph) {
     const policy = this._resizePolicies.get(aLayoutableSubmorph) || { width: 'fixed', height: 'fixed' };
-    return (this.wrapSubmorphs || this.hugContentsVertically) ? 'fixed' : policy.height;
+    return this.wrapSubmorphs ? 'fixed' : policy.height;
   }
 
   getResizeWidthPolicyFor (aLayoutableSubmorph) {
     const policy = this._resizePolicies.get(aLayoutableSubmorph) || { width: 'fixed', height: 'fixed' };
-    return (this.wrapSubmorphs || this.hugContentsHorizontally) ? 'fixed' : policy.width;
+    return this.wrapSubmorphs ? 'fixed' : policy.width;
   }
 
   setResizePolicyFor (aLayoutableSubmorph, policy) {

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -337,6 +337,10 @@ export class TilingLayout extends Layout {
     }
   }
 
+  get layoutableSubmorphs () {
+    return super.layoutableSubmorphs.filter(m => m.visible);
+  }
+
   get reactToSubmorphAnimations () {
     return this._reactToSubmorphAnimations;
   }
@@ -977,6 +981,15 @@ export class TilingLayout extends Layout {
       let fixedHeight = padding.top() + padding.bottom() - this.spacing;
       let fixedWidth = padding.left() + padding.right() - this.spacing;
       let numDynamic = 0;
+
+      if (hugContentsVertically) {
+        container.height = container.submorphBounds(m => layoutableSubmorphs.includes(m) && this.getResizeHeightPolicyFor(m) == 'fixed').height + padding.top() + padding.bottom();
+      }
+
+      if (hugContentsHorizontally) {
+        container.width = container.submorphBounds(m => layoutableSubmorphs.includes(m) && this.getResizeWidthPolicyFor(m) == 'fixed').width + padding.left() + padding.right();
+      }
+
       morphsOnAxis.forEach(m => {
         if (isHorizontal) {
           fixedWidth += this.spacing;
@@ -1086,14 +1099,6 @@ export class TilingLayout extends Layout {
         this.changePropertyAnimated(m, posAccessor, pos, animate);
       });
     });
-
-    if (hugContentsVertically) {
-      container.height = container.submorphBounds(m => layoutableSubmorphs.includes(m)).height + padding.top() + padding.bottom();
-    }
-
-    if (hugContentsHorizontally) {
-      container.width = container.submorphBounds(m => layoutableSubmorphs.includes(m)).width + +padding.left() + padding.right();
-    }
 
     this.active = false;
     this.forceLayoutsInNextLevel();


### PR DESCRIPTION
This is a slight enhancement to `TilingLayout` which affects the horizontal and vertical hugging of the contents.
Previously, hugging contents along a dimension would require that *all* of the laid out submorphs have a fixed width along that dimension. Instead of throwing errors, `TilingLayout` would actually just flat out ignore if a dimension of such a submorph was set to `'fill'` and instead just default to `'fixed'`. The idea was that we must not allow the submorphs size along that dimension to be ambiguous, else the hugging would not know what size to "hug" to.
I found that requiring *all* submorphs to have that property is overly restrictive since just having one submorph be fixed is enough to determine the hugging size of the dimension.
Further relaxing this restriction enables simplifications for `TilingLayout` instances, where previously we had to rely on a custom layout routines that to some of the fitting manually. This was for instance the case in the `LoadingIndicator` as can be seen in this PR.
In case *all* of the submorphs are set to fit the owner, although the owner is told to fit to the submorphs we now instead disable the hugging and set it to fixed. This is incidentally the same behaviour that can be observed in Figma.

Below is a recording of the resulting behaviour in action:

![layout-hugging](https://user-images.githubusercontent.com/1296388/204481312-3d59972c-94c7-47b7-a4e7-55a77cc99a7d.gif)

The fixed morph dictates the width of the container, while all of the other morph in this example are set to adjust to the owner width.