### PR TITLE
🧰📠: properly take into account the ignored files defined in package.json

### DIFF
--- a/lively-system-interface/interfaces/local-system.js
+++ b/lively-system-interface/interfaces/local-system.js
@@ -113,10 +113,11 @@ export class LocalCoreInterface extends AbstractCoreInterface {
     try {
       const url = packageOrAddress.address ? packageOrAddress.address : packageOrAddress;
       const p = modules.getPackage(url);
-      return (await p.resources(undefined, exclude))
+
+      return (await p.resources(undefined, [...exclude, ...p.lively?.ide?.exclude || []]))
         .map(ea => Object.assign(ea, { package: ea.package.url }));
     } catch (e) {
-      console.warn(`resourcesOfPackage error for ${packageOrAddress}: ${e}`);
+      console.warn(`resourcesOfPackage error for ${packageOrAddress}: ${e}`); // eslint-disable-line no-console
       return [];
     }
   }
@@ -173,7 +174,6 @@ export class LocalCoreInterface extends AbstractCoreInterface {
       ? ast.parse(sourceOrAstOrNothing)
       : sourceOrAstOrNothing;
     const id = this.normalizeSync(moduleName);
-    const format = this.moduleFormat(id);
     const scope = modules.module(id).env().recorder;
     const importsExports = await this.importsAndExportsOf(id, parsed);
 

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -392,7 +392,6 @@ export class PackageTreeData extends TreeData {
 
   async getLoadedModuleUrls () {
     const selectedPkg = this.root.subNodes.find(pkg => !pkg.isCollapsed);
-    // this is super slow. Fix me!
     const files = await this.systemInterface.resourcesOfPackage(selectedPkg.url, ['assets', 'objectdb', '.git']);
     await this.systemInterface.getPackage(selectedPkg.url);
     const loadedModules = {};


### PR DESCRIPTION
Ignored packages as defined in the package json where no longer properly adhered by the system interface.
This lead to performance issues when browsing packages with huge ignored directories (i.e. lively.freezer).