### PR TITLE
Enhancement/optional canvas mode

### DIFF
--- a/lively.ide/studio/top-bar-buttons.cp.js
+++ b/lively.ide/studio/top-bar-buttons.cp.js
@@ -1,0 +1,128 @@
+import { component, ViewModel, Icon, part, TilingLayout, ShadowObject, Label } from 'lively.morphic';
+import { Color, pt, rect } from 'lively.graphics';
+
+class TopBarButtonModel extends ViewModel {
+  static get properties () {
+    return {
+      expose: {
+        get () {
+          return ['activateButton', 'deactivateButton'];
+        }
+      },
+      opts: {}
+    };
+  }
+
+  activateButton () {
+    this.view.master = TopBarButtonSelected;
+  }
+
+  deactivateButton () {
+    this.view.master = null;
+  }
+}
+
+export const TopBarButton = component({
+  type: Label,
+  defaultViewModel: TopBarButtonModel,
+  name: 'top bar button',
+  lineHeight: 1,
+  fontColor: {
+    value: Color.rgb(102, 102, 102),
+    onlyAtInstantiation: true
+  },
+  fontSize: {
+    value: 23,
+    onlyAtInstantiation: true
+  },
+  nativeCursor: 'pointer',
+  padding: {
+    value: rect(0, 1, 0, -1),
+    onlyAtInstantiation: true
+  }
+});
+
+export const TopBarButtonSelected = component(TopBarButton, {
+  name: 'top bar button selected',
+  dropShadow: new ShadowObject({ color: Color.rgba(64, 196, 255, 0.4), fast: false }),
+  fontColor: Color.rgb(0, 176, 255)
+});
+
+class TopBarButtonDropDownModel extends ViewModel {
+  static get properties () {
+    return {
+      expose: {
+        get () {
+          return ['dropdown', 'symbol', 'activateButton', 'deactivateButton'];
+        }
+      },
+      opts: {}
+    };
+  }
+
+  activateButton () {
+    this.symbol.master = TopBarButtonSelected;
+    this.dropdown.master = TopBarButtonSelected;
+  }
+
+  deactivateButton () {
+    this.symbol.master = null;
+    this.dropdown.master = null;
+  }
+
+  get dropdown () {
+    return this.view.get(this.opts.dropdown.name);
+  }
+
+  get symbol () {
+    return this.view.get(this.opts.symbol.name);
+  }
+
+  viewDidLoad () {
+    const { view, opts } = this;
+    view.name = opts.name;
+    view.tooltip = opts.tooltip;
+    const symbolButton = view.get('symbol');
+    const dropdownButton = view.get('dropdown');
+    symbolButton.name = opts.symbol.name;
+    symbolButton.tooltip = opts.symbol.tooltip;
+    symbolButton.textAndAttributes = opts.symbol.textAndAttributes;
+    dropdownButton.name = opts.dropdown.name;
+
+    delete this.view.owner.owner.viewModel._ui;
+  }
+}
+
+export const TopBarButtonDropDown = component({
+  name: 'outer button name',
+  defaultViewModel: TopBarButtonDropDownModel,
+  extent: pt(55.8, 24.7),
+  fill: Color.rgba(46, 75, 223, 0),
+  layout: new TilingLayout({
+    axisAlign: 'center',
+    align: 'center',
+    padding: {
+      height: 0,
+      width: 0,
+      x: 5,
+      y: 5
+    },
+    spacing: 5
+  }),
+  nativeCursor: 'pointer',
+  submorphs: [
+    part(TopBarButton, {
+      name: 'symbol',
+      reactsToPointer: false,
+      textAndAttributes: Icon.textAttribute('square'),
+      tooltip: 'symbol tooltip'
+    }),
+    part(TopBarButton, {
+      name: 'dropdown',
+      fontSize: 23,
+      nativeCursor: 'pointer',
+      textAndAttributes: Icon.textAttribute('angle-down')
+    })
+  ],
+  tooltip: 'dropdown tooltip'
+});

