### PR TITLE
Fix/line comment whitespace termination issue

### DIFF
--- a/lively.ide/js/mode.js
+++ b/lively.ide/js/mode.js
@@ -230,6 +230,14 @@ defineMode('javascript', function crea (config, parserConfig) {
         return ret('commentHighlight', 'commentHighlight');
       }
     }
+
+    // Consume any whitespace characters before checking for the end of the line
+    stream.eatWhile(/\s/);
+
+    if (stream.eol()) {
+      state.tokenize = tokenBase;
+    }
+
     return ret('comment', 'comment');
   }
 

--- a/lively.ide/js/mode.js
+++ b/lively.ide/js/mode.js
@@ -130,7 +130,8 @@ defineMode('javascript', function crea (config, parserConfig) {
         state.tokenize = tokenComment;
         return ret('comment', 'comment');
       } else if (stream.eat('/')) {
-        state.tokenize = tokenLineComment;
+        stream.eatWhile(/\s/);
+        if (!stream.eol()) state.tokenize = tokenLineComment;
         return ret('comment', 'comment');
       } else if (expressionAllowed(stream, state, 1)) {
         readRegexp(stream);


### PR DESCRIPTION
Fixes an issue where the javascript tokenizer would incorrectly categorize lines that are following a line comment that is either empty or terminates with a space to be considered comments *as well*.