### PR TITLE
🧰: avoid empty inspector when printing of values fails

### DIFF
--- a/lively.ide/js/inspector/context.js
+++ b/lively.ide/js/inspector/context.js
@@ -107,7 +107,7 @@ function safePrint (value) {
 
   }
 
-  if (!result) return '[CAN NOT BE DISPLAYED]';
+  if (!result) return '[CANNOT BE DISPLAYED]';
   return result;
 }
 

--- a/lively.ide/js/inspector/context.js
+++ b/lively.ide/js/inspector/context.js
@@ -92,17 +92,37 @@ export function isMultiValue (foldableValue, propNames) {
     v => obj.equals(v, foldableValue && foldableValue.valueOf()));
 }
 
+function safePrint (value) {
+  let result;
+  try {
+    result = string.print(value);
+  } catch (err) {
+  }
+
+  try {
+    if (!result) {
+      result = JSON.stringify(value);
+    }
+  } catch (err) {
+
+  }
+
+  if (!result) return '[CAN NOT BE DISPLAYED]';
+  return result;
+}
+
 export function printValue (value) {
   let result;
-  if (obj.isPrimitive(value)) result = string.print(value);
+
+  if (obj.isPrimitive(value)) result = safePrint(value);
   else if (Array.isArray(value)) {
     const tooLong = value.length > 3;
     if (tooLong) value = value.slice(0, 3);
-    let printed = string.print(value);
+    let printed = safePrint(value);
     if (tooLong) printed = printed.slice(0, -1) + ', ...]';
     result = printed;
   } else {
-    result = string.print(value);
+    result = safePrint(value);
   }
   result = result.replace(/\n/g, '');
   if (result.length > 500) result = result.slice(0, 20) + `...[${result.length - 20} CHARS]"`;


### PR DESCRIPTION
Fixes empty inspectors when inspecting certain data structures.
It happens when some of the values inside a structure that are supposed to be displayed in the inspector fail to convert to a string. I replaced the printing approach in the inspector with a `safePrint` that attempts different stringification attempts and wraps each in a try/catch.

closes #610.