### PR TITLE
🎨: avoid incorrect scroll layer adjustment request in text morphs

### DIFF
--- a/lively.morphic/env.js
+++ b/lively.morphic/env.js
@@ -254,7 +254,12 @@ export class MorphicEnv {
     return requestState.promise;
   }
 
-  forceUpdate () {
-    if (this.renderer) this.renderer.renderStep();
+  forceUpdate (aMorph) {
+    if (!this.renderer) return;
+    if (aMorph && !this.renderer.renderMap.has(aMorph)) {
+      this.renderer.renderMorph(aMorph, true, true);
+      return;
+    }
+    this.renderer.renderStep();
   }
 }

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -281,7 +281,10 @@ export default class Renderer {
     applyAttributesToNode(morph, node);
     applyStylingToNode(morph, node);
 
-    if (morph.submorphs.length === 0) return node;
+    if (morph.submorphs.length === 0) {
+      if (immediatePatchSpecialProps) morph.patchSpecialProps && morph.patchSpecialProps(node, this);
+      return node;
+    }
 
     const skipWrapping = morph.layout && morph.layout.renderViaCSS;
 
@@ -289,7 +292,7 @@ export default class Renderer {
       this.installWrapperNodeFor(morph, node);
     }
 
-    if (immediatePatchSpecialProps) morph.patchSpecialProps && morph.patchSpecialProps(node);
+    if (immediatePatchSpecialProps) morph.patchSpecialProps && morph.patchSpecialProps(node, this);
     morph.renderingState.hasStructuralChanges = true;
     return node;
   }

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -257,6 +257,7 @@ export class Text extends Morph {
         group: 'text',
         defaultValue: true,
         isStyleProp: true,
+        after: ['borderWidth', 'borderColor', 'borderRadius', 'borderStyle'],
         set (readOnly) {
           if (!readOnly) {
             this.backedUpSelectionMode = this.selectionMode;
@@ -283,6 +284,7 @@ export class Text extends Morph {
 
       needsDocument: {
         defaultValue: false,
+        after: ['borderWidth', 'borderStyle', 'borderColor', 'borderRadius'],
         set (needsDocument) {
           if (needsDocument) {
             this.backWithDocument();
@@ -2144,9 +2146,11 @@ export class Text extends Morph {
     this.renderingState.needsScrollLayerAdded = true;
     this.renderingState.needsLinesToBeCleared = true;
     this._isUpgrading = false;
-    if (this.env.renderer) { this.env.forceUpdate(); } else {
+    if (this.env.renderer) {
+      this.env.forceUpdate(this);
+    } else {
       this.whenEnvReady().then(() => {
-        this.env.forceUpdate();
+        this.env.forceUpdate(this);
       });
     }
   }


### PR DESCRIPTION
Fixes an issue, where creating an input line would cause a crash of the renderer like so: `part(InputLineDefault, { readOnly: true, needsDocument: false }).openInWorld();`