### PR TITLE
🎨: properly install dom measure at the beginning of the document body

### DIFF
--- a/lively.morphic/rendering/font-metric.js
+++ b/lively.morphic/rendering/font-metric.js
@@ -298,7 +298,7 @@ class DOMTextMeasure {
     const el = this.element = doc.createElement('div');
     el.className = 'dom-measure' + (debug ? ' debug' : '');
     this.setMeasureNodeStyles(el.style, true);
-    parentEl.appendChild(el);
+    parentEl.insertBefore(el, parentEl.firstChild);
     return this;
   }
 


### PR DESCRIPTION
Fixes an issue where the patching of the fixed morphs would break, leaving nodes behind in the DOM that would keep sticking around although the morphs were not longer in the world. Closes #764 and #734.