### PR TITLE
🎛️: fix typo in `list.js`

### DIFF
--- a/lively.components/list.js
+++ b/lively.components/list.js
@@ -47,7 +47,7 @@ export class ListItemMorph extends Label {
         }
       },
       list: {
-        drived: true,
+        derived: true,
         get () {
           return this.owner.owner;
         }
@@ -1525,7 +1525,7 @@ export class InteractiveItem extends ListItemMorph {
         }
       },
       list: {
-        drived: true,
+        derived: true,
         get () {
           return this.owner.owner;
         }


### PR DESCRIPTION
Closes #590.