### PR TITLE
Improved Test Scripts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,4 +20,4 @@ jobs:
           chmod a+x ./install.sh
           ./install.sh
       - name: Run CI Test Script 
-        run:  ./scripts/ci-tests.sh
+        run:  ./scripts/tests.sh

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  Tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -20,4 +20,4 @@ jobs:
           chmod a+x ./install.sh
           ./install.sh
       - name: Run CI Test Script 
-        run:  ./scripts/tests.sh
+        run:  ./scripts/test.sh

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,85 +1,144 @@
 /*
 This script can be used to run the test in a selected package.
-Just pass the package as a parameter when executing this script (only one at a time).
-Example call of this script: `node test.js lively.morphic`.
 The script assumes that a lively server is running locally on port 9011.
-This script gets used by tests.sh.
+This script gets used by `test.sh`. To invoke tests, run `test.sh`.
+You should rarely (never) want to invoke this script here directly.
+
+This script suppots two "modes" of running tests, running them locally or inside of a GitHub Action.
+In the latter case, we use some special formatting hints for actions in our output and provide a markdown summary of failing tests
+to be rendered by GitHub.
+Since this script gets called by another shell script, that we need to run further, even if a test fails in here, we communicate some
+summary statistics and other information in the form of text files, that then get used in the outer shell script.
 */
 
-const http = require('http')
+const http = require('http');
+const fs = require('fs');
 
-const targetPackage = process.argv[2]
-let passed = 0, failed = 0, skipped = 0;
+const CI = !!process.env.CI;
 
