### PR TITLE
🎨: prevent negative scroll in text morph

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -521,7 +521,7 @@ export class Text extends Morph {
         renderSynchronously: true,
         set (val) {
           const maxScroll = this.scrollExtent.subXY(this.width, this.height);
-          this.setProperty('scroll', val.minPt(maxScroll));
+          this.setProperty('scroll', val.minPt(maxScroll).maxPt(pt(0, 0)));
         }
       },
 


### PR DESCRIPTION
Fixes the well known issue of negative overscroll in text morphs.