### PR TITLE
🎨: fix rendering of gradient with transparency

### DIFF
--- a/lively.morphic/rendering/property-dom-mapping.js
+++ b/lively.morphic/rendering/property-dom-mapping.js
@@ -172,8 +172,12 @@ function addFill (morph, style) {
     style.background = Color.transparent.toString();
     return;
   }
-  if (fill.isGradient) style.backgroundImage = fill.toString();
-  else style.background = fill.toString();
+  if (fill.isGradient) {
+    // we need to set the background color to something
+    // that does not interfere with the opaque fill.
+    style.background = Color.transparent.toString();
+    style.backgroundImage = fill.toString();
+  } else style.background = fill.toString();
 }
 
 function addExtentStyle (morph, style) {


### PR DESCRIPTION
Fixes an issue where transitioning from a opaque fill to a gradient fill with a transparent stop, the transparent stop would not be visible.
<img width="514" alt="no-transparent-stop-visible" src="https://user-images.githubusercontent.com/1296388/225886226-afe2b6b9-ea82-43c6-85ab-fede1711aaa9.png">
