### PR TITLE
🧰: fix spinner loading animation

### DIFF
--- a/lively.ide/studio/shared.cp.js
+++ b/lively.ide/studio/shared.cp.js
@@ -376,7 +376,7 @@ const Spinner = component({
           }\n\
           .spinner div {\n\
             transform-origin: 32px 32px;\n\
-            animation: lds-spinner .6s linear infinite;\n\
+            animation: spinner .6s linear infinite;\n\
           }\n\
           .spinner div:after {\n\
             content: " ";\n\


### PR DESCRIPTION
I changed the CSS class name for better readability (imo) but forgot to change the animation as well. Thus, the spinner did not spin. This is now fixed.