### PR TITLE
Fix/window switcher quirks

### DIFF
--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -1,5 +1,5 @@
 import { component, ShadowObject, Icon, Ellipse, Text, easings, part, TilingLayout, HTMLMorph, ViewModel } from 'lively.morphic';
-import { Color, rect, pt } from 'lively.graphics';
+import { Color, Rectangle, rect, pt } from 'lively.graphics';
 import { InputLineDark } from 'lively.components/inputs.cp.js';
 
 class WindowPreviewModel extends ViewModel {
@@ -45,6 +45,8 @@ class WindowPreviewModel extends ViewModel {
     if (evt.targetMorph === this.ui.closeButton) return;
     this.windowSwitcher.close();
     this.window.activate(null, true);
+    const translatedPos = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.window.bounds()).topLeft();
+    this.window.topLeft = translatedPos;
   }
 
   onHoverIn () {

--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -92,7 +92,13 @@ const WindowPreview = component({
     extent: pt(100, 100),
     fill: Color.transparent
   },
-  { name: 'overlay', fill: Color.transparent, extent: pt(130, 130), nativeCursor: 'pointer' },
+  {
+    name: 'overlay',
+    fill: Color.transparent,
+    extent: pt(130, 130),
+    halosEnabled: false,
+    nativeCursor: 'pointer'
+  },
   {
     name: 'close button',
     type: Ellipse,

--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -234,6 +234,7 @@ class WindowSwitcherModel extends ViewModel {
     if (this.reopenPropertiesPanel) $world.propertiesPanelFlap.executeAction();
     this.view.remove();
     $world.blur = 0;
+    $world.focus();
   }
 
   get keybindings () {

--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -55,6 +55,7 @@ class WindowPreviewModel extends ViewModel {
     });
     this.ui.htmlMorph.animate({
       scale: 1.2,
+      center: this.ui.htmlMorph.center,
       duration: 200,
       easing: easings.inOut
     });
@@ -71,6 +72,7 @@ class WindowPreviewModel extends ViewModel {
     });
     this.ui.htmlMorph.animate({
       scale: 1,
+      center: this.ui.htmlMorph.center,
       duration: 200,
       easing: easings.inOut
     });
@@ -294,7 +296,8 @@ export const WindowSwitcher = component({
       fill: Color.transparent,
       reactsToPointer: false,
       layout: new TilingLayout({
-        wrapSubmorphs: true
+        wrapSubmorphs: true,
+        padding: Rectangle.inset(10, 10, 10, 10)
       }),
       clipMode: 'auto',
       halosEnabled: false

--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -106,6 +106,7 @@ const WindowPreview = component({
     extent: pt(20, 20),
     fill: Color.black.withA(0.6),
     halosEnabled: false,
+    nativeCursor: 'pointer',
     submorphs: [{
       type: 'text',
       reactsToPointer: false,


### PR DESCRIPTION
Fixes several issues with the windows switcher such as:
1. accidental halo on the preview overlays.
2. scaling the previews on hover now happens with respect to the center of the preview.
3. shadows of previews used to be cropped by the enclosing preview container.