--- a/lively.ide/studio/top-bar-buttons.cp.js
+++ b/lively.ide/studio/top-bar-buttons.cp.js
@@ -61,13 +61,11 @@ class TopBarButtonDropDownModel extends ViewModel {
   }
 
   activateButton () {
-    this.symbol.master = TopBarButtonSelected;
-    this.dropdown.master = TopBarButtonSelected;
+    this.symbol.master = TopBarButtonSelected; // eslint-disable-line no-use-before-define
   }
 
   deactivateButton () {
     this.symbol.master = null;
-    this.dropdown.master = null;
   }
 
   get dropdown () {

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -358,7 +358,13 @@ export class TopBarModel extends ViewModel {
               ]
             : ['     ', {}],
           '   Enabled '
-        ], () => {
+        ], async () => {
+          const currentMode = config.ide.studio.canvasModeEnabled;
+          let changeMode = true;
+          if (!currentMode) {
+            changeMode = await $world.confirm('Confirm to activate Canvas Mode. This will reset the scale of all open Morphs to 1!');
+          }
+          if (!changeMode) return;
           config.ide.studio.canvasModeEnabled = !config.ide.studio.canvasModeEnabled;
           $world.resetScaleFactor();
           !config.ide.studio.canvasModeEnabled ? this.toggleMiniMap(false) : this.toggleMiniMap();

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -218,7 +218,7 @@ export class TopBarModel extends ViewModel {
     }
 
     if (evt.targetMorph === canvasModeButton) {
-      this.toggleMiniMap();
+      this.toggleMiniMap(null);
     }
 
     if (evt.targetMorph === canvasModeSelector) {
@@ -358,7 +358,11 @@ export class TopBarModel extends ViewModel {
               ]
             : ['     ', {}],
           '   Enabled '
-        ], () => config.ide.studio.canvasModeEnabled = !config.ide.studio.canvasModeEnabled
+        ], () => {
+          config.ide.studio.canvasModeEnabled = !config.ide.studio.canvasModeEnabled;
+          $world.resetScaleFactor();
+          !config.ide.studio.canvasModeEnabled ? this.toggleMiniMap(false) : this.toggleMiniMap();
+        }
       ]
     ];
   }
@@ -378,13 +382,14 @@ export class TopBarModel extends ViewModel {
     }
   }
 
