### PR TITLE
🎛️: stop muller columns from stealing active text focus

### DIFF
--- a/lively.components/muller-columns.cp.js
+++ b/lively.components/muller-columns.cp.js
@@ -309,7 +309,8 @@ export class MullerColumnViewModel extends ViewModel {
   onMouseMove (evt) {
     const hoveredList = this.lists.find(list => list.fullContainsWorldPoint(evt.position));
     if (hoveredList) {
-      hoveredList.focus();
+      const win = this.view.getWindow();
+      if (!$world.focusedMorph.isText || win?.isActive()) hoveredList.focus();
       this.lists.forEach(list => {
         const control = list._managedNode && list._managedNode.listControl;
         if (control) {


### PR DESCRIPTION
Fixes a common issue where muller columns inside the system browser would steal the focus when hovered, while a text morph was still holding onto the focus in order to receive text input. I believe this is one of the main causes for unfocused filtered list prompts.

Should fix some of #668 