### PR TITLE
🎨: prevent setting text scroll ahead of document bounds

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -520,7 +520,8 @@ export class Text extends Morph {
       scroll: {
         renderSynchronously: true,
         set (val) {
-          this.setProperty('scroll', val);
+          const maxScroll = this.scrollExtent.subXY(this.width, this.height);
+          this.setProperty('scroll', val.minPt(maxScroll));
         }
       },
 


### PR DESCRIPTION
Fixes an issue where we could set the scroll of a text morph beyond the possible scroll dictated by the bounds of the document.

![overscroll](https://user-images.githubusercontent.com/1296388/210405775-25942027-3f55-41a9-ab72-99b938af494d.gif)
