### PR TITLE
🎨: pass module manager when loading world via file path

### DIFF
--- a/lively.morphic/world-loading.js
+++ b/lively.morphic/world-loading.js
@@ -4,7 +4,7 @@ import { subscribe, emit } from 'lively.notifications';
 import { Path, obj, date, promise, string } from 'lively.lang';
 import { defaultDirectory } from 'lively.ide/shell/shell-interface.js';
 import ShellClientResource from 'lively.shell/client-resource.js';
-
+import * as moduleManager from 'lively.modules';
 import { MorphicEnv } from './env.js';
 import { createMorphSnapshot } from './serialization.js';
 import { MorphicDB } from './morphicdb/index.js';
@@ -250,7 +250,7 @@ export async function interactivelySaveWorld (world, options) {
 
     world.changeMetaData('file', jsonStoragePath, false, false);
 
-    const snap = await createMorphSnapshot(world);
+    const snap = await createMorphSnapshot(world, { moduleManager });
     await resourceHandle.writeJson(snap);
     await resource((await defaultDirectory(ShellClientResource.defaultL2lClient)) + '/..')
       .join(jsonStoragePath.replace('.json', '.br.json'))

--- a/lively.morphic/world.js
+++ b/lively.morphic/world.js
@@ -75,7 +75,7 @@ export class World extends Morph {
   }
 
   static async loadFromResource (res, oldWorld = this.defaultWorld(), options = {}) {
-    return await loadWorld(await loadMorphFromSnapshot(await res.readJson()), oldWorld, options);
+    return await loadWorld(await loadMorphFromSnapshot(await res.readJson(), options), oldWorld, options);
   }
 
   constructor (props) {
@@ -105,7 +105,7 @@ export class World extends Morph {
       ...super.commands, {
         name: 'resize to fit window',
         exec: async (world) => {
-          world.extent = world.windowBounds().extent()
+          world.extent = world.windowBounds().extent();
           world.relayout();
           return true;
         }


### PR DESCRIPTION
Fixes an issue with incorrect invocation of the world loading when using resources.