### PR TITLE
🧰🎨: add option to trigger world menu via top bar

### DIFF
--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -149,6 +149,20 @@ export class TopBarModel extends ViewModel {
     addFn('haloFilterFn', this.getProperty('haloFilterFn'));
   }
 
+  viewDidLoad () {
+    if (config.ide.studio.worldMenuInTopBar) {
+      const worldMenuButton = part(TopBarButton, {
+        name: 'world menu button',
+        textAndAttributes: Icon.textAttribute('burger'),
+        tooltip: 'Open World Menu'
+      });
+      this.ui.tilingLayout.addMorphAt(worldMenuButton, 0);
+      connect(worldMenuButton, 'onMouseDown', () => {
+        $world.openMenu($world.menuItems());
+      });
+    }
+  }
+
   onMouseDown (evt) {
     const shapeSelector = this.ui.selectShapeType;
     const handHaloSelector = this.ui.selectHandOrHalo;

--- a/lively.morphic/config.js
+++ b/lively.morphic/config.js
@@ -76,7 +76,8 @@ const config = {
 
     studio: {
       zoom: { step: 0.07, min: 0.02 },
-      defaultMode: 'Halo' // can either be 'Halo' or 'Hand'
+      defaultMode: 'Halo', // can either be 'Halo' or 'Hand'
+      worldMenuInTopBar: false
     },
 
     js: {


### PR DESCRIPTION
Closes #736, as requested by @rickmcgeer.

![Screenshot from 2023-03-06 18-11-02](https://user-images.githubusercontent.com/14252419/223182232-f44b3d9e-bebe-4af5-a882-d3eb4832a7fd.png)

Note, that this is an optional feature, that is disabled by default. To enable it, you need to add `config.ide.studio.worldMenuInTopBar = true` in your `localconfig.js` at the root of your lively.next folder.