### PR TITLE
Enhancement/selection optimizations

### DIFF
--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1682,7 +1682,7 @@ export default class Renderer {
    * @param {Text} morph - The Text which selections were changed.
    */
   patchSelectionLayer (node, morph) {
-    if (!node) return;
+    if (!node || !node.isConnected) return;
     node.querySelectorAll('div.newtext-cursor').forEach(c => c.remove());
     node.querySelectorAll('svg.selection').forEach(s => s.remove());
     const nodeToAppendTo = !morph.document ? node : node.querySelectorAll('.scrollWrapper')[0];

--- a/lively.morphic/text/layout.js
+++ b/lively.morphic/text/layout.js
@@ -192,7 +192,7 @@ export default class Layout {
 
   // FIXME: will always fail for morphs that are in label mode
   // i.e. that do not have a document
-  whatsVisible (morph) { 
+  whatsVisible (morph) {
     const startRow = morph.renderingState.firstVisibleRow;
     const endRow = morph.renderingState.lastVisibleRow;
     const lines = morph.document.lines.slice(startRow, endRow);
@@ -322,7 +322,6 @@ export default class Layout {
     }
 
     if (!bounds) {
-      // throw new Error(`Cannot compute bounds for line ${row}/${column}`);
       console.warn(`Cannot compute bounds for line ${row}/${column}`);
       bounds = new Rectangle(0, 0, 0, 0);
     }

--- a/lively.morphic/text/selection.js
+++ b/lively.morphic/text/selection.js
@@ -90,12 +90,14 @@ export class Selection {
     if (range.equals(this._range)) return;
 
     this._range = range;
+    if (!range.isEmpty()) {
     // next two ops are super expensive on deserialization
-    this._goalColumn = this.textMorph.lineWrapping
-      ? this.textMorph.columnInWrappedLine(this.lead)
-      : this.lead.column;
+      this._goalColumn = this.textMorph.lineWrapping
+        ? this.textMorph.columnInWrappedLine(this.lead)
+        : this.lead.column;
 
-    this._goalX = this.textMorph.charBoundsFromTextPosition(this.lead).x;
+      this._goalX = this.textMorph.charBoundsFromTextPosition(this.lead).x;
+    }
 
     this.startAnchor.position = range.start;
     this.endAnchor.position = range.end;


### PR DESCRIPTION
Currently, the console gets spammed with "Cannot compute bounds for line 0/0" **a lot**.
I found two of the worst offenders and squashed them.

In both cases, the problem were empty selections/ranges of empty selections, which tried calculating their bounds/positions. This requires the bounds measuring of the layout, which will only work properly when a morph is already rendered properly.

@merryman please test drive this before merging. Thanks.