### PR TITLE
🪨: silence errors when http-resource results in 404

### DIFF
--- a/lively.resources/src/http-resource.js
+++ b/lively.resources/src/http-resource.js
@@ -159,7 +159,11 @@ function makeRequest (resource, method = 'GET', body, headers = {}, onProgress =
   fetchOpts.redirect = 'follow';
   fetchOpts.headers = { ...headers, ...moreHeaders };
 
-  return fetch(url, fetchOpts);
+  try {
+    return fetch(url, fetchOpts);
+  } catch (e) {
+    return e;
+  }
 }
 
 export function upload (resource, body) {


### PR DESCRIPTION
In 06fa501d4f85ebd3cea928536eaa7f3c507ec8ad we added a check for the .gitignore file in a package, which works by using `exists` calls. As for the core packages, usually no .gitignore exists, this lead to a lot of 404 errors in the console.
This should resolve this issue and I could not see any downsides - but please verify and correct me, might very well be that I overlooked something.

![Screenshot from 2023-04-25 16-26-58](https://user-images.githubusercontent.com/14252419/234310523-6c7788ba-4169-429f-b0ed-d7e431ecbfbd.png)
