### PR TITLE
🎨: only add text specific commands for interactive texts

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -1579,6 +1579,7 @@ export class Text extends Morph {
   }
 
   get commands () {
+    if (!(this.document && this.textLayout)) return [];
     return this.pluginCollect('getCommands', (this._commands || []).concat(commands));
   }
 


### PR DESCRIPTION
Closes #627.

When going through the list of commands that are available on `Text`, it turned out, that they all only really make sense when one has an editable morph at ones hand. We briefly thought about extracting the commands into an EditorPlugin or the base EditorPlugin, but since the whole editing of `Text` is implemented via commands, and we have things like the world naming input line which require editing but do not have any plugin, and we did not want to have an IDE dependency to a new plugin in the text morph, we opted for this solution.