### PR TITLE
Fix/annotation clipping

### DIFF
--- a/lively.components/muller-columns.cp.js
+++ b/lively.components/muller-columns.cp.js
@@ -8,6 +8,7 @@ import { DefaultList } from './list.cp.js';
 // ColumnListDefault.openInWorld()
 const ColumnListDefault = component(DefaultList, {
   name: 'column list default',
+  styleClasses: ['clipped'],
   borderWidthRight: 1,
   borderColor: Color.rgb(213, 216, 220),
   extent: pt(230, 93.5),

--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -906,6 +906,7 @@ const ListPrompt = component(ConfirmPrompt, {
         name: 'list',
         borderColor: Color.rgb(149, 165, 166),
         borderRadius: 4,
+        styleClasses: ['clipped'],
         dropShadow: new ShadowObject({ distance: 3, rotation: 75, color: Color.rgba(0, 0, 0, 0.2) }),
         extent: pt(410, 354),
         fill: Color.rgba(66, 73, 73, 0.85),

--- a/lively.ide/js/browser/commands.js
+++ b/lively.ide/js/browser/commands.js
@@ -322,7 +322,7 @@ export default function browserCommands (browser) {
             isListItem: true,
             label: [
               `${ea.name}`, null,
-              `${ea.url}`, { fontSize: '70%', textStyleClasses: ['annotation'] }
+              `${ea.url}`, { paddingLeft: '5px', fontSize: '70%', textStyleClasses: ['annotation'] }
             ],
             value: ea
           };

--- a/lively.ide/js/import-helper.js
+++ b/lively.ide/js/import-helper.js
@@ -151,6 +151,7 @@ function labelForExport (exportSpec) {
   return [
     exportName, {},
     `${type} ${reexportString || ''} ${annotationString}`, {
+      paddingLeft: '5px',
       fontSize: '70%',
       textStyleClasses: ['truncated-text', 'annotation']
     }

--- a/lively.morphic/rendering/morphic-default.js
+++ b/lively.morphic/rendering/morphic-default.js
@@ -5,9 +5,9 @@ import { styleProps, stylepropsToNode } from './property-dom-mapping.js';
 import bowser from 'bowser';
 
 /**
-  * @param {Morph} morph - The Morph for which to generate the attributes. 
+  * @param {Morph} morph - The Morph for which to generate the attributes.
   */
- export function defaultAttributes (morph) {
+export function defaultAttributes (morph) {
   const attrs = {
     id: morph.id,
     class: (morph.hideScrollbars
@@ -27,13 +27,13 @@ import bowser from 'bowser';
 
 /**
  * Extract the styling information from `morph`'s morphic model and applies them to its DOM node.
- * Classes subclassing Morph can implement `renderStyles` that gets the Object with the styles to be applied passed before they are applied to the node. 
+ * Classes subclassing Morph can implement `renderStyles` that gets the Object with the styles to be applied passed before they are applied to the node.
  * @see defaultStyle.
  * @param {Morph} morph - The Morph to be rendered.
  * @param {Node} node - The node in which `morph` is rendered into the DOM.
  * @returns {Node} `morph`'s DOM node with applied styling attributes.
  */
- export function applyStylingToNode (morph, node) {
+export function applyStylingToNode (morph, node) {
   let styleProps = defaultStyle(morph);
 
   if (typeof morph.renderStyles === 'function') {
@@ -42,7 +42,7 @@ import bowser from 'bowser';
 
   stylepropsToNode(styleProps, node); // eslint-disable-line no-use-before-define
 
-  if (morph.owner && morph.owner.isText && morph.owner.embeddedMorphMap.has(morph)){
+  if (morph.owner && morph.owner.isText && morph.owner.embeddedMorphMap.has(morph)) {
     node.style.position = 'sticky';
     node.style.transform = '';
     node.style.textAlign = 'initial';
@@ -50,7 +50,7 @@ import bowser from 'bowser';
     node.style.removeProperty('left');
   }
   if (morph.renderingState.inlineGridImportant && node.style['display'] !== 'none') node.style.setProperty('display', 'inline-grid', 'important');
-  if (morph.renderingState.inlineFlexImportant && node.style['display'] !== 'none') node.style.setProperty('display','inline-flex','important');
+  if (morph.renderingState.inlineFlexImportant && node.style['display'] !== 'none') node.style.setProperty('display', 'inline-flex', 'important');
 
   return node;
 }
@@ -315,6 +315,20 @@ div.text-layer span {
   float: right;
   top: 50%;
   text-align: right;
+}
+
+.List.clipped .annotation {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  flex-grow: 1;
+}
+
+.List.clipped .ListItemMorph .line {
+  display: flex;
+}
+
+.List.clipped .ListItemMorph .newtext-text-layer.actual {
+  width: 100%;
 }
 
 .truncated-text {


### PR DESCRIPTION
Implements the (ellipsis) clipping of annotations in list item morphs via additional style classes.
![clipped-annotations](https://user-images.githubusercontent.com/1296388/213524731-24e10621-e646-4567-b333-5b0802076ade.jpg)
