### PR TITLE
🎨: fix initializing of text with hidden scrollbars

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -2753,11 +2753,11 @@ export class Text extends Morph {
       const scrollLayer = node.querySelector('.scrollLayer');
 
       if (this.hideScrollbars) {
-        scrollWrapper.classList.add('hiddenScrollbar');
-        scrollLayer.classList.add('hiddenScrollbar');
+        scrollWrapper?.classList.add('hiddenScrollbar');
+        scrollLayer?.classList.add('hiddenScrollbar');
       } else {
-        scrollWrapper.classList.remove('hiddenScrollbar');
-        scrollLayer.classList.remove('hiddenScrollbar');
+        scrollWrapper?.classList.remove('hiddenScrollbar');
+        scrollLayer?.classList.remove('hiddenScrollbar');
       }
 
       this.renderingState.hideScrollbars = this.hideScrollbars;


### PR DESCRIPTION
Previously, it was possible that `patchSpecialProps` was executed before the scrollLayer and scrollWrapper were initialized and thus the renderer would silently fail.