### PR TITLE
🧰: adjust default extent of console

### DIFF
--- a/lively.ide/debug/console.cp.js
+++ b/lively.ide/debug/console.cp.js
@@ -251,7 +251,6 @@ class LocalJSConsoleModel extends ViewModel {
 
   async menuItems () {
     const viewItems = await this.withoutBindingsDo(async () => await this.view.menuItems());
-    debugger;
     return [
       { command: '[console] clear', target: this, alias: 'clear' },
       { isDivider: true },
@@ -289,7 +288,9 @@ const Console = component({
   type: Text,
   name: 'debug console',
   defaultViewModel: LocalJSConsoleModel,
-  extent: pt(300, 400),
+  lineWrapping: true,
+  fixedWidth: true,
+  extent: pt(500, 400),
   fill: Color.black.withA(.9),
   fontColor: Color.white,
   clipMode: 'auto'

--- a/lively.morphic/helpers.js
+++ b/lively.morphic/helpers.js
@@ -79,16 +79,16 @@ export function clearStylePropertiesForClassesIn (moduleId) {
 function getPropSettings (type) {
   const klass = (!type || obj.isString(type)) ? getClassForName(type || 'default') : type;
   const { package: pkg, pathInPackage } = klass[Symbol.for('lively-module-meta')];
-  const { properties: props } = klass[Symbol.for('lively.classes-properties-and-settings')];
-  return { props, moduleId: string.joinPath(pkg.name, pathInPackage) };
+  const { properties: props, order } = klass[Symbol.for('lively.classes-properties-and-settings')];
+  return { order, props, moduleId: string.joinPath(pkg.name, pathInPackage) };
 }
 
 export function getStylePropertiesFor (type) {
   if (CachedStyleProperties.has(type)) return CachedStyleProperties.get(type);
-  const { props, moduleId } = getPropSettings(type);
+  const { props, moduleId, order } = getPropSettings(type);
   const styleProps = [];
   styleProps.moduleId = moduleId;
-  for (let prop in props) {
+  for (let prop of order) {
     if (props[prop].isStyleProp) styleProps.push(prop);
     if (props[prop].foldable) {
       styleProps.push(...props[prop].foldable.map(sub => prop + string.capitalize(sub)));


### PR DESCRIPTION
This is a small correction to #554 which adjusts the default extent of the console and removes a debugger statement.