-  toggleMiniMap () {
-    const miniMap = $world.getSubmorphNamed('world mini map');
-    if (miniMap) {
+  toggleMiniMap (forceState) {
+    let miniMap = $world.getSubmorphNamed('world mini map');
+
+    if (miniMap && forceState !== true && forceState !== undefined) {
       this.colorTopbarButton('mini map button', false);
       miniMap.remove();
       $world.getSubmorphNamed('world zoom indicator').relayout();
-    } else {
+    } else if (!miniMap && forceState !== false && forceState !== undefined) {
       this.colorTopbarButton('mini map button', true);
       const miniMap = part(WorldMiniMap).openInWorld();
       miniMap.relayout();

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -167,6 +167,8 @@ export class TopBarModel extends ViewModel {
     const handHaloSelector = this.ui.handOrHaloModeButton.dropdown;
     const handOrHaloModeButton = this.ui.handOrHaloModeButton;
     const shapeModeButton = this.ui.shapeModeButton;
+    const canvasModeButton = this.ui.canvasModeButton;
+    const canvasModeSelector = this.ui.canvasModeButton.dropdown;
     const target = this.primaryTarget || this.world();
 
     if (evt.targetMorph === shapeSelector) {
@@ -215,8 +217,13 @@ export class TopBarModel extends ViewModel {
       this.toggleCommentBrowser();
     }
 
-    if (evt.targetMorph.name === 'mini map button') {
+    if (evt.targetMorph === canvasModeButton) {
       this.toggleMiniMap();
+    }
+
+    if (evt.targetMorph === canvasModeSelector) {
+      const menu = this.world().openWorldMenu(evt, this.getCanvasModeItems());
+      menu.position = canvasModeButton.globalBounds().bottomLeft().subPt(this.world().scroll);
     }
   }
 
@@ -335,6 +342,25 @@ export class TopBarModel extends ViewModel {
         }
       ];
     });
+  }
+
+  // When we have a control panel this should be moved there with a toggle as would be appropriate.
+  getCanvasModeItems () {
+    return [
+      [
+        [
+          ...config.ide.studio.canvasModeEnabled
+            ? [
+                ...Icon.textAttribute('check', {
+                  fontSize: 11,
+                  paddingTop: '2px'
+                }), '    ', {}
+              ]
+            : ['     ', {}],
+          '   Enabled '
+        ], () => config.ide.studio.canvasModeEnabled = !config.ide.studio.canvasModeEnabled
+      ]
+    ];
   }
 
   colorTopbarButton (buttonName, active) {
@@ -1271,11 +1297,21 @@ const TopBar = component({
         textAndAttributes: Icon.textAttribute('comment-alt'),
         tooltip: 'Toggle Comment Browser'
       }),
-      part(TopBarButton, {
-        name: 'mini map button',
-        padding: rect(3, 0, -3, 0),
-        textAndAttributes: Icon.textAttribute('map-location-dot'),
-        tooltip: 'Toggle Mini Map'
+      part(TopBarButtonDropDown, {
+        viewModel: {
+          opts: {
+            name: 'canvas mode button',
+            tooltip: 'Enable/Disable Canvas mode',
+            symbol: {
+              name: 'mini map button',
+              textAndAttributes: Icon.textAttribute('map-location-dot'),
+              tooltip: 'Open/Close the Minimap'
+            },
+            dropdown: {
+              name: 'canvas mode dropdown'
+            }
+          }
+        }
       })]
   },
   {

--- a/lively.ide/world-mini-map.cp.js
+++ b/lively.ide/world-mini-map.cp.js
@@ -1,5 +1,5 @@
 /* global XMLSerializer */
-import { ViewModel, part, Morph, component } from 'lively.morphic';
+import { ViewModel, config, Morph, component } from 'lively.morphic';
 import { Canvas } from 'lively.components/canvas.js';
 import { pt, Color } from 'lively.graphics';
 import { max, min } from 'lively.lang/array.js';
@@ -25,6 +25,8 @@ class MiniMapModel extends ViewModel {
   }
 
   repositionViewPort (evt) {
+    if (!config.ide.studio.canvasModeEnabled) return;
+
     const clickedPositionOnMap = this.view.localize(evt.position);
 
     const clickedPositionInCanvasSpace = pt(this.xFromMapSpaceToCanvasSpace(clickedPositionOnMap.x), this.yFromMapSpaceToCanvasSpace(clickedPositionOnMap.y));

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -309,6 +309,8 @@ export class LivelyWorld extends World {
   }
 
   onMouseWheel (evt) {
+    if (!config.ide.studio.canvasModeEnabled) return;
+
     const { domEvt, targetMorphs } = evt;
 
     const zoomOperation = domEvt.ctrlKey || domEvt.buttons === 4 || evt.isCommandKey();

--- a/lively.morphic/config.js
+++ b/lively.morphic/config.js
@@ -75,6 +75,7 @@ const config = {
     workerEnabled: false,
 
     studio: {
+      canvasModeEnabled: true,
       zoom: { step: 0.07, min: 0.02 },
       defaultMode: 'Halo', // can either be 'Halo' or 'Hand'
       worldMenuInTopBar: false


### PR DESCRIPTION
Introduces a flag `canvasModeEnabled` inside of `config.ide.studio` that controls whether endless zoom/scroll is active inside of the world or not. By default, it is active, but can simply be deactivated with an entry in ones localconfig.

It is also possible to activate/deactivate the functionality at runtime. Since activating the zooming requires resetting the scale of all morphs in the world (as we forcefully overwrite the scale to achieve the zooming behavior) there is a warning when doing so.

https://user-images.githubusercontent.com/14252419/231170161-cff4b57f-f64c-464f-80ca-4089daa1cdf7.mp4

