### PR TITLE
Fix Editor in Inspector

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -908,7 +908,6 @@ const SystemBrowser = component({
     type: Text,
     name: 'source editor',
     readOnly: false,
-    acceptsDrops: false,
     needsDocument: true,
     borderColor: Color.rgb(204, 204, 204),
     borderRadius: {

--- a/lively.ide/js/inspector/ui.cp.js
+++ b/lively.ide/js/inspector/ui.cp.js
@@ -1,4 +1,4 @@
-import { GridLayout, morph, Text, Icon, Label, component, part } from 'lively.morphic';
+import { GridLayout, config, morph, Text, Icon, Label, component, part } from 'lively.morphic';
 import { pt, rect, Color } from 'lively.graphics';
 import { DarkButton, SystemButton } from 'lively.components/buttons.cp.js';
 import { LabeledCheckBox, SearchField } from 'lively.components/inputs.cp.js';
@@ -188,18 +188,17 @@ const SystemInspector = component({
     nativeCursor: 'ns-resize'
   }, {
     type: Text,
-    readOnly: false,
-    fill: Color.white,
     name: 'code editor',
-    borderColor: Color.rgb(204, 204, 204),
-    borderWidth: 1,
-    clipMode: 'auto',
-    fixedHeight: true,
-    fixedWidth: true,
-    fontFamily: 'IBM Plex Mono',
+    readOnly: false,
+    borderRadius: {
+      topLeft: 0,
+      topRight: 0,
+      bottomRight: 6,
+      bottomLeft: 6
+    },
     lineWrapping: 'by-chars',
-
-    padding: rect(4, 2, 0, 0)
+    padding: rect(4, 2, 0, 0),
+    ...config.codeEditor.defaultStyle
   }, part(DarkButton, {
     viewModel: {
       label: { value: 'fix undeclared vars', fontSize: 12 }

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -251,7 +251,6 @@ export class Text extends Morph {
       readOnly: {
         group: 'text',
         defaultValue: true,
-        isStyleProp: true,
         after: ['borderWidth', 'borderColor', 'borderRadius', 'borderStyle'],
         set (readOnly) {
           if (!readOnly) {


### PR DESCRIPTION
We did not understand the problem 100 percent, but this is what we gathered:

When a morph gets instantiated from an inline-component, the following happens: 
1. The structure gets created.
2. Non-style properties get set.
3. Specified style-properties get set.

The `readOnly` property of `Text` was a  style property previously (for unknown reasons). Thus, it was set to `true` for the longest time during the instantiation of the editor and only later set to false. This broke with assumptions I made when implementing the text rendering and the text implementation. Thus, an alternative fix for this would have been setting `needsDocument` to true on the source editor of the inspector.
However, this goes against how the `needsDocument` flag is used, at its purpose is to enforce a document on morphs which otherwise would not have one. It is bad to abuse it to solve such kinds of timing issues.

It is important to know, that two aspects of this bug remain unsolved/not understood:

1. It is quite safe to say that the rendering problem is then caused by measurement problems. However, those manifest differently on different systems, e.g., @merryman could not reproduce the initial problem on his system.
2. What problems exactly this misconfiguration caused inside of the renderer, is unknown.