### PR TITLE
❄️: add no experimental fetch flag to loading screen build script

### DIFF
--- a/lively.freezer/tools/build-loading-screen.sh
+++ b/lively.freezer/tools/build-loading-screen.sh
@@ -2,4 +2,4 @@
 . ../scripts/lively-next-flatn-env.sh
 lively_next_flatn_env "$(dirname "$(pwd)")"
 export FLATN_DEV_PACKAGE_DIRS=$FLATN_DEV_PACKAGE_DIRS:$(pwd);
-node --no-warnings --experimental-import-meta-resolve --experimental-loader ../flatn/resolver.mjs ./tools/build.loading-screen.mjs
+node --no-warnings --no-experimental-fetch --experimental-import-meta-resolve --experimental-loader ../flatn/resolver.mjs ./tools/build.loading-screen.mjs


### PR DESCRIPTION
For whatever reason, we were still missing the `no-experimental-fetch` flag in the loading screen build script. This *may* have also caused the issues reported in #731 which to date still keep popping up.