### PR TITLE
🎨: fix lost embedded submorphs issue when measuring line

### DIFF
--- a/lively.morphic/rendering/font-metric.js
+++ b/lively.morphic/rendering/font-metric.js
@@ -426,10 +426,8 @@ class DOMTextMeasure {
 
         nodeForMorph = $world.env.renderer.getNodeForMorph(morph);
         actualTextNode = nodeForMorph && nodeForMorph.querySelector(`#${morph.id}textLayer`);
-        if (!line.lineNeedsRerender) {
-          const dataRowId = String(line.row);
-          lineNode = Array.from(actualTextNode.children).find(n => n.getAttribute('data-row') === dataRowId);
-        }
+        const dataRowId = String(line.row);
+        lineNode = actualTextNode && Array.from(actualTextNode.children).find(n => n.getAttribute('data-row') === dataRowId);
 
         const needsToCreateNode = !lineNode || line.lineNeedsRerender;
         let nodeToReplace;


### PR DESCRIPTION
Revision to #602. There was a bug where we would accidentally loose embedded line morphs since they were being rendered into an intermediate line that was not mounted back.