### PR TITLE
🎨🧰: add option for adaptive cursor coloring

### DIFF
--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -500,6 +500,7 @@ export class TopBarModel extends ViewModel {
             position,
             readOnly: true,
             textString: 'I am a text field!',
+            dynamicCursorColoring: true,
             fill: Color.white
           });
           textMorph.addPlugin(new RichTextPlugin());
@@ -569,7 +570,8 @@ export class TopBarModel extends ViewModel {
     return {
       readOnly: true,
       padding: Rectangle.inset(1, 1, 1, 1),
-      cursorWidth: 1.5
+      cursorWidth: 1.5,
+      dynamicCursorColoring: true
     };
   }
 

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1252,7 +1252,7 @@ export default class Renderer {
     const { textLayout } = morph;
 
     const { start, end, cursorVisible, selectionColor } = selection;
-    let { document, cursorColor } = morph;
+    let { document, cursorColor, cursorPosition } = morph;
     const isReverse = selection.isReverse();
 
     const startBounds = textLayout.boundsFor(morph, start);
@@ -1264,7 +1264,9 @@ export default class Renderer {
     const endPos = pt(endBounds.x, endBounds.y);
 
     const cursorPos = isReverse ? pt(startBounds.x, startBounds.y) : endPos;
-    if (morph.dynamicCursorColoring) cursorColor = morph.textAttributeAt({ row: start.row, column: start.column - 1 })?.fontColor || morph.fontColor || cursorColor;
+
+    if (morph.dynamicCursorColoring) cursorColor = morph.textAttributeAt({ row: cursorPosition.row, column: cursorPosition.column - 1 })?.fontColor || morph.fontColor || cursorColor;
+
     const cursorHeight = isReverse ? leadLineHeight : endLineHeight;
     const renderedCursor = this.cursor(cursorPos, cursorHeight, cursorVisible, diminished, cursorWidth, cursorColor);
 

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1252,7 +1252,7 @@ export default class Renderer {
     const { textLayout } = morph;
 
     const { start, end, cursorVisible, selectionColor } = selection;
-    const { document, cursorColor } = morph;
+    let { document, cursorColor } = morph;
     const isReverse = selection.isReverse();
 
     const startBounds = textLayout.boundsFor(morph, start);
@@ -1264,6 +1264,7 @@ export default class Renderer {
     const endPos = pt(endBounds.x, endBounds.y);
 
     const cursorPos = isReverse ? pt(startBounds.x, startBounds.y) : endPos;
+    if (morph.dynamicCursorColoring) cursorColor = morph.textAttributeAt({ row: start.row, column: start.column - 1 })?.fontColor || morph.fontColor || cursorColor;
     const cursorHeight = isReverse ? leadLineHeight : endLineHeight;
     const renderedCursor = this.cursor(cursorPos, cursorHeight, cursorVisible, diminished, cursorWidth, cursorColor);
 

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -640,6 +640,13 @@ export class Text extends Morph {
         defaultValue: Color.black
       },
 
+      dynamicCursorColoring: {
+        group: 'text styling',
+        type: 'Boolean',
+        isStyleProp: true,
+        defaultValue: false
+      },
+
       fill: {
         group: 'styling',
         after: ['document'],


### PR DESCRIPTION
Since the Cursor Color is a separate property, the cursor was often very hard to see, especially on dark backgrounds. This PR allows to enable adaptive coloring of the cursor, so that the cursor always assumes the color of the character at the current cursor position. The option of hardcoding the cursor color does still exist. Per default, the adaptive cursor coloring is active for text morphs that are created with the topbar and inactive for all other text morphs.

https://user-images.githubusercontent.com/14252419/235676785-eb9a1a9e-7964-44c1-aaef-8644f60f683a.mp4

