### PR TITLE
🐳: fix docker-setup when running outside of a TTY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clear-esm-cache clear-headless-cache start install hooks docker-build docker-start docker-watch docker-bash docker-stop
+.PHONY: clear-esm-cache clear-headless-cache start install hooks docker-build-prepare docker-start docker-watch docker-bash docker-stop
 clear-esm-cache:
 	rm -rf esm_cache
 	mkdir esm_cache
@@ -13,21 +13,37 @@ start:
 hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks
 
-docker-build-only:
+docker-build-prepare:
 	# Builds the image our containers are based on, including all dependencies which are not installed via flatn
 	docker build -t lively:latest .
 	# Delete old lively.next container in case we previously had containers on this system
 	docker rm lively.next || true
-	# Mounts the lively root directory inside of a container and runs the install script, which installs flatns deps
-	# Using the host user and group id leads to correct permissions on files created inside of the container
-	# Fot not entirely clear reasons it is important that the absolute path to lively is the same on the host and inside of containers
-	# Otherwise, DAV dirLists might produce nonsense 
+
+# Mounts the lively root directory inside of a container and runs the install script, which installs flatns deps
+# Using the host user and group id leads to correct permissions on files created inside of the container
+# Fot not entirely clear reasons it is important that the absolute path to lively is the same on the host and inside of containers
+# Otherwise, DAV dirLists might produce nonsense.
+# Inside of CI, we need to ommit the -it flag, as its used to make the installation canceable with Strg+C, but this only works in TTYs.
+# However, CI does not provide one. 
+ifeq ($(GITHUB_ACTIONS),true)
+docker-install:
+	docker run -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --user $(shell id -u):$(shell id -g) lively:latest ./install.sh
+else
+docker-install:
 	docker run -it -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --user $(shell id -u):$(shell id -g) lively:latest ./install.sh
-	
+endif
+
+ifeq ($(GITHUB_ACTIONS),true)
+docker-build-start:
+	docker run -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --name lively.next --user $(shell id -u):$(shell id -g)  lively:latest ./start.sh
+else
 docker-build-start:
 	docker run -it -p 127.0.0.1:9011:9011 -v $(shell pwd):$(shell pwd):z -w $(shell pwd) --name lively.next --user $(shell id -u):$(shell id -g)  lively:latest ./start.sh
+endif
 
-docker-build: docker-build-only docker-build-start
+docker-build-only: docker-build-prepare docker-install
+
+docker-build: docker-build-prepare docker-install docker-build-start
 
 docker-start:
 	docker start lively.next

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clear-esm-cache clear-headless-cache start install hooks docker-build-prepare docker-start docker-watch docker-bash docker-stop
+.PHONY: clear-esm-cache clear-headless-cache start install hooks docker-build-prepare docker-start docker-watch docker-bash docker-stop loading-screen
 clear-esm-cache:
 	rm -rf esm_cache
 	mkdir esm_cache
@@ -9,6 +9,9 @@ clear-headless-cache:
 
 start:
 	./start.sh
+
+loading-screen:
+	env CI=true npm --prefix lively.freezer run build-loading-screen
 
 hooks:
 	git config --local core.hooksPath $(shell pwd)/.githooks


### PR DESCRIPTION
This caused the docker action we recently introduced to fail all the time, just because it ran inside of Github Actions.