### PR TITLE
Fix/css layout measure

### DIFF
--- a/lively.ide/studio/controls/body.cp.js
+++ b/lively.ide/studio/controls/body.cp.js
@@ -323,7 +323,7 @@ export class DynamicPropertyModel extends ViewModel {
       beacuse the vdom has not yet rendered the layout and we can not determine the
       total height via measuring. This will be gone once we move away from the vdom issue.
     */
-    p.height = 25;
+    p.env.forceUpdate(p);
     p.topRight = this.view.globalBounds().topLeft();
     p.topLeft = this.world().visibleBounds().translateForInclusion(p.globalBounds()).topLeft();
     once(p, 'remove', this, 'closePopup');

--- a/lively.morphic/env.js
+++ b/lively.morphic/env.js
@@ -256,7 +256,7 @@ export class MorphicEnv {
 
   forceUpdate (aMorph) {
     if (!this.renderer) return;
-    if (aMorph && !this.renderer.renderMap.has(aMorph)) {
+    if (aMorph && !aMorph.owner && !this.renderer.renderMap.has(aMorph)) {
       this.renderer.renderMorph(aMorph, true, true);
       return;
     }

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -746,7 +746,7 @@ export class TilingLayout extends Layout {
   updateBoundsFor (morph) {
     morph.renderingState.cssLayoutToMeasureWith = null;
     const node = this.getNodeFor(morph);
-    if (node) {
+    if (node && node.parentNode) {
       if (morph === this.container) {
         this.updateContainerViaDom(node);
       } else { this.updateSubmorphViaDom(morph, node); }


### PR DESCRIPTION
Fixes an issue where the bounds of morphs resized via their would not be properly updated in time of their first render.
Fixed morphs were especially prone to this issue as reported in #598.