### PR TITLE
🎨: prevent undefined entries from entering props cache

### DIFF
--- a/lively.morphic/helpers.js
+++ b/lively.morphic/helpers.js
@@ -84,6 +84,7 @@ function getPropSettings (type) {
 }
 
 export function getStylePropertiesFor (type) {
+  if (typeof type === 'undefined') type = 'default';
   if (CachedStyleProperties.has(type)) return CachedStyleProperties.get(type);
   const { props, moduleId, order } = getPropSettings(type);
   const styleProps = [];


### PR DESCRIPTION
This prevents a particular case, where style specs without a type props would cause the style properties cache to be populated with `undefined` entries.