### PR TITLE
🧰: update halos with deep targets on world scroll

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -304,6 +304,7 @@ export class LivelyWorld extends World {
         m.position = this.worldToScreen(m.positionOnCanvas);
       });
     });
+    this.halos().forEach(h => h.alignWithTarget()); // also update the nested ones
   }
 
   onMouseWheel (evt) {


### PR DESCRIPTION
Fixes a minor issue, where halos that were focusing on nested morphs were not getting realigned if the world was scrolled.