### PR TITLE
🎛️: catch error when data url generation fails

### DIFF
--- a/lively.components/canvas.js
+++ b/lively.components/canvas.js
@@ -137,7 +137,13 @@ export class Canvas extends Morph {
     else this.__canvas_init__ = () => func(this.context);
   }
 
-  toDataURI () { return this._canvas && this._canvas.toDataURL(); }
+  toDataURI () {
+    try {
+      return this._canvas && this._canvas.toDataURL();
+    } catch (err) {
+      return err.message;
+    }
+  }
 
   fromDataURI (uri) {
     const img = new Image();


### PR DESCRIPTION
In certain scenarios, the canvas context is unable to generate a data url. Those cases used to cause crashes in the initialisation of canvas morphs. We now fail silently and return an empty string instead.