### PR TITLE
🧰🖌️: allow drag-creation of morphs not only from top-left

### DIFF
--- a/lively.graphics/geometry-2d.js
+++ b/lively.graphics/geometry-2d.js
@@ -582,6 +582,10 @@ export class Rectangle {
       this.x + (r.x * this.width), this.y + (r.y * this.height), r.width * this.width, r.height * this.height);
   }
 
+  scaleBy (scaleX, scaleYOrUndefined) {
+    return new Rectangle(this.x, this.y, this.width * scaleX, this.height * (scaleYOrUndefined || scaleX));
+  }
+
   scaleRectIn (fullRect) {
     // return a relative rect for this as a part of fullRect
     return new Rectangle((this.x - fullRect.x) / fullRect.width, (this.y - fullRect.y) / fullRect.height, this.width / fullRect.width, this.height / fullRect.height);

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -522,10 +522,11 @@ export class TopBarModel extends ViewModel {
     const type = target._yieldShapeOnClick;
     if (!type) return false;
     if (!this.canBeCreatedViaDrag(type)) return false;
+    this._shapeCreationStartPos = evt.positionIn(target);
     target._yieldedShape = morph({
       type,
       scale: $world.scaleFactor,
-      position: evt.positionIn(target),
+      position: this._shapeCreationStartPos,
       extent: pt(1, 1),
       fill: Color.white,
       borderWidth: 1,
@@ -576,7 +577,8 @@ export class TopBarModel extends ViewModel {
     const target = this.primaryTarget || this.world();
     if (target._yieldedShape) {
       if (!target._yieldedShape.owner && evt.state.absDragDelta.r() > 10) target.addMorph(target._yieldedShape);
-      target._yieldedShape.extent = evt.positionIn(target.world()).subPt(evt.state.dragStartPosition).subPt(pt(1, 1)).maxPt(pt(1, 1)).scaleBy(1 / $world.scaleFactor);
+      target._yieldedShape.setBounds(Rectangle.fromAny(evt.position, this._shapeCreationStartPos).scaleBy(1 / $world.scaleFactor));
+
       Object.assign(
         target._sizeTooltip, {
           opacity: 1,


### PR DESCRIPTION
Previously, we could only create shapes with the top-bar tooling from by dragging from the top-left to the bottom-right of the shape to be created. However, we could create grey selections in the other direction as well.

This PR reuses the strategy from selections for the other shapes in order to allow easier creation of shapes. 