### PR TITLE
Feature/function guard

### DIFF
--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -166,6 +166,7 @@ export default class Window extends Morph {
       this.borderColor = Color.gray.darker();
       this._faderTriggered = true;
       fader.opacity = 1;
+      await promise.delay(300);
     } else {
       if (this._originalBounds) {
         this.animate({

--- a/lively.ide/styling/gradient-editor.js
+++ b/lively.ide/styling/gradient-editor.js
@@ -7,7 +7,7 @@ import {
   LinearGradient
 } from 'lively.graphics';
 import { ViewModel, part } from 'lively.morphic';
-import { num, arr } from 'lively.lang';
+import { num, fun, arr } from 'lively.lang';
 import { connect, noUpdate, signal } from 'lively.bindings';
 import { joinPath } from 'lively.lang/string.js';
 import { ColorStop } from './color-stops.cp.js';
@@ -174,7 +174,9 @@ export class GradientControlModel extends ViewModel {
       vector: rect(0),
       stops // do not share stops!!
     });
-    this.updateStopControls(this.gradientValue.stops);
+    fun.guardNamed('updateGradient', () => {
+      this.updateStopControls(this.gradientValue.stops);
+    })();
     this.gradientHalo.refresh(this);
   }
 
@@ -222,8 +224,6 @@ export class GradientControlModel extends ViewModel {
   }
 
   async updateStopControls (stops, haloOrEditor = this) {
-    if (haloOrEditor._active) return;
-    haloOrEditor._active = true;
     let stopControls = haloOrEditor.stopControls;
     // fixme: do not rely on the ordering of stop controls
     for (const stop of stops) {
@@ -239,7 +239,6 @@ export class GradientControlModel extends ViewModel {
     haloOrEditor.stopControls.forEach(stopControl => {
       stopControl.positionIn(haloOrEditor);
     });
-    haloOrEditor._active = false;
   }
 }
 
@@ -402,7 +401,9 @@ export class GradientHaloModel extends ViewModel {
   refresh (gradientControl, target) {
     const gradientValue = gradientControl.gradientValue;
     this.alignWithTarget();
-    gradientControl.updateStopControls(gradientValue.stops, this);
+    fun.guardNamed('updateGradient', () => {
+      gradientControl.updateStopControls(gradientValue.stops, this);
+    })();
   }
 
   placeStop (aStopControl) {

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -824,12 +824,20 @@ export class LivelyWorld extends World {
       pos = requester.globalBounds().center();
       if (requester.isWorld) pos = requester.visibleBounds().center();
       if (win = requester.getWindow()) {
-        await win.toggleFader(true);
+        fun.guardNamed('toggleFader-' + win.id, () => {
+          return win.toggleFader(true);
+        })();
         pos = win.globalBounds().center();
       }
     }
     const res = await doFn(pos);
-    if (win) win.toggleFader(false);
+    if (win) {
+      setTimeout(() => {
+        fun.guardNamed('toggleFader-' + win.id, () => {
+          return win.toggleFader(false);
+        })();
+      }, 300);
+    }
     return res;
   }
 

--- a/lively.lang/tests/function-test.js
+++ b/lively.lang/tests/function-test.js
@@ -2,6 +2,7 @@
 
 import { expect } from 'mocha-es6';
 import * as fun from '../function.js';
+import { promise } from 'lively.lang';
 
 describe('fun', function () {
   describe('accessing methods -- own and all', function () {
@@ -629,6 +630,18 @@ describe('fun', function () {
       expect(log).to.equal('bRun');
       // expect(fun).to.have.property("_eitherNameRegistry");
       // expect(fun._eitherNameRegistry).to.not.have.property(name);
+    });
+
+    it('can restrict that a function is only executed unless it has returned', async () => {
+      let log = '';
+      let name = 'guard-test-' + Date.now();
+      async function a () { await promise.delay(10), log += 'aRun'; }
+      async function b () { await promise.delay(10), log += 'bRun'; }
+      async function c () { await promise.delay(10), log += 'cRun'; }
+      (async () => fun.guardNamed(name, a)())();
+      (async () => fun.guardNamed(name, b)())();
+      await (async () => fun.guardNamed(name, c)())();
+      expect(log).to.equal('aRun');
     });
 
     it('can replace a function for one call', function () {


### PR DESCRIPTION
I observed several cases where we still use custom instance variables to implement guards that ensure we do not traverse a certain function body more than once until if finishes execution.
This guard abstraction should provide us with a standardised solution for these scenarios.
I included two example use cases found in the gradient editor and the fader toggling of the windows when we open a prompt.