### PR TITLE
🧰: move window into view that is selected in window switcher

### DIFF
--- a/lively.ide/window-switcher.cp.js
+++ b/lively.ide/window-switcher.cp.js
@@ -43,10 +43,14 @@ class WindowPreviewModel extends ViewModel {
 
   onMouseDown (evt) {
     if (evt.targetMorph === this.ui.closeButton) return;
-    this.windowSwitcher.close();
-    this.window.activate(null, true);
-    const translatedPos = this.world().visibleBoundsExcludingTopBar().translateForInclusion(this.window.bounds()).topLeft();
-    this.window.topLeft = translatedPos;
+    const { window, windowSwitcher } = this;
+    windowSwitcher.close();
+    window.activate(null, true);
+    const translatedPos = window.world()
+      .visibleBoundsExcludingTopBar()
+      .translateForInclusion(window.bounds())
+      .topLeft();
+    window.topLeft = translatedPos;
   }
 
   onHoverIn () {


### PR DESCRIPTION
This fixes an issue when moving between large and small displays (like unplugging your laptop from a large external display).
In those cases there may be numerous windows that are now outside of the window bounds. The window switcher is a great way to get a hold of those windows, but up till now would not move them into view once selected.
This fixes that.