### PR TITLE
❄️: skip transpiling JSON served from esm cdn

### DIFF
--- a/lively.freezer/index.js
+++ b/lively.freezer/index.js
@@ -186,7 +186,7 @@ export async function bundlePart (partOrSnapshot, {
   const bundle = await rollup({
     plugins: [
       freezerPlugin,
-      jsonPlugin()
+      jsonPlugin({ exclude: /esm\:\/\/cache\/.*\.json/ })
     ]
   });
   return await bundle.generate({
@@ -223,7 +223,7 @@ export async function bundleModule (moduleId, {
         resolver: BrowserResolver,
         autoRun: htmlConfig
       }),
-      jsonPlugin()
+      jsonPlugin({ exclude: /esm\:\/\/cache\/.*\.json/ })
     ]
   });
   return await bundle.generate({
@@ -242,7 +242,7 @@ export async function jspmCompile (url, out, globalName, redirect = {}) {
     input: url,
     plugins: [
       freezerPlugin,
-      jsonPlugin()
+      jsonPlugin({ exclude: /esm\:\/\/cache\/.*\.json/ })
     ]
   });
   await bundle.generate({
@@ -261,7 +261,7 @@ export async function bootstrapLibrary (url, out, asBrowserModule = true, global
         resolver: BrowserResolver,
         excludedModules: ['babel-plugin-transform-jsx']
       }),
-      jsonPlugin()
+      jsonPlugin({ exclude: /esm\:\/\/cache\/.*\.json/ })
     ]
   });
   await bundle.generate({


### PR DESCRIPTION
Fixes an issue where JSONs served from `jspm.dev` would cause errors in the rollup pipeline since the CDN already serves them pre-transpiled. Also related to #678.