### PR TITLE
🎨: handle hiding of scrollbars directly in renderer

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -544,13 +544,7 @@ export class Morph {
         group: 'styling',
         type: 'Boolean',
         isStyleProp: true,
-        defaultValue: false,
-        set (val) {
-          if (val) this.addStyleClass('hiddenScrollbar');
-          else this.removeStyleClass('hiddenScrollbar');
-
-          this.setProperty('hideScrollbars', val);
-        }
+        defaultValue: false
       },
 
       scroll: {

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -543,12 +543,15 @@ export default class Renderer {
     const node = this.getNodeForMorph(morph);
     const scrollChanged = !rs.animationAdded && rs.scrollChanged;
     const turnedVisible = node.style.display === 'none' && morph.visible;
+
     applyStylingToNode(morph, node);
     if (morph.patchSpecialProps) {
       morph.patchSpecialProps(node, this, () => applyStylingToNode(morph, node)); // super expensive for text
     }
 
+    // FIXME: order of these two is important, in an ideal case the styleClass application should not kill other CSS classes
     this.applyStyleClasses(morph, node);
+    morph.hideScrollbars ? node.classList.add('hiddenScrollbar') : node.classList.remove('hiddenScrollbar');
 
     if (turnedVisible || scrollChanged) {
       if (turnedVisible) {


### PR DESCRIPTION
Previously, we handled this by utilizing morphic styleClasses, which led to problems in conjunction with components, see https://github.com/LivelyKernel/lively.next/issues/796