### PR TITLE
🎨: ensure non conflicting default names for morphs in policies

### DIFF
--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -62,6 +62,7 @@ export class ComponentDescriptor {
    */
   static extractSpec (generatorFunction) {
     morph.evaluateAsSpec = evaluateAsSpec = true;
+    morph.usedNames = new Set();
 
     let spec = {};
     try {
@@ -504,6 +505,8 @@ export class ViewModel {
  */
 export function part (componentDescriptor, overriddenProps = {}) {
   if (evaluateAsSpec) {
+    if (!overriddenProps.name && morph.usedNames.has(componentDescriptor.stylePolicy.name)) overriddenProps.name = string.newUUID();
+    morph.usedNames.add(componentDescriptor.stylePolicy.name);
     return componentDescriptor.extend(overriddenProps); // creates an abstract inline policy
   }
 

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1,4 +1,4 @@
-import { arr, tree, promise, obj } from 'lively.lang';
+import { arr, string, tree, promise, obj } from 'lively.lang';
 import { pt } from 'lively.graphics';
 import { morph, getStylePropertiesFor, getDefaultValueFor } from '../helpers.js';
 
@@ -120,6 +120,10 @@ export class StylePolicy {
    */
   get name () {
     return this.spec.name;
+  }
+
+  set name (s) {
+    this.spec.name = s;
   }
 
   /**
@@ -256,6 +260,8 @@ export class StylePolicy {
     };
     const ensureStylePoliciesInStandalone = (spec) => {
       return tree.mapTree(spec, (node, submorphs) => {
+        if (!node.name) { node.name = string.newUUID(); }
+        morph.usedNames.add(node.name);
         if (node.isPolicy) return node;
         if (node.master && node !== spec) {
           return new klass({ ...obj.dissoc(node, ['master']), submorphs }, node.master, false);

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -871,4 +871,22 @@ describe('components', () => {
     expect(m.get('holly').fill).to.eql(Color.red);
     expect(m.get('holly').getSubmorphNamed('alice').fill).to.eql(Color.lively);
   });
+
+  it('properly assigns custom generated names in case of a conflict', () => {
+    const C = ComponentDescriptor.for(() => component(c6, {
+      submorphs: [
+        add(
+          part(c1, {
+            submorphs: [add(part(c2)), add(part(c2))]
+          }), 'lively'
+        ),
+        add(part(c1), 'lively')
+      ]
+    }));
+    const m = part(C);
+    expect(m.submorphs[0].name).to.eql('c1');
+    expect(m.submorphs[1].name).not.to.eql('c1');
+    expect(m.submorphs[0].submorphs[0].name).to.eql('c2');
+    expect(m.submorphs[0].submorphs[1].name).not.to.eql('c2');
+  });
 });


### PR DESCRIPTION
Fixes issues that arose with component definitions that contained specs without a name property.
This fix will either carry over the name of the master component for that *anonymous* spec, or generate a UUID that will server as the default name, if needed.