-console.log(`::notice:: Tests for ${targetPackage} 📦`)
+const targetPackage = process.argv[2];
+let passed = 0; let failed = 0; let skipped = 0;
+let markdownListOfFailingTests = '';
+
+if (CI) {
+  console.log(`::notice:: Tests for ${targetPackage} 📦`);
+  fs.appendFileSync('summary.txt', `### Tests for ${targetPackage} 📦\n`);
+} else {
+  console.log(`🛈 Tests for ${targetPackage} 📦`);
+  console.log('');
+}
 const options = {
   hostname: 'localhost',
   port: 9011,
   path: '/subserver/TestRunner/' + targetPackage,
   method: 'GET'
-}
+};
 
 const req = http.request(options, res => {
-  data = ''
+  data = '';
   res.on('data', chunk => {
     data += chunk;
-  })
+  });
   res.on('end', () => {
     try {
-      data = JSON.parse(data)
+      data = JSON.parse(data);
       if (!Object.keys(data).length) {
-        console.log(`::notice:: ${targetPackage} does not contain any tests`);
+        if (CI) {
+          console.log(`::notice:: ${targetPackage} does not contain any tests`);
+        } else {
+          console.log(`🛈 ${targetPackage} does not contain any tests`);
+          fs.appendFileSync('summary.txt', `🛈 ${targetPackage} does not contain any tests.\n`);
+        }
+
         return;
       }
       if (data.error) {
-        console.log(`::error:: Running the tests produced the following error: ${JSON.stringify(data.error)}`);
+        if (CI) console.log(`::error:: Running the tests produced the following error: ${JSON.stringify(data.error)}`);
+        else console.log(`❌ Running the tests produced the following error: ${JSON.stringify(data.error)}`);
         return;
       }
       data.forEach((testfile) => {
-        const pathStructure = testfile.file.split("/")
-        const testsFolderIndex = pathStructure.findIndex(p => p === "tests")
-        const testPathStructure = pathStructure.slice(testsFolderIndex + 1)
-        const testfileName = testPathStructure.join(' >> ')
-        
-        if (testfile.tests.some((test) => test.type === 'test' && test.state && test.state !== 'succeeded')) console.log(`::group:: ${testfileName} ❌`)
-        else if (testfile.tests.every((test) => !test.state)) console.log(`::group:: ${testfileName} ⏭️`)
-        else console.log(`::group:: ${testfileName} ✅`)
+        const pathStructure = testfile.file.split('/');
+        const testsFolderIndex = pathStructure.findIndex(p => p === 'tests');
+        const testPathStructure = pathStructure.slice(testsFolderIndex + 1);
+        const testfileName = testPathStructure.join(' >> ');
+
+        if (testfile.tests.some((test) => test.type === 'test' && test.state && test.state !== 'succeeded')) {
+          if (CI) {
+            console.log(`::group:: ${testfileName} ❌`);
+          } else {
+            console.log(`${testfileName} ❌`);
+            console.log('---');
+          }
+        } else if (testfile.tests.every((test) => !test.state)) {
+          if (CI) {
+            console.log(`::group:: ${testfileName} ⏭️`);
+          } else {
+            console.log(`${testfileName} ⏭️`);
+            console.log('---');
+          }
+        } else {
+          if (CI) {
+            console.log(`::group:: ${testfileName} ✅`);
+          } else {
+            console.log(`${testfileName} ✅`);
+            console.log('---');
+          }
+        }
         testfile.tests.forEach((test) => {
           if (test.type !== 'test') return;
           if (!test.state) {
             skipped += 1;
             console.log(`${test.fullTitle} skipped ⏭️`);
             return;
-          } 
+          }
           if (test.state === 'succeeded') {
             passed += 1;
             console.log(`${test.fullTitle} passed ✅`);
-          } 
-          else {
+          } else {
             failed += 1;
-            console.log(`::error:: ${test.fullTitle} failed ❌`);
-            process.exitCode = 1;
+            if (CI) {
+              console.log(`::error:: ${test.fullTitle} failed ❌`);
+              markdownListOfFailingTests = markdownListOfFailingTests + `- ${test.fullTitle} failed ❌\n`;
+            } else {
+              console.log(`${test.fullTitle} failed ❌`);
+            }
           }
-        })
-        console.log(`::endgroup::`)
-      })
-      console.log(`SUMMARY-passed:${passed}`);
-      console.log(`SUMMARY-skipped:${skipped}`);
-      console.log(`SUMMARY-failed:${failed}`);
+        });
+        if (CI) console.log('::endgroup::');
+        else console.log('');
+      });
+      if (CI) {
+        console.log(`SUMMARY-passed:${passed}`);
+        fs.appendFileSync('summary.txt', `✅ ${passed} tests passed\n`);
+        console.log(`SUMMARY-skipped:${skipped}`);
+        fs.appendFileSync('summary.txt', `⏭️ ${skipped} tests skipped\n`);
+        console.log(`SUMMARY-failed:${failed}`);
+        fs.appendFileSync('summary.txt', `❌ ${failed} tests failed\n`);
+        if (markdownListOfFailingTests !== '') {
+          const firstLineOfSummary = `While running the tests for ${targetPackage}, the following ${failed} test(s) failed:\n`;
+          fs.appendFileSync('failing.txt', firstLineOfSummary);
+          fs.appendFileSync('failing.txt', markdownListOfFailingTests);
+        }
+      }
+    } catch (err) {
+      if (CI) {
+        console.log(`::error:: Running the tests produced the following error: "${err}"`);
+      } else {
+        console.log(`❌ Running the tests produced the following error: "${err}"`);
+      }
     }
-    catch (err) {
-      console.log(`::error:: Running the tests produced the following error: "${err}"`);
-      process.exitCode = 1;
-    }
-  })
+  });
 }
-)
+);
 
 req.on('error', err => {
-  console.log(`::error:: Error while trying to get the results of tests for ${targetPackage}`);
-  console.log(err)
-  process.exitCode = 1;
-  console.log("::endgroup::");
-})
+  if (CI) console.log(`::error:: Error while trying to get the results of tests for ${targetPackage}`);
+  else console.log(`❌ Error while trying to get the results of tests for ${targetPackage}`);
+  console.log(err);
+  if (CI) {
+    console.log('::endgroup::');
+  }
+});
 
-req.end()
+req.end();

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -2,9 +2,10 @@
 This script can be used to run the test in a selected package.
 Just pass the package as a parameter when executing this script (only one at a time).
 Example call of this script: `node test.js lively.morphic`.
-The script assumes that a lively server is running localy on port 9011.
-This script gets used by ci-tests.sh
+The script assumes that a lively server is running locally on port 9011.
+This script gets used by tests.sh.
 */
+
 const http = require('http')
 
 const targetPackage = process.argv[2]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Just a small wrapper script so that it is easier to run a test-suite locally,
-# without worrying about the --dns-result-order stuff below
-# call like "./test.sh lively.package"
-
-node --dns-result-order ipv4first ./scripts/test.js "$1"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,12 @@
 # It either executes all tests present in the test folders of the packages specified in `testfiles` (defaulting to all lively core packages),
 # or all tests in the single package given as a parameter when executing this script.
 # It is not possible to run multiple explicitly specified packages (except when modifying the below array).
+# As this script supports either running locally or inside of a GitHub Action environment, this leaves us with four cases:
+# (1) Testing the lively core a) in CI b) locally or (1) Testing one specific package a) in CI or b) locally.
+# In case (1), we provicde some summary statistics at the end of our test run.
+# In the cases a) we add some GitHub Actions output formatting hints as well as providing markdown to be rendered in the summary section of the action run.
+# See https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/ for further information.
+# In cases b), we provide more lean, human readable output meant for reading consumtion in a shell. 
 # For Linux systems, this script requires `ss` to run. On Mac, netstat is required instead.
 # On mac, make sure to have `gsed` installed.
 
@@ -45,6 +51,11 @@ testfiles=(
 if [ "$1" ];
 then
   testfiles=("$1" )
+else
+  if [ "$CI" ];
+  then
+    echo '# Tests for `lively.next` 🧪' >> "$GITHUB_STEP_SUMMARY"
+  fi
 fi
 
 # For not entirely clear reasons, the lively.server dies due to a socket hangup
@@ -112,25 +123,37 @@ for package in "${testfiles[@]}"; do
   fi
 done
 
-# print out summary statistics
-read -r -d '' SUMMARY << EOM
-███████ ██    ██ ███    ███ ███    ███  █████  ██████  ██    ██ 
-██      ██    ██ ████  ████ ████  ████ ██   ██ ██   ██  ██  ██  
-███████ ██    ██ ██ ████ ██ ██ ████ ██ ███████ ██████    ████   
-     ██ ██    ██ ██  ██  ██ ██  ██  ██ ██   ██ ██   ██    ██    
-███████  ██████  ██      ██ ██      ██ ██   ██ ██   ██    ██    
-                                                                
-                                                                
-EOM
-echo "$SUMMARY"
-((ALL_TESTS=GREEN_TESTS + RED_TESTS + SKIPPED_TESTS))
-echo "Executed $ALL_TESTS tests in $TESTED_PACKAGES packages."
-((GREEN_PERCENTAGES=GREEN_TESTS*100/ALL_TESTS))
-((RED_PERCENTAGES=RED_TESTS*100/ALL_TESTS))
-((SKIPPED_PERCENTAGES=SKIPPED_TESTS*100/ALL_TESTS))
-echo "✅ $GREEN_TESTS (≈$GREEN_PERCENTAGES %) passed."
-echo "❌ $RED_TESTS (≈$RED_PERCENTAGES %) failed."
-echo "⏩ $SKIPPED_TESTS (≈$SKIPPED_PERCENTAGES %) skipped."
+if [ ! "$1" ];
+then
+  ((ALL_TESTS=GREEN_TESTS + RED_TESTS + SKIPPED_TESTS))
+  ((GREEN_PERCENTAGES=GREEN_TESTS*100/ALL_TESTS))
+  ((RED_PERCENTAGES=RED_TESTS*100/ALL_TESTS))
+  ((SKIPPED_PERCENTAGES=SKIPPED_TESTS*100/ALL_TESTS))
+  if [ "$CI" ];
+  then
+    {
+      echo '## Summary Statistics';
+      echo "- Executed $ALL_TESTS tests in $TESTED_PACKAGES packages.";
+      echo "- ✅ $GREEN_TESTS (≈$GREEN_PERCENTAGES %) passed.";
+      echo "- ❌ $RED_TESTS (≈$RED_PERCENTAGES %) failed.";
+      echo "- ⏩ $SKIPPED_TESTS (≈$SKIPPED_PERCENTAGES %) skipped."
+    } >> "$GITHUB_STEP_SUMMARY"
+    cat summary.txt >> "$GITHUB_STEP_SUMMARY"
+  else
+    echo 'Summary Statistics'
+    echo ''
+    echo "- Executed $ALL_TESTS tests in $TESTED_PACKAGES packages."
+    echo "- ✅ $GREEN_TESTS (≈$GREEN_PERCENTAGES %) passed."
+    echo "- ❌ $RED_TESTS (≈$RED_PERCENTAGES %) failed."
+    echo "- ⏩ $SKIPPED_TESTS (≈$SKIPPED_PERCENTAGES %) skipped."
+  fi
+elif [ "$CI" ];
+  then
+  if [ -f "failing.txt" ]; then
+    cat failing.txt >> "$GITHUB_STEP_SUMMARY"
+  fi
+fi
+
 if ((RED_TESTS > 0 || ALL_TESTS == 0)); 
 then
   exit 1

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# This script is used by the CI test running pipeline.
-# It executes all tests present in the test folders of the packages specified in `testfiles`.
-# It is not possible to run only some selected packages (only when modifying the below array).
+# This script can be used to run tests outside of a lively.next environment. It is used for the CI pipelines for lively.next and its projects.
+# It either executes all tests present in the test folders of the packages specified in `testfiles` (defaulting to all lively core packages),
+# or all tests in the single package given as a parameter when executing this script.
+# It is not possible to run multiple explicitly specified packages (except when modifying the below array).
 # For Linux systems, this script requires `ss` to run. On Mac, netstat is required instead.
-# On mac, make sure to habe `gsed` installed.
+# On mac, make sure to have `gsed` installed.
 
 TESTED_PACKAGES=0
 GREEN_TESTS=0
@@ -40,6 +41,11 @@ testfiles=(
 "lively.headless"
 "lively.keyboard"
 )
+
+if [ "$1" ];
+then
+  testfiles=("$1" )
+fi
 
 # For not entirely clear reasons, the lively.server dies due to a socket hangup
 # when testing multiple packages consecutively on a hosted GitHub Actions runner.


### PR DESCRIPTION
This PR unifies the way we run tests outside of lively.next both in CI and locally.

The definitive way to run tests is now to always invoke `scripts/test.sh`. There are two ways of doing this:

1. Just executing the script, which will result in testing all packages enumerated inside of the script, i.e. the lively core packages.
2. It is also possible to provide **one** argument when executing the script, the name of the package to test. In the case it is not one of the lively core packages, the package gets loaded from the /projects folder inside of lively.next (this is not really related to this PR, just noting it for the sake of completion).

Depending on whether one runs in CI or not, the output of the script is either incorporating GitHub formatting hints and a markdown summary to be rendered by GitHub, or aims to be easily readable by humans in a terminal.

## Below are some example outputs:

1. The output of the nightly test run of the lively core:
![image](https://user-images.githubusercontent.com/14252419/223159712-02a4090a-735e-41be-8360-9e5126402f66.png)

2. The output of an example project prototype running the tests for the project package:
![image](https://user-images.githubusercontent.com/14252419/223160075-0c10ca10-ce90-4cb1-862f-668ed0cc829d.png)

3. Testing a single package locally in the terminal: 
![image](https://user-images.githubusercontent.com/14252419/223160733-cda17b05-c054-4f54-bdf5-a73b07968bfa.png)
