### PR TITLE
🎨: wait for $world on ensureFont()

### DIFF
--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -586,6 +586,7 @@ function insertFontCSS (name, fontUrl) {
 export function ensureFont (addedFonts) {
   if (typeof $world === 'undefined') {
     // defer loading of fonts until world has been loaded
+    setTimeout(() => ensureFont(addedFonts), 100);
     return;
   }
   for (const name in addedFonts) {


### PR DESCRIPTION
Fixes an issue where `ensureFont()` would just terminate without loading the font if invoked before `$world` was initialized. (happens quite a bit in bundles).