### PR TITLE
🔁: replace outdated rest-spread plugin, add optional-chaining transpile

### DIFF
--- a/lively.source-transform/index.js
+++ b/lively.source-transform/index.js
@@ -68,7 +68,8 @@ export function es5Transpilation (source) {
     presets: [['es2015', { modules: false }]],
     plugins: [
       'transform-exponentiation-operator', 'transform-async-to-generator',
-      'syntax-object-rest-spread', 'transform-object-rest-spread'
+      'syntax-object-rest-spread', 'proposal-object-rest-spread',
+      'proposal-optional-chaining'
       // 'syntax-import-meta', 'optional-catch-binding',
       // ['transform-jsx', { "module": 'lively.ide/jsx/generator.js'}]
     ],


### PR DESCRIPTION
Fixes another issue related to #678. Transpilation in lively.next is pretty much all over the place now, but I wont get to that until I will have a chance to revisit the SystemJS6 upgrade project is underway. In the meantime this will squash the errors.