### PR TITLE
Various Window Fixes

### DIFF
--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -101,12 +101,12 @@ export default class Window extends Morph {
     };
   }
 
-  static maximizedBounds () {
-    return $world.visibleBoundsExcludingTopBar().insetBy(40).withWholeNumbers();
+  static maximumBounds () {
+    return $world.visibleBoundsExcludingTopBar().insetBy(40).roundTo(1);
   }
 
   updateNonMinimizedBounds () {
-    if (!this.extent.roundTo(1).equals(Window.maximizedBounds().extent())) this.nonMinimizedBounds = this.position.extent(this.extent);
+    if (!this.extent.roundTo(1).equals(Window.maximumBounds().extent())) this.nonMinimizedBounds = this.position.extent(this.extent);
   }
 
   build () {
@@ -528,7 +528,7 @@ export default class Window extends Morph {
   toggleMaximize () { if (!this.minimized) this.applyMaximize(); }
 
   applyMaximize () {
-    const maximized = obj.equals(this.position.extent(this.extent.roundTo(1)), Window.maximizedBounds());
+    const maximized = obj.equals(this.position.extent(this.extent.roundTo(1)), Window.maximumBounds());
     if (!maximized) {
       $world.execCommand('resize active window', { window: this, how: 'full' });
     } else {

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -541,6 +541,7 @@ export default class Window extends Morph {
     }
     this.relayoutResizer();
     this.relayoutWindowControls();
+    this.ui.resizer.visible = true;
   }
 
   async toggleMinimize () { this.minimized = !this.minimized; }

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -91,15 +91,19 @@ export default class Window extends Morph {
       nonMinimizedBounds: {},
       nonMaximizedBounds: {},
       minimized: {
+        defaultValue: false,
         set (isMinimized) {
+          const changed = !!isMinimized !== !!this.minimized;
           this.setProperty('minimized', isMinimized);
-          this.applyMinimize();
+          if (changed) this.applyMinimize();
         }
       },
       maximized: {
+        defaultValue: true,
         set (isMaximized) {
+          const changed = !!isMaximized !== !!this.maximized;
           this.setProperty('maximized', isMaximized);
-          this.applyMaximize();
+          if (changed) this.applyMaximize();
         }
       }
     };

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -102,7 +102,7 @@ export default class Window extends Morph {
   }
 
   static maximumBounds () {
-    return $world.visibleBoundsExcludingTopBar().insetBy(40).roundTo(1);
+    return $world.visibleBoundsExcludingStudioInterface().insetBy(40).roundTo(1);
   }
 
   updateNonMinimizedBounds () {
@@ -537,7 +537,7 @@ export default class Window extends Morph {
     if (!maximized) {
       $world.execCommand('resize active window', { window: this, how: 'full' });
     } else {
-      this.nonMinimizedBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.nonMinimizedBounds);
+      this.nonMinimizedBounds = this.world().visibleBoundsExcludingStudioInterface().translateForInclusion(this.nonMinimizedBounds);
       this.animate({
         bounds: this.nonMinimizedBounds,
         duration: 100,
@@ -566,7 +566,7 @@ export default class Window extends Morph {
       this.withMetaDo({ metaInteraction: true }, () => {
         this.targetMorph && (this.targetMorph.visible = true);
       });
-      let goalBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.nonMinimizedBounds);
+      let goalBounds = this.world().visibleBoundsExcludingStudioInterface().translateForInclusion(this.nonMinimizedBounds);
       if (this.wasFullscreen) {
         goalBounds = Window.maximumBounds();
         delete this.wasFullscreen;

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -561,15 +561,20 @@ export default class Window extends Morph {
       this.withMetaDo({ metaInteraction: true }, () => {
         this.targetMorph && (this.targetMorph.visible = true);
       });
-      this.nonMinimizedBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.nonMinimizedBounds);
+      let goalBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.nonMinimizedBounds);
+      if (this.wasFullscreen) {
+        goalBounds = Window.maximumBounds();
+        delete this.wasFullscreen;
+      }
       this.animate({
-        bounds: this.nonMinimizedBounds,
+        bounds: goalBounds,
         styleClasses: ['neutral', 'active', ...arr.without(this.styleClasses, 'minimzed')],
         duration,
         easing
       }).then(() => this.clipMode = 'visible');
       collapseButton.tooltip = 'collapse window';
     } else {
+      if (obj.equals(this.position.extent(this.extent).roundTo(1), Window.maximumBounds())) this.wasFullscreen = true;
       this.clipMode = 'hidden';
       let minimizedBounds = (this.minimizedBounds || bounds).withExtent(pt(width, 28));
       const labelBounds = windowTitle.textBounds();

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -539,9 +539,10 @@ export default class Window extends Morph {
 
   async applyMinimize () {
     if (!this.targetMorph) return;
-    let { nonMinimizedBounds, minimized, width } = this;
+
+    let { minimized, width } = this;
     const { windowTitle, resizer } = this.ui;
-    const bounds = this.bounds();
+    const bounds = this.position.extent(this.extent);
     const duration = 100;
     const collapseButton = this.getSubmorphNamed('minimize');
     const easing = easings.outQuad;
@@ -551,9 +552,9 @@ export default class Window extends Morph {
       this.withMetaDo({ metaInteraction: true }, () => {
         this.targetMorph && (this.targetMorph.visible = true);
       });
-      nonMinimizedBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(nonMinimizedBounds || bounds);
+      this.nonMinimizedBounds = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.nonMinimizedBounds || bounds);
       this.animate({
-        bounds: nonMinimizedBounds,
+        bounds: this.nonMinimizedBounds,
         styleClasses: ['neutral', 'active', ...arr.without(this.styleClasses, 'minimzed')],
         duration,
         easing
@@ -565,12 +566,14 @@ export default class Window extends Morph {
       let minimizedBounds = (this.minimizedBounds || bounds).withExtent(pt(width, 28));
       const labelBounds = windowTitle.textBounds();
       const buttonOffset = this.get('window controls').bounds().right() + 3;
-      if (labelBounds.width + 2 * buttonOffset < minimizedBounds.width) { minimizedBounds = minimizedBounds.withWidth(labelBounds.width + buttonOffset + 5); }
+      if (labelBounds.width + 2 * buttonOffset < minimizedBounds.width) {
+        minimizedBounds = minimizedBounds.withWidth(labelBounds.width + buttonOffset + 5);
+      }
       this.minimizedBounds = minimizedBounds;
       collapseButton.tooltip = 'uncollapse window';
       this.animate({
         styleClasses: ['minimized', 'active', ...arr.without(this.styleClasses, 'neutral')],
-        bounds: minimizedBounds,
+        bounds: this.minimizedBounds,
         duration,
         easing
       }).then(() => {

--- a/lively.components/window.js
+++ b/lively.components/window.js
@@ -106,7 +106,12 @@ export default class Window extends Morph {
   }
 
   updateNonMinimizedBounds () {
-    if (!this.extent.roundTo(1).equals(Window.maximumBounds().extent())) this.nonMinimizedBounds = this.position.extent(this.extent);
+    if (this.minimized) return;
+    if (!this.extent.roundTo(1).equals(Window.maximumBounds().extent()) &&
+       (!this.minimizedBounds ||
+       !this.extent.roundTo(1).equals(this.minimizedBounds.extent().roundTo(1)))) {
+      this.nonMinimizedBounds = this.position.extent(this.extent).roundTo(1);
+    }
   }
 
   build () {

--- a/lively.graphics/geometry-2d.js
+++ b/lively.graphics/geometry-2d.js
@@ -782,6 +782,12 @@ export class Rectangle {
     return nearest;
   }
 
+  withWholeNumbers () {
+    const { x, y } = new Point(this.x, this.y).roundTo(1);
+    const { x: width, y: height } = new Point(this.width, this.height).roundTo(1);
+    return new Rectangle(x, y, width, height);
+  }
+
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // printing
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/lively.graphics/geometry-2d.js
+++ b/lively.graphics/geometry-2d.js
@@ -795,9 +795,9 @@ export class Rectangle {
     return nearest;
   }
 
-  withWholeNumbers () {
-    const { x, y } = new Point(this.x, this.y).roundTo(1);
-    const { x: width, y: height } = new Point(this.width, this.height).roundTo(1);
+  roundTo (n) {
+    const { x, y } = new Point(this.x, this.y).roundTo(n);
+    const { x: width, y: height } = new Point(this.width, this.height).roundTo(n);
     return new Rectangle(x, y, width, height);
   }
 

--- a/lively.graphics/geometry-2d.js
+++ b/lively.graphics/geometry-2d.js
@@ -1,6 +1,19 @@
 import { num, string, grid } from 'lively.lang';
 import { cssLengthToPixels } from './convert-css-length.js';
 
+export function rect (arg1, arg2, arg3, arg4) {
+  // arg1 and arg2 can be location and corner or
+  // arg1/arg2 = location x/y and arg3/arg4 = extent x/y
+  let x, y, w, h;
+  if (typeof arg1 === 'number') {
+    x = arg1, y = arg2, w = arg3, h = arg4;
+  } else {
+    x = arg1.x; y = arg1.y;
+    w = arg2.x - x; h = arg2.y - y;
+  }
+  return new Rectangle(x, y, w, h); // eslint-disable-line no-use-before-define
+}
+
 export class Point {
   static ensure (duck) {
     return (duck && duck.isPoint)
@@ -19,10 +32,10 @@ export class Point {
   }
 
   static fromLiteral (literal) {
-    return pt(literal.x, literal.y);
+    return new Point(literal.x, literal.y);
   }
 
-  static fromTuple (tuple) { return pt(tuple[0], tuple[1]); }
+  static fromTuple (tuple) { return new Point(tuple[0], tuple[1]); }
 
   constructor (x, y) {
     this.x = x || 0;
@@ -99,20 +112,20 @@ export class Point {
   }
 
   eqPt (p) {
-    return this.x == p.x && this.y == p.y;
+    return this.x === p.x && this.y === p.y;
   }
 
   equals (p) {
-    return this.x == p.x && this.y == p.y;
+    return this.x === p.x && this.y === p.y;
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // instance creation
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-  withX (x) { return pt(x, this.y); }
+  withX (x) { return new Point(x, this.y); }
 
-  withY (y) { return pt(this.x, y); }
+  withY (y) { return new Point(this.x, y); }
 
   copy () { return new Point(this.x, this.y); }
 
@@ -137,12 +150,12 @@ export class Point {
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   normalized () {
     const r = this.r();
-    return pt(this.x / r, this.y / r);
+    return new Point(this.x / r, this.y / r);
   }
 
   fastNormalized () {
     const r = this.fastR();
-    return pt(this.x / r, this.y / r);
+    return new Point(this.x / r, this.y / r);
   }
 
   dotProduct (p) {
@@ -153,18 +166,18 @@ export class Point {
     const x = mx.a * this.x + mx.c * this.y + mx.e;
     const y = mx.b * this.x + mx.d * this.y + mx.f;
     // if no accumulator passed, allocate a fresh one
-    return !acc ? pt(x, y) : Object.assign(acc, { x, y });
+    return !acc ? new Point(x, y) : Object.assign(acc, { x, y });
   }
 
   matrixTransformDirection (mx, acc) {
     const x = mx.a * this.x + mx.c * this.y;
     const y = mx.b * this.x + mx.d * this.y;
     // if no accumulator passed, allocate a fresh one
-    return !acc ? pt(x, y) : Object.assign(acc, { x, y });
+    return !acc ? new Point(x, y) : Object.assign(acc, { x, y });
   }
 
   griddedBy (grid) {
-    return pt(this.x - (this.x % grid.x), this.y - (this.y % grid.y));
+    return new Point(this.x - (this.x % grid.x), this.y - (this.y % grid.y));
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -187,18 +200,18 @@ export class Point {
   }
 
   nearestPointOnLineBetween (p1, p2) {
-    if (p1.x == p2.x) return pt(p1.x, this.y);
-    if (p1.y == p2.y) return pt(this.x, p1.y);
+    if (p1.x === p2.x) return new Point(p1.x, this.y);
+    if (p1.y === p2.y) return new Point(this.x, p1.y);
     const x1 = p1.x;
     const y1 = p1.y;
     const x21 = p2.x - x1;
     const y21 = p2.y - y1;
     const t = (((this.y - y1) / x21) + ((this.x - x1) / y21)) / ((x21 / y21) + (y21 / x21));
-    return pt(x1 + (t * x21), y1 + (t * y21));
+    return new Point(x1 + (t * x21), y1 + (t * y21));
   }
 
   interpolate (i, p, transformLinear = true) {
-    if (transformLinear) return pt(num.interpolate(i, this.x, p.x), num.interpolate(i, this.y, p.y));
+    if (transformLinear) return new Point(num.interpolate(i, this.x, p.x), num.interpolate(i, this.y, p.y));
     return Point.polar(num.interpolate(i, this.r(), p.r()), num.interpolate(i, this.theta(), p.theta()));
   }
 
@@ -224,13 +237,13 @@ export class Point {
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // converting
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-  asRectangle () { return new Rectangle(this.x, this.y, 0, 0); }
+  asRectangle () { return new Rectangle(this.x, this.y, 0, 0); } // eslint-disable-line no-use-before-define
 
-  extent (ext) { return new Rectangle(this.x, this.y, ext.x, ext.y); }
+  extent (ext) { return new Rectangle(this.x, this.y, ext.x, ext.y); } // eslint-disable-line no-use-before-define
 
-  extentAsRectangle () { return new Rectangle(0, 0, this.x, this.y); }
+  extentAsRectangle () { return new Rectangle(0, 0, this.x, this.y); } // eslint-disable-line no-use-before-define
 
-  lineTo (end) { return new Line(this, end); }
+  lineTo (end) { return new Line(this, end); } // eslint-disable-line no-use-before-define
 
   toTuple () { return [this.x, this.y]; }
 
@@ -296,14 +309,14 @@ export class Rectangle {
     if (typeof element.getBoundingClientRect === 'function') {
       const b = element.getBoundingClientRect();
       return rect(b.left, b.top, b.width, b.height);
-    } else if (element.namespaceURI == 'http://www.w3.org/1999/xhtml') {
+    } else if (element.namespaceURI === 'http://www.w3.org/1999/xhtml') {
       const x = cssLengthToPixels(element.style.left || '0px');
       const y = cssLengthToPixels(element.style.top || '0px');
       const width = cssLengthToPixels(element.style.width || '0px');
       const height = cssLengthToPixels(element.style.hieght || '0px');
       return new Rectangle(x, y, width, height);
     }
-    if (element.namespaceURI == 'http://www.w3.org/2000/svg') {
+    if (element.namespaceURI === 'http://www.w3.org/2000/svg') {
       return new Rectangle(element.x.baseVal.value, element.y.baseVal.value,
         element.width.baseVal.value, element.height.baseVal.value);
     }
@@ -459,7 +472,7 @@ export class Rectangle {
     if (!other) {
       return false;
     }
-    return this.x == other.x && this.y == other.y && this.width == other.width && this.height == other.height;
+    return this.x === other.x && this.y === other.y && this.width === other.width && this.height === other.height;
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -510,13 +523,13 @@ export class Rectangle {
     return new Point(this.x + (this.width / 2), this.y + (this.height / 2));
   }
 
-  topEdge () { return new Line(this.topLeft(), this.topRight()); }
+  topEdge () { return new Line(this.topLeft(), this.topRight()); } // eslint-disable-line no-use-before-define
 
-  bottomEdge () { return new Line(this.bottomLeft(), this.bottomRight()); }
+  bottomEdge () { return new Line(this.bottomLeft(), this.bottomRight()); } // eslint-disable-line no-use-before-define
 
-  leftEdge () { return new Line(this.topLeft(), this.bottomLeft()); }
+  leftEdge () { return new Line(this.topLeft(), this.bottomLeft()); } // eslint-disable-line no-use-before-define
 
-  rightEdge () { return new Line(this.topRight(), this.bottomRight()); }
+  rightEdge () { return new Line(this.topRight(), this.bottomRight()); } // eslint-disable-line no-use-before-define
 
   edges () {
     return [this.topEdge(),
@@ -527,12 +540,12 @@ export class Rectangle {
 
   allPoints () {
     // take rectangle as discrete grid and return all points in the grid
-    // rect(3,4,2,3).allPoints() == [pt(3,4),pt(4,4),pt(3,5),pt(4,5),pt(3,6),pt(4,6)]
+    // rect(3,4,2,3).allPoints() === [pt(3,4),pt(4,4),pt(3,5),pt(4,5),pt(3,6),pt(4,6)]
     // if you want to convert points to indices use
-    // var w = 5, h = 7; rect(3,4,2,3).allPoints().map(function(p) { return p.y * w + p.x; }) == [23,24,28,29,33,34]
+    // const w = 5, h = 7; rect(3,4,2,3).allPoints().map(function(p) { return p.y * w + p.x; }) === [23,24,28,29,33,34]
     const x = this.x; const y = this.y; const w = this.width; const h = this.height; const points = [];
     for (let j = y; j < y + h; j++) {
-      for (let i = x; i < x + w; i++) { points.push(pt(i, j)); }
+      for (let i = x; i < x + w; i++) { points.push(new Point(i, j)); }
     }
     return points;
   }
@@ -669,7 +682,7 @@ export class Rectangle {
 
   closestPointToPt (p) {
     // Assume p lies outside me; return a point on my perimeter
-    return pt(Math.min(Math.max(this.x, p.x), this.maxX()), Math.min(Math.max(this.y, p.y), this.maxY()));
+    return new Point(Math.min(Math.max(this.x, p.x), this.maxX()), Math.min(Math.max(this.y, p.y), this.maxY()));
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -698,7 +711,7 @@ export class Rectangle {
   }
 
   randomPoint () {
-    return Point.random(pt(this.width, this.height)).addPt(this.topLeft());
+    return Point.random(new Point(this.width, this.height)).addPt(this.topLeft());
   }
 
   constrainPt (pt) {
@@ -737,7 +750,6 @@ export class Rectangle {
   }
 
   toAttributeValue (d) {
-    var d = 0.01;
     let result = [this.left()];
     if (this.top() === this.bottom() && this.left() === this.right()) {
       if (this.top() === this.left()) result.push(this.top());
@@ -771,12 +783,13 @@ export class Rectangle {
 
   partNameNearest (partNames, p) {
     let dist = 1.0e99;
-    var partName = partNames[0];
+    let partName = partNames[0];
 
+    let nearest;
     for (let i = 0; i < partNames.length; i++) {
-      var partName = partNames[i];
+      partName = partNames[i];
       const pDist = p.dist(this.partNamed(partName));
-      if (pDist < dist) { var nearest = partName; dist = pDist; }
+      if (pDist < dist) { nearest = partName; dist = pDist; }
     }
 
     return nearest;
@@ -814,8 +827,7 @@ export class Transform {
       if (translation.isPoint) {
         const delta = translation;
         const angleInRadians = rotation || 0.0;
-        var scale = scale;
-        if (scale === undefined) { scale = pt(1.0, 1.0); }
+        if (scale === undefined) { scale = new Point(1.0, 1.0); }
         this.a = this.ensureNumber(scale.x * Math.cos(angleInRadians));
         this.b = this.ensureNumber(scale.y * Math.sin(angleInRadians));
         this.c = this.ensureNumber(scale.x * -Math.sin(angleInRadians));
@@ -879,10 +891,10 @@ export class Transform {
     const r = Math.atan2(-c, a); // radians
     // avoid div by 0
     const sy = (Math.abs(b) > Math.abs(d)) ? b / Math.sin(r) : d / Math.cos(r);
-    return pt(sx, sy);
+    return new Point(sx, sy);
   }
 
-  getTranslation () { return pt(this.e, this.f); }
+  getTranslation () { return new Point(this.e, this.f); }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // testing
@@ -890,7 +902,7 @@ export class Transform {
   isTranslation () {
     // as specified in:
     // http://www.w3.org/TR/SVG11/coords.html#InterfaceSVGTransform
-    return (this.a == 1 && this.b == 0 && this.c == 0 && this.d == 1);
+    return (this.a === 1 && this.b === 0 && this.c === 0 && this.d === 1);
   }
 
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -902,8 +914,8 @@ export class Transform {
     const theta = this.getRotation();
     const sp = this.getScalePoint();
 
-    if (theta != 0.0) attr += ' rotate(' + this.getRotation() + ')'; // in degrees
-    if (sp.x != 1.0 || sp.y != 1.0) attr += ' scale(' + sp.x + ',' + sp.y + ')';
+    if (theta !== 0.0) attr += ' rotate(' + this.getRotation() + ')'; // in degrees
+    if (sp.x !== 1.0 || sp.y !== 1.0) attr += ' scale(' + sp.x + ',' + sp.y + ')';
 
     return attr;
   }
@@ -915,26 +927,26 @@ export class Transform {
 
     if (bounds) {
       // FIXME this is to fix the rotation...!
-      var offsetX = bounds.width / 2;
-      var offsetY = bounds.height / 2;
+      let offsetX = bounds.width / 2;
+      let offsetY = bounds.height / 2;
       attr += ' translate(' + offsetX.toFixed(2) + 'px,' + offsetY.toFixed(2) + 'px)';
     }
 
     const theta = this.getRotation();
-    if (theta != 0.0) {
+    if (theta !== 0.0) {
       attr += ' rotate(' +
         this.getRotation().toFixed(2) + 'deg)';
     }
 
     if (bounds) {
       // FIXME this is to fix the rotation...!
-      var offsetX = bounds.width / 2;
-      var offsetY = bounds.height / 2;
+      const offsetX = bounds.width / 2;
+      const offsetY = bounds.height / 2;
       attr += ' translate(' + (offsetX * -1).toFixed(2) + 'px,' + (offsetY * -1).toFixed(2) + 'px)';
     }
 
     const sp = this.getScalePoint();
-    if (sp.x != 1.0 || sp.y != 1.0) {
+    if (sp.x !== 1.0 || sp.y !== 1.0) {
       attr += ' scale(' + sp.x.toFixed(2) + ',' + sp.y.toFixed(2) + ')';
     }
 
@@ -969,8 +981,8 @@ export class Transform {
   }
 
   transformRectToRect (r) {
-    const minPt = pt(Infinity, Infinity);
-    const maxPt = pt(-Infinity, -Infinity);
+    const minPt = new Point(Infinity, Infinity);
+    const maxPt = new Point(-Infinity, -Infinity);
     this.matrixTransformForMinMax(r.topLeft(), minPt, maxPt);
     this.matrixTransformForMinMax(r.bottomRight(), minPt, maxPt);
     if (!this.isTranslation()) {
@@ -1042,7 +1054,7 @@ export class Transform {
 
 export class Line {
   static fromCoords (startX, startY, endX, endY) {
-    return new Line(pt(startX, startY), pt(endX, endY));
+    return new Line(new Point(startX, startY), new Point(endX, endY));
   }
 
   constructor (start, end) {
@@ -1159,7 +1171,7 @@ export class Line {
       !num.between(y, y3, y4, eps)) return null;
     }
 
-    return pt(x, y);
+    return new Point(x, y);
   }
 
   perpendicularLine (relPos = 0, magn = 1, rot = 'cc'/* c-clockwise, cc-counterclockwise */) {
@@ -1193,19 +1205,6 @@ export class Line {
       bindings: { 'lively.graphics/geometry-2d.js': ['Line'] }
     };
   }
-}
-
-export function rect (arg1, arg2, arg3, arg4) {
-  // arg1 and arg2 can be location and corner or
-  // arg1/arg2 = location x/y and arg3/arg4 = extent x/y
-  let x, y, w, h;
-  if (typeof arg1 === 'number') {
-    x = arg1, y = arg2, w = arg3, h = arg4;
-  } else {
-    x = arg1.x; y = arg1.y;
-    w = arg2.x - x; h = arg2.y - y;
-  }
-  return new Rectangle(x, y, w, h);
 }
 
 export function pt (x, y) { return new Point(x, y); }

--- a/lively.ide/js/linter.js
+++ b/lively.ide/js/linter.js
@@ -93,7 +93,8 @@ const rules = {
   'no-const-assign': 'warn',
   'no-unused-vars': ['warn', { args: 'none', varsIgnorePattern: '_' }],
   'no-use-before-define': ['error', { functions: true, classes: true, variables: true }],
-  'no-constructor-return': 'error'
+  'no-constructor-return': 'error',
+  'no-console': 'warn'
 };
 
 config.rules = rules;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -499,7 +499,7 @@ const commands = [
 
       if (!win) return;
 
-      const worldB = world.visibleBoundsExcludingTopBar().insetBy(15);
+      const worldB = world.visibleBoundsExcludingTopBar().insetBy(40);
       const winB = win.bounds();
       // FIXME!
       if (!win._normalBounds) win._normalBounds = winB;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -499,7 +499,7 @@ const commands = [
 
       if (!win) return;
 
-      const worldB = world.visibleBoundsExcludingTopBar().insetBy(40);
+      const worldB = world.visibleBoundsExcludingStudioInterface().insetBy(40);
       const winB = win.bounds();
       // FIXME!
       if (!win._normalBounds) win._normalBounds = winB;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -508,10 +508,10 @@ const commands = [
       const thirdW = Math.min(thirdWMin, Math.max(1000, worldB.width / 3));
       const thirdColBounds = worldB.withWidth(thirdW);
 
-      if (!how) how = await askForHow();
+      if (!how) how = await askForHow(); // eslint-disable-line no-use-before-define
       if (!how) return;
 
-      win.setBounds(resizeBounds(how, worldB));
+      win.setBounds(resizeBounds(how, worldB)); // eslint-disable-line no-use-before-define
       if (how === 'reset') delete win._normalBounds;
 
       return true;
@@ -704,14 +704,14 @@ const commands = [
 
       let { a = '', b = '', format = null, extent = pt(500, 600) } = opts;
       if (!format) {
-        ({ a, b, format } = findFormat(a, b));
+        ({ a, b, format } = findFormat(a, b)); // eslint-disable-line no-use-before-define
       } else { a = String(a); b = String(b); }
 
       const diff = await System.import('esm://cache/diff@5.0.0');
 
       let diffed;
 
-      diffed = await diffInWindow(a, b, { fontFamily: 'monospace', ...opts, format });
+      diffed = await diffInWindow(a, b, { fontFamily: 'monospace', ...opts, format }); // eslint-disable-line no-use-before-define
 
       function findFormat (a, b) {
         if (obj.isPrimitive(a) || a instanceof RegExp ||
@@ -767,12 +767,12 @@ const commands = [
         editors = world.withAllSubmorphsSelect(ea =>
           ea.isText && !ea.isInputLine && !ea.isUsedAsEpiMorph()).reverse();
       }
-      if (!editor1) editor1 = await selectMorph(editors);
+      if (!editor1) editor1 = await selectMorph(editors); // eslint-disable-line no-use-before-define
       if (!editor1) return world.setStatusMessage('Canceled');
-      if (!editor2) editor2 = await selectMorph(arr.without(editors, editor1));
+      if (!editor2) editor2 = await selectMorph(arr.without(editors, editor1)); // eslint-disable-line no-use-before-define
       if (!editor2) return world.setStatusMessage('Canceled');
 
-      return doDiff(editor1, editor2);
+      return doDiff(editor1, editor2); // eslint-disable-line no-use-before-define
 
       function doDiff (ed1, ed2) {
         const p1 = ed1.pluginFind(ea => ea.evalEnvironment);
@@ -810,8 +810,8 @@ const commands = [
           listPrompt.getSubmorphNamed('list').updateFilter = function () {
             const parsed = this.parseInput();
             if (parsed.input.length < 3) return;
-            const morphs = findWindowOrMorphWithStrings(parsed.lowercasedTokens);
-            this.listMorph.items = morphsToCandidates(morphs, parsed.lowercasedTokens);
+            const morphs = findWindowOrMorphWithStrings(parsed.lowercasedTokens); // eslint-disable-line no-use-before-define
+            this.listMorph.items = morphsToCandidates(morphs, parsed.lowercasedTokens); // eslint-disable-line no-use-before-define
           };
         }
       });

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -111,6 +111,21 @@ export class LivelyWorld extends World {
     }
   }
 
+  visibleBoundsExcludingStudioInterface () {
+    const boundsExcludingTopBar = this.visibleBoundsExcludingTopBar();
+    const sideBars = this.activeSideBars;
+    let bounds = boundsExcludingTopBar;
+    if (sideBars.includes('scene graph')) {
+      const sceneGraph = this.get('scene graph');
+      bounds = pt(bounds.x + sceneGraph.width, bounds.y).extent(pt(bounds.width - sceneGraph.width, bounds.height));
+    }
+    if (sideBars.includes('properties panel')) {
+      const propertiesPanel = this.get('properties panel');
+      bounds = pt(bounds.x, bounds.y).extent(pt(bounds.width - propertiesPanel.width, bounds.height));
+    }
+    return bounds;
+  }
+
   makeDirty () {
     if (!this.renderingState.needsRerender && this.get('world mini map')) {
       this.get('world mini map').drawMorphs();

--- a/lively.morphic/rendering/property-dom-mapping.js
+++ b/lively.morphic/rendering/property-dom-mapping.js
@@ -28,7 +28,8 @@ const propsToDelete = [
   'margin-right',
   'grid-template-rows',
   'grid-template-columns',
-  'will-change'
+  'will-change',
+  'filter'
 ];
 
 /**


### PR DESCRIPTION
Closes #620.

![fixed_window_switcher](https://user-images.githubusercontent.com/14252419/214651234-ced615a7-e5ff-4011-83ab-f384b30deff7.gif)

Also fixes a problem where windows would change their position/bounds when being minimized/uncollapsed.
![fixed_minimization](https://user-images.githubusercontent.com/14252419/214651351-f78876e7-abda-4121-9102-edf27697cac8.gif)

Resizing windows with the left and top resizers will no longer result in changed positions or bounds.
![fixed_resizing](https://user-images.githubusercontent.com/14252419/214651457-de6100f3-1379-43ed-8ffe-227d9073aa09.gif)

Maximizing windows will now behave smarter. When a window is maximized (double click on the window title) and is currently not displayed in fullscreen, it will go into fullscreen. Double clicking a window that is displayed in full screen will change its position and extent back to the last values **before** the window was displayed in fullscreen.
![improved_maximization](https://user-images.githubusercontent.com/14252419/214651746-bcfeb5f9-572d-4f9f-aa05-15b10bc4a023.gif)


