### PR TITLE
📦: ensure node-gyp when building lively packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ if [[ $NODE_VERSION -lt 18 ]]; then
   exit 1;
 fi
 
-export PATH=$lv_next_dir/flatn/bin:$PATH
+export PATH=$lv_next_dir:$lv_next_dir/flatn/bin:$PATH
 export FLATN_PACKAGE_DIRS=
 export FLATN_PACKAGE_COLLECTION_DIRS=$lv_next_dir/lively.next-node_modules
 eval $(node -p 'let PWD=process.cwd();let packages = JSON.parse(require("fs").readFileSync(PWD+"/lively.installer/packages-config.json")).map(ea => require("path").join(PWD, ea.name));`export FLATN_DEV_PACKAGE_DIRS=${packages.join(":")}`')                                                              

--- a/lively.installer/install.js
+++ b/lively.installer/install.js
@@ -116,7 +116,7 @@ export async function install(baseDir, dependenciesDir, verbose) {
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     if (step5_runPackageInstallScripts) {
       console.log(`=> running install scripts of ${packageMap.allPackages().length} packages`);
-
+      await exec('ln -s ' + require.resolve('node-gyp/bin/node-gyp.js') + ' node-gyp')
       pBar && pBar.setValue(0)
       i = 0; for (let p of packages) {
         pBar && pBar.setLabel(`npm setup ${p.name}`);
@@ -124,6 +124,7 @@ export async function install(baseDir, dependenciesDir, verbose) {
         await buildPackage(p.directory, packageMap, ["dependencies"]);
         pBar && pBar.setValue(++i / packages.length)
       }
+      await exec('rm node-gyp');
     }
 
     if (step8_runPackageBuildScripts) {

--- a/lively.installer/install.js
+++ b/lively.installer/install.js
@@ -116,7 +116,9 @@ export async function install(baseDir, dependenciesDir, verbose) {
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     if (step5_runPackageInstallScripts) {
       console.log(`=> running install scripts of ${packageMap.allPackages().length} packages`);
-      await exec('ln -s ' + require.resolve('node-gyp/bin/node-gyp.js') + ' node-gyp')
+      // upon first install this is not yet inside the lookup
+      const nodeGyp = packageMap.lookup('node-gyp');
+      await exec('ln -s ' + join(nodeGyp.location, nodeGyp.bin['node-gyp']) + ' node-gyp')
       pBar && pBar.setValue(0)
       i = 0; for (let p of packages) {
         pBar && pBar.setLabel(`npm setup ${p.name}`);


### PR DESCRIPTION
Fixes an issue that happens on systems where the architecture demands to build leveldown on the machine.
We temporary create a symlink that can then be used by any build script invoking `node-gyp`. The symlink is then deleted.