### PR TITLE
Fix/color picker interference

### DIFF
--- a/lively.ide/studio/controls/border.cp.js
+++ b/lively.ide/studio/controls/border.cp.js
@@ -417,7 +417,7 @@ const BorderControlElements = component({
         name: 'interactive label',
         textAndAttributes: ['', {
           fontSize: 16,
-          fontFamily: 'Material Icons',
+          fontFamily: 'Material Icons'
         }]
       }, without('button holder')]
     }), part(EnumSelector, {
@@ -439,7 +439,7 @@ const BorderControlElements = component({
         padding: rect(0, 4, 7, -4),
         textAndAttributes: ['', {
           fontSize: 18,
-          fontFamily: 'Material Icons',
+          fontFamily: 'Material Icons'
         }]
       }, 'label'), {
         name: 'label',
@@ -491,7 +491,7 @@ const BorderPopup = component(DarkPopupWindow, {
             padding: rect(4, 4, 0, 0),
             textAndAttributes: ['\ue22e', {
               fontSize: 20,
-              fontFamily: 'Material Icons',
+              fontFamily: 'Material Icons'
             }]
           }),
           part(AddButton, {
@@ -501,7 +501,7 @@ const BorderPopup = component(DarkPopupWindow, {
             padding: rect(4, 4, 0, 0),
             textAndAttributes: ['\ue232', {
               fontSize: 20,
-              fontFamily: 'Material Icons',
+              fontFamily: 'Material Icons'
             }]
           }),
           part(AddButton, {
@@ -511,7 +511,7 @@ const BorderPopup = component(DarkPopupWindow, {
             padding: rect(4, 4, 0, 0),
             textAndAttributes: ['\ue230', {
               fontSize: 20,
-              fontFamily: 'Material Icons',
+              fontFamily: 'Material Icons'
             }]
           }),
           part(AddButton, {
@@ -521,7 +521,7 @@ const BorderPopup = component(DarkPopupWindow, {
             padding: rect(4, 4, 0, 0),
             textAndAttributes: ['\ue229', {
               fontSize: 20,
-              fontFamily: 'Material Icons',
+              fontFamily: 'Material Icons'
             }]
           })
         ]
@@ -583,7 +583,7 @@ const BorderControl = component(PropertySection, {
         padding: rect(6, 4, 0, 0),
         textAndAttributes: ['', {
           fontSize: 18,
-          fontFamily: 'Material Icons',
+          fontFamily: 'Material Icons'
         }]
       }))
     ]

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -6,6 +6,7 @@ import { PropLabel } from '../shared.cp.js';
 import { PropertySection } from './section.cp.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { obj } from 'lively.lang';
+import { noUpdate } from 'lively.bindings';
 
 const placeholderImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAfRJREFUaEPtmTFrFFEUhb+jIIKQgFZGi3QBU6SQCDaCXVJbqZCQpLW2E1OntRJCFEXxB2gdCxtFAxYh+QOJVYoU0c4THkxg3dmZnWXnTWbk3XLnzbvn3HPuXd4b0fFQx/GTCJy3gkmBVitg+wawAdwHrjcM9hewDTyVdFCUu9BCGfifwLWGgfenOwLmikiUEXgHPDpn8Gfp30t6PAhLGYEg21RLCBxKCnbORRkB966W1OjEsl0pfyIQy2JJgaoVSAoUVKBqAVMTJwslC41ZgWShMQuYptCoFrI9Kel42Hut/B+w/QBYB+5I+lNGonUEbM8A34AJYEvSWmsI2L4NXJQUAObC9hXgKzDb83BJ0tsiEo0pYPsq8AO4lFkjdwC3Peh4egLMS9orIB3/QGP7AvAJWMhAfAfu9frb9hPgRUGldzPSv/ufN6KA7dCQz/uSf5D0MPxm+y7wOVOnyC2vJK02TsD2IvARCCr0xzPgJbAD3Bw2MoFlSW9610VVwPZ05vvg/0HxF9gHblUAH5bk+iEaAduXgS9AmDx1xj/9EJPAJlA6w8dg9VrSStY/8afQGECHvhpNgaGZa1qQCFStQE0Fz21TNf9/fbnb+ev1cJ3d3Q8c2Szu7iemWM1Z976NfrSoG3zYLxGIUdVR9kwKjFKtGGtPAaQTYEDIYzesAAAAAElFTkSuQmCC';
 
@@ -42,7 +43,7 @@ export class FillControlModel extends ViewModel {
   }
 
   ensureHalo () {
-    if (this.targetMorph.world()) $world.showHaloFor(this.targetMorph);
+    noUpdate(() => { if (this.targetMorph.world()) $world.showHaloFor(this.targetMorph); });
   }
 
   confirm () {


### PR DESCRIPTION
To make sure that we reopen the normal halo after closing the fill halo (which might replace the halo with the gradient halo) we call `showHaloFor()` upon closing the fill color picker. However, as that is also the mechanism that causes the side bar to focus on a morph, this triggered a closing of all currently open popups. As that is no necessary in the case where we just close the fill color picker, we can disable the connection that causes this here.

Closes #804.