### PR TITLE
Add Copy Button to Color Picker and Version Checker

### DIFF
--- a/lively.ide/studio/dark-color-picker.cp.js
+++ b/lively.ide/studio/dark-color-picker.cp.js
@@ -35,8 +35,6 @@ const DarkColorPicker = component(ColorPicker, {
     borderColor: Color.rgb(112, 123, 124),
     submorphs: [{
       name: 'color encoding',
-      extent: pt(219.2, 25.3),
-      clipMode: 'hidden',
       submorphs: [
         {
           name: 'color code selector',
@@ -49,10 +47,8 @@ const DarkColorPicker = component(ColorPicker, {
         },
         {
           name: 'controls',
-          extent: pt(150, 25),
           submorphs: [{
             name: 'hex encoding',
-            extent: pt(150, 25),
             submorphs: [
               {
                 name: 'hex opacity control',
@@ -67,8 +63,7 @@ const DarkColorPicker = component(ColorPicker, {
                 name: 'hex input',
                 borderRadius: 0,
                 fill: Color.rgb(66, 73, 73),
-                fontColor: Color.rgbHex('B2EBF2'),
-                fontSize: 14
+                fontColor: Color.rgbHex('B2EBF2')
               }]
           }, {
             name: '3 val encoding',
@@ -110,18 +105,20 @@ const DarkColorPicker = component(ColorPicker, {
             name: 'css encoding',
             submorphs: [{
               name: 'css input',
-              fontSize: 14,
               master: DarkNumberIconWidget,
               borderRadius: 0
             }]
           }]
+        },
+        {
+          name: 'color copier',
+          fontColor: Color.white
         }]
     }]
   }, {
     name: 'color palettes',
     submorphs: [{
       name: 'color palette selector',
-      extent: pt(98.2, 25),
       master: EnumSelector,
       viewModel: {
         listMaster: DarkThemeList,

--- a/lively.ide/styling/color-picker.cp.js
+++ b/lively.ide/styling/color-picker.cp.js
@@ -508,11 +508,12 @@ const ColorPicker = component(PopupWindow, {
         name: 'color palette view',
         cssDeclaration: `.palette-container {
   height: 100%;
-  width: 100%;
   display: flex;
+  padding-left: 6px;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: left;
   overflow: auto;
+  margin-right: 1px;
 }
 
 .color-cell {

--- a/lively.ide/styling/color-picker.cp.js
+++ b/lively.ide/styling/color-picker.cp.js
@@ -1,5 +1,5 @@
 import { Color, Rectangle, LinearGradient, rect, pt } from 'lively.graphics';
-import { Ellipse, without, ShadowObject, Label, TilingLayout, component, add, part } from 'lively.morphic';
+import { Ellipse, Icon, without, ShadowObject, Label, TilingLayout, component, add, part } from 'lively.morphic';
 import {
   ColorEncoderModel, ColorInputModel, ColorPickerModel,
   ColorPaletteView, FieldPickerModel, HuePickerModel, OpacityPickerModel
@@ -118,7 +118,7 @@ const DefaultInputLine = component({
 const HexEncoder = component({
   name: 'hex encoder',
   borderColor: Color.rgb(23, 160, 251),
-  extent: pt(160, 25),
+  extent: pt(140, 25),
   fill: Color.rgb(189, 195, 199),
   layout: new TilingLayout({
     axisAlign: 'center',
@@ -129,7 +129,7 @@ const HexEncoder = component({
     part(DefaultNumberWidget, {
       name: 'hex opacity control',
       dropShadow: false,
-      extent: pt(49.6, 23),
+      extent: pt(40, 23),
       floatingPoint: false,
       borderRadius: 0,
       max: 1,
@@ -152,8 +152,8 @@ const HexEncoder = component({
 const ThreeValEncoder = component({
   name: 'three val encoder',
   borderColor: Color.rgb(23, 160, 251),
-  extent: pt(160, 25),
-  fill: Color.rgb(189, 195, 199),
+  extent: pt(140, 25),
+  fill: Color.transparent,
   layout: new TilingLayout({
     align: 'center',
     axisAlign: 'center',
@@ -163,7 +163,7 @@ const ThreeValEncoder = component({
     part(DefaultNumberWidget, {
       name: 'opacity control',
       dropShadow: false,
-      extent: pt(49.6, 22),
+      extent: pt(40, 22),
       floatingPoint: false,
       max: 1,
       min: 0,
@@ -179,7 +179,7 @@ const ThreeValEncoder = component({
       type: NumberWidget,
       name: 'first value',
       dropShadow: false,
-      extent: pt(35, 22),
+      extent: pt(30, 22),
       floatingPoint: false,
       borderRadius: 0,
       max: 255,
@@ -195,7 +195,7 @@ const ThreeValEncoder = component({
       name: 'second value',
       borderRadius: 0,
       dropShadow: false,
-      extent: pt(35, 22),
+      extent: pt(30, 22),
       floatingPoint: false,
       max: 255,
       min: 0,
@@ -209,7 +209,7 @@ const ThreeValEncoder = component({
       name: 'third value',
       borderRadius: 0,
       dropShadow: false,
-      extent: pt(35, 22),
+      extent: pt(30, 22),
       floatingPoint: false,
       max: 255,
       min: 0,
@@ -224,7 +224,7 @@ const ThreeValEncoder = component({
 const CssEncoder = component({
   name: 'css encoder',
   borderColor: Color.rgb(23, 160, 251),
-  extent: pt(160, 25),
+  extent: pt(140, 25),
   fill: Color.rgb(189, 195, 199),
   isLayoutable: false,
   layout: new TilingLayout({
@@ -244,7 +244,7 @@ const CssEncoder = component({
   submorphs: [part(DefaultInputLine, {
     name: 'css input',
     placeholder: 'CSS color string',
-    extent: pt(158, 23),
+    extent: pt(140, 23),
     padding: rect(5, 3, -5, -3)
   })],
   visible: false
@@ -255,7 +255,10 @@ const ColorEncoder = component({
   name: 'color encoder',
   extent: pt(219.6, 25),
   fill: Color.transparent,
-  layout: new TilingLayout({ justifySubmorphs: 'spaced' }),
+  layout: new TilingLayout({
+    justifySubmorphs: 'spaced',
+    spacing: 5
+  }),
   submorphs: [
     part(DropDownList, {
       name: 'color code selector',
@@ -277,13 +280,26 @@ const ColorEncoder = component({
       fill: Color.transparent,
       layout: new TilingLayout({
         axis: 'column',
-        axisAlign: 'right'
+        hugContentsVertically: true,
+        hugContentsHorizontally: true,
+        wrapSubmorphs: true
       }),
       submorphs: [
         part(HexEncoder, { name: 'hex encoding' }),
         part(ThreeValEncoder, { name: '3 val encoding', visible: false }),
         part(CssEncoder, { name: 'css encoding', visible: false })
       ]
+    },
+    {
+      type: Label,
+      name: 'color copier',
+      nativeCursor: 'pointer',
+      fontSize: 20,
+      lineHeight: 1.1,
+      fontColor: Color.rgb(102, 102, 102),
+      fill: Color.transparent,
+      padding: 3,
+      textAndAttributes: Icon.textAttribute('copy')
     }
   ]
 });

--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -86,6 +86,10 @@ export class AnimationQueue {
     this.animations.forEach(anim => anim.startSvg(svgNode, type));
   }
 
+  startTextAnimationsFor (textLayerNode) {
+    this.animations.forEach(anim => anim.startText(textLayerNode));
+  }
+
   removeAnimation (animation) {
     arr.remove(this.animations, animation);
   }
@@ -143,6 +147,7 @@ export class PropertyAnimation {
     }
     this.config = this.convertBounds(config);
     this.needsAnimation = {
+      text: morph.isText,
       svg: morph.isPath,
       path: morph.isPath
     };
@@ -289,11 +294,12 @@ export class PropertyAnimation {
 
   gatherAnimationProps () {
     const { morph } = this;
-    const { isPath, isPolygon } = morph;
+    const { isPath, isPolygon, isText } = morph;
     const props = {};
     props.css = styleProps(this.morph);
     if (isPath) props.path = addPathAttributes(morph, {});
     if (isPolygon) props.polygon = addPathAttributes(morph, {});
+    if (isText) props.text = morph.styleObject();
     return props;
   }
 
@@ -328,6 +334,14 @@ export class PropertyAnimation {
         v1 = Color.fromString(v1);
         v2 = Color.fromString(v2);
         return i => v1.interpolate(i, v2);
+    }
+  }
+
+  startText (textLayerNode) {
+    if (this.needsAnimation['text']) {
+      this.needsAnimation['text'] = false;
+      const [before, after] = this.getAnimationProps('text');
+      textLayerNode && this.tween(textLayerNode, before, after);
     }
   }
 

--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -1,6 +1,6 @@
 import { obj, promise, fun, num, properties, arr, string } from 'lively.lang';
 import { Color } from 'lively.graphics';
-import { styleProps, addSvgAttributes, addPathAttributes } from './property-dom-mapping.js';
+import { styleProps, addPathAttributes } from './property-dom-mapping.js';
 import flubber from 'flubber';
 import Bezier from 'bezier-easing';
 import 'web-animations-js';

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -222,6 +222,11 @@ export default class Renderer {
       morph._animationQueue.startSvgAnimationsFor(svgNode, 'path');
     }
 
+    if (morph.isText) {
+      const textLayerNode = node.querySelector('.actual');
+      morph._animationQueue.startTextAnimationsFor(textLayerNode);
+    }
+
     morph._animationQueue.startAnimationsFor(node);
     morph.renderingState.animationAdded = false;
   }


### PR DESCRIPTION
Adds a button to copy the currently running commit of lively.next from the color picker as well as the option to copy the currently picked color from the color picker.

 
![image](https://user-images.githubusercontent.com/14252419/224113237-ceb3786c-6050-4b16-b698-f8209edd280f.png)

https://user-images.githubusercontent.com/14252419/224113523-f6a39926-f006-4b8d-8ace-66b05307b268.mp4

---

In order to get the color effect on the copy button, I implemented the possibility to animate css properties which are applied to the textlayer of a text morph.
