### PR TITLE
🧰: restructure save world dialogue to use `TilingLayout`, not constraint

### DIFF
--- a/lively.ide/studio/dialogs.cp.js
+++ b/lively.ide/studio/dialogs.cp.js
@@ -1,8 +1,8 @@
 import { DarkPrompt, ConfirmPromptModel, RedButton, GreenButton } from 'lively.components/prompts.cp.js';
 import { DarkDropDownList, DarkList } from 'lively.components/list.cp.js';
 import { component, add, part } from 'lively.morphic/components/core.js';
-import { pt, rect, Color } from 'lively.graphics';
-import { ConstraintLayout, TilingLayout, MorphicDB, ShadowObject, Text, Label } from 'lively.morphic';
+import { pt, Rectangle, rect, Color } from 'lively.graphics';
+import { TilingLayout, MorphicDB, ShadowObject, Text, Label } from 'lively.morphic';
 import { InputLineDark } from 'lively.components/inputs.cp.js';
 
 import { interactivelyChooseMorphicDB, interactivelyChosenCurrentMorphicDB } from 'lively.morphic/morphicdb/tools.js';
@@ -154,175 +154,220 @@ const SaveWorldDialog = component(DarkPrompt, {
   add({
     name: 'prompt controls',
     clipMode: 'hidden',
-    extent: pt(450, 210),
+    extent: pt(455.5, 258.5),
     fill: Color.transparent,
-    layout: new ConstraintLayout({
-      lastExtent: {
-        x: 450,
-        y: 210
-      },
-      reactToSubmorphAnimations: false,
-      submorphSettings: [
-        ['storage type', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['storage type selector', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['file path input', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['name input', {
-          x: 'resize',
-          y: 'fixed'
-        }], ['tag input', {
-          x: 'resize',
-          y: 'fixed'
-        }], ['description', {
-          x: 'resize',
-          y: 'fixed'
-        }], ['name label', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['name label copy', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['destination chooser label', {
-          x: 'fixed',
-          y: 'fixed'
-        }], ['choose db button', {
-          x: 'move',
-          y: 'fixed'
-        }]]
+    layout: new TilingLayout({
+      align: 'center',
+      axis: 'column',
+      axisAlign: 'center',
+      orderByIndex: true,
+      padding: rect(11, 11, 0, 0),
+      spacing: 5
     }),
-    submorphs: [{
-      type: Label,
-      name: 'name label',
-      fill: Color.rgba(255, 255, 255, 0),
-      fontColor: Color.rgb(255, 255, 255),
-      fontFamily: 'IBM Plex Sans',
-      fontSize: 15,
-      nativeCursor: 'pointer',
-      position: pt(1, 40.1),
-      textAndAttributes: ['save as: ', {}]
-    }, {
-      type: Label,
-      name: 'destination chooser label',
-      fontFamily: 'IBM Plex Sans',
-      fill: Color.rgba(255, 255, 255, 0),
-      fontColor: Color.rgb(255, 255, 255),
-      fontSize: 15,
-      nativeCursor: 'pointer',
-      position: pt(1, 116),
-      textAndAttributes: ['description:', null]
-    }, part(InputLineDark, {
-      name: 'name input',
-      fontSize: 15,
-      extent: pt(336.5, 24.6),
-      padding: rect(4, 4, 0, 0),
-      historyId: 'lively.morphic-save-world-names',
-      position: pt(97, 38.4),
-      submorphs: [{
-        name: 'placeholder',
-        extent: pt(48, 24.6),
-        fontSize: 15,
-        padding: rect(4, 4, 0, 0)
-      }]
-    }), {
-      type: Text,
-      name: 'description',
-      readOnly: false,
-      borderRadius: 5,
-      clipMode: 'auto',
-      nativeCursor: 'text',
-      dropShadow: new ShadowObject({ distance: 3, rotation: 75, color: Color.rgba(0, 0, 0, 0.2) }),
-      extent: pt(336.5, 89.9),
-      fill: Color.rgb(229, 231, 233),
-      fixedHeight: true,
-      fixedWidth: true,
-      fontFamily: 'IBM Plex Sans',
-      fontSize: 15,
-      haloShadow: new ShadowObject({ distance: 4, color: Color.rgba(0, 0, 0, 0.26), blur: 10 }),
-      highlightWhenFocused: true,
-      lineWrapping: true,
-      padding: rect(4, 4, 0, 0),
-      position: pt(97, 115)
-    }, part(InputLineDark, {
-      name: 'tag input',
-      fontSize: 15,
-      placeholder: 'tag1 tag2 tag3 ...',
-      extent: pt(336.5, 24.5),
-      highlightWhenFocused: true,
-      historyId: 'lively.morphic-save-world-names',
-      padding: rect(4, 4, 0, 0),
-      position: pt(97, 76),
-      scroll: pt(0, 1)
-    }), {
-      type: Label,
-      name: 'name label copy',
-      fill: Color.rgba(255, 255, 255, 0),
-      fontColor: Color.rgb(255, 255, 255),
-      fontFamily: 'IBM Plex Sans',
-      fontSize: 15,
-      nativeCursor: 'pointer',
-      position: pt(1, 79.8),
-      textAndAttributes: ['tags:', null]
-    }, {
-      type: Label,
-      name: 'choose db button',
-      fill: Color.rgba(255, 255, 255, 0),
-      fontColor: Color.rgb(204, 204, 204),
-      fontSize: 15,
-      fontStyle: 'bold',
-      nativeCursor: 'pointer',
-      padding: rect(0, 3, 0, -1),
-      position: pt(250, 0),
-      reactsToPointer: false,
-      textAndAttributes: ['Change DB  ', {
-        fontFamily: 'IBM Plex Sans'
-      }, '', {
-        fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
-        paddingTop: '2px',
-        textStyleClasses: ['fa']
-      }]
-    },
-    {
-      type: Label,
-      name: 'storage type',
-      fill: Color.rgba(255, 255, 255, 0),
-      fontColor: Color.rgb(255, 255, 255),
-      fontFamily: 'IBM Plex Sans',
-      fontSize: 15,
-      nativeCursor: 'pointer',
-      position: pt(1.4, 3.4),
-      textAndAttributes: ['store as:', null]
-    }, part(DarkDropDownList, {
-      name: 'storage type selector',
-      layout: new TilingLayout({
-        axisAlign: 'center',
-        orderByIndex: true,
-        padding: rect(5, 0, -5, 0),
-        wrapSubmorphs: false
-      }),
-      extent: pt(105.1, 23),
-      position: pt(96, 3),
-      viewModel: {
-        listMaster: DarkList,
-        openListInWorld: true,
-        listAlign: 'selection',
-        selection: 'Morphic DB',
-        items: [{ string: 'JSON', value: 'json', isListItem: true }, { string: 'Morphic DB', value: 'db', isListItem: true }]
+    submorphs: [
+      {
+        name: 'first row',
+        extent: pt(450, 50),
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          justifySubmorphs: 'spaced',
+          orderByIndex: true
+        }),
+        submorphs: [
+          {
+            type: Label,
+            name: 'storage label',
+            fill: Color.rgba(255, 255, 255, 0),
+            fontColor: Color.rgb(255, 255, 255),
+            fontFamily: 'IBM Plex Sans',
+            fontSize: 15,
+            nativeCursor: 'pointer',
+            position: pt(1.4, 3.4),
+            textAndAttributes: ['store as:', null]
+          },
+          part(DarkDropDownList, {
+            name: 'storage type selector',
+            layout: new TilingLayout({
+              axisAlign: 'center',
+              orderByIndex: true,
+              padding: rect(5, 0, -5, 0),
+              wrapSubmorphs: false
+            }),
+            extent: pt(105.1, 23),
+            position: pt(96, 3),
+            viewModel: {
+              listMaster: DarkList,
+              openListInWorld: true,
+              listAlign: 'selection',
+              selection: 'Morphic DB',
+              items: [{ string: 'JSON', value: 'json', isListItem: true }, { string: 'Morphic DB', value: 'db', isListItem: true }]
+            }
+          }),
+          {
+            type: Label,
+            name: 'choose db button',
+            fill: Color.rgba(255, 255, 255, 0),
+            fontColor: Color.rgb(204, 204, 204),
+            fontSize: 15,
+            fontStyle: 'bold',
+            nativeCursor: 'pointer',
+            extent: pt(234, 25),
+            fixedHeight: true,
+            fixedWidth: true,
+            reactsToPointer: false,
+            textAndAttributes: ['Change DB ', null, '', {
+              fontFamily: '"Font Awesome 6 Free", "Font Awesome 6 Brands"',
+              fontWeight: '900'
+            }, ' ', {
+              backgroundColor: undefined,
+              fontColor: Color.rgb(204, 204, 204),
+              fontFamily: 'IBM Plex Sans, Sans-Serif',
+              fontSize: 15,
+              fontStyle: 'bold',
+              fontWeight: 'normal',
+              letterSpacing: undefined,
+              lineHeight: 1.4,
+              nativeCursor: 'text',
+              textAlign: undefined,
+              textDecoration: 'none',
+              textStyleClasses: undefined,
+              wordSpacing: undefined
+            }]
+
+          }, part(InputLineDark, {
+            name: 'file path input',
+            visible: false,
+            position: pt(211.2, 0.5),
+            extent: pt(234, 25),
+            fontSize: 15,
+            highlightWhenFocused: true,
+            historyId: 'lively.morphic-save-world-names',
+            placeholder: './path/to/snapshot.json'
+          })]
+      },
+      {
+        name: 'second row',
+        extent: pt(450, 50),
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          justifySubmorphs: 'spaced',
+          orderByIndex: true
+        }),
+        submorphs: [
+          {
+            type: Label,
+            name: 'name label',
+            fill: Color.rgba(255, 255, 255, 0),
+            fontColor: Color.rgb(255, 255, 255),
+            fontFamily: 'IBM Plex Sans',
+            fontSize: 15,
+            nativeCursor: 'pointer',
+            position: pt(1, 40.1),
+            textAndAttributes: ['save as: ', {}]
+          }, part(InputLineDark, {
+            name: 'name input',
+            fontSize: 15,
+            extent: pt(365, 27),
+            padding: rect(4, 4, 0, 0),
+            historyId: 'lively.morphic-save-world-names',
+            position: pt(97, 38.4),
+            submorphs: [{
+              name: 'placeholder',
+              extent: pt(48, 29),
+              fontSize: 15,
+              padding: rect(4, 4, 0, 0)
+            }]
+          })
+        ]
+      }, {
+        name: 'third row',
+        extent: pt(450, 50),
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          justifySubmorphs: 'spaced',
+          orderByIndex: true
+        }),
+        submorphs: [{
+          type: Label,
+          name: 'tag label',
+          extent: pt(56, 16),
+          fill: Color.rgba(255, 255, 255, 0),
+          fontColor: Color.rgb(255, 255, 255),
+          fontFamily: 'IBM Plex Sans',
+          fontSize: 15,
+          nativeCursor: 'pointer',
+          position: pt(1, 79.8),
+          textAndAttributes: ['tags:', null]
+        }, part(InputLineDark, {
+          name: 'tag input',
+          fontSize: 15,
+          placeholder: 'tag1 tag2 tag3 ...',
+          extent: pt(365.5, 27),
+          highlightWhenFocused: true,
+          historyId: 'lively.morphic-save-world-names',
+          padding: rect(4, 4, 0, 0),
+          position: pt(97, 76),
+          scroll: pt(0, 1),
+          submorphs: [{
+            name: 'placeholder',
+            extent: pt(122, 29),
+            fontFamily: '"IBM Plex Sans",Sans-Serif',
+            fontSize: 15,
+            nativeCursor: 'text',
+            padding: rect(4, 4, 0, 0),
+            textAndAttributes: ['tag1 tag2 tag3 ...', null]
+          }]
+        })]
+      },
+      {
+        name: 'fourth row',
+        extent: pt(450, 115.3),
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'right',
+          justifySubmorphs: 'spaced',
+          orderByIndex: true,
+          padding: rect(0, 15, 0, -15)
+        }),
+        submorphs: [{
+          type: Label,
+          name: 'description label',
+          extent: pt(84.5, 24.5),
+          fontFamily: 'IBM Plex Sans',
+          fill: Color.rgba(255, 255, 255, 0),
+          fontColor: Color.rgb(255, 255, 255),
+          fontSize: 15,
+          nativeCursor: 'pointer',
+          position: pt(1, 116),
+          textAndAttributes: ['description:', null]
+        }, {
+          type: Text,
+          name: 'description',
+          textAndAttributes: ['', null],
+          readOnly: false,
+          borderRadius: 5,
+          clipMode: 'auto',
+          nativeCursor: 'text',
+          dropShadow: new ShadowObject({ distance: 3, rotation: 75, color: Color.rgba(0, 0, 0, 0.2) }),
+          extent: pt(365, 85.9),
+          fill: Color.rgb(229, 231, 233),
+          fixedHeight: true,
+          fixedWidth: true,
+          fontFamily: 'IBM Plex Sans',
+          fontSize: 15,
+          haloShadow: new ShadowObject({ distance: 4, color: Color.rgba(0, 0, 0, 0.26), blur: 10 }),
+          highlightWhenFocused: true,
+          lineWrapping: true,
+          padding: rect(4, 4, 0, 0),
+          position: pt(97, 115)
+        }]
       }
-    }), part(InputLineDark, {
-      name: 'file path input',
-      position: pt(211.2, 0.5),
-      extent: pt(210, 25),
-      fontSize: 15,
-      highlightWhenFocused: true,
-      historyId: 'lively.morphic-save-world-names',
-      placeholder: './path/to/snapshot.json',
-      visible: false
-    })
     ]
   }), add({
     name: 'button wrapper',


### PR DESCRIPTION
The `ConstraintLayout` is currently totally JS-based (see #625) and quite quirky. Since I'd like to remix the `SaveWorldDialog` for the saving of Projects, I got rid of the `ConstraintLayout` and replaced it with `TilingLayout`s and a few wrapper morphs. 