### PR TITLE
🛠️: pin puppeteer version used inside of action

### DIFF
--- a/.github/workflows/check_world_loading.yml
+++ b/.github/workflows/check_world_loading.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install puppeteer
-        run: npm i puppeteer
+        run: npm install puppeteer@19.7.3
       - name: Install lively.next 
         run:  |
          chmod a+x ./install.sh


### PR DESCRIPTION
This fixes a problem that occurred since last Friday, when the 'Check if lively boots' action began failing all of a sudden. The error occurred when the loading screen got bundled during the installation. The problem only occurred in this action.
This is the stack trace of the failing:

```
Setting env vars for FLATN_PACKAGE_DIRS, FLATN_PACKAGE_COLLECTION_DIRS, FLATN_DEV_PACKAGE_DIRS for lively.next
[lively.freezer]: Freezing in Progress
/home/runner/work/lively.next/lively.next/lively.next-node_modules/@rollup__SLASH__plugin-commonjs/22.0.0/dist/cjs/index.js:184
    for (const path$1 of glob__default["default"].sync(isNegated ? pattern.substr(1) : pattern)) {
                                                  ^

TypeError: glob__default.default.sync is not a function or its return value is not iterable
    at getDynamicRequireModules (/home/runner/work/lively.next/lively.next/lively.next-node_modules/@rollup__SLASH__plugin-commonjs/22.0.0/dist/cjs/index.js:184:51)
    at commonjs (/home/runner/work/lively.next/lively.next/lively.next-node_modules/@rollup__SLASH__plugin-commonjs/22.0.0/dist/cjs/index.js:1982:48)
    at Object.supportingPlugins (/home/runner/work/lively.next/lively.next/lively.freezer/src/resolvers/node.cjs:202:5)
    at Object.options (file:///home/runner/work/lively.next/lively.next/lively.freezer/src/plugins/rollup.js:81:29)
    at /home/runner/work/lively.next/lively.next/lively.next-node_modules/rollup/2.68.0/dist/shared/rollup.js:23596:43

Node.js v18.12.1
```

Thus, the relevant source code can be found at: https://github.com/rollup/plugins/blob/master/packages/commonjs/src/dynamic-modules.js.

What happened was, that `puppeteer` released a new version during the day. This version transitively included `glob` in the dependency tree.
**Previously:**
![Screenshot from 2023-03-14 12-55-22](https://user-images.githubusercontent.com/14252419/225010593-b3bbf378-cc1c-47f7-97fb-66a80290cab0.png)

**After the update:**
![Screenshot from 2023-03-14 12-58-45](https://user-images.githubusercontent.com/14252419/225010632-9051e854-5c55-49e8-97ec-29625f6fd535.png)

Thus, when we execute `npm i puppeteer` previously to installing lively.next, we now install an unknown version of `glob`. `flatn` seems to then later use this version preferred over the ones installed inside of the lively.next-node_modules folder.

The solution is thus to pin the version of `puppeteer` we install to the last version that came out without its own `glob` installation. 