### PR TITLE
Fix/text edit popup

### DIFF
--- a/lively.ide/text/rich-text-editor-plugin.js
+++ b/lively.ide/text/rich-text-editor-plugin.js
@@ -80,11 +80,13 @@ export class RichTextPlugin extends EditorPlugin {
     if (!this.textMorph.selection.isEmpty()) {
       const { start } = this.textMorph.selection;
       const startBounds = this.textMorph.charBoundsFromTextPosition(start);
-      const startPoint = this.textMorph.worldPoint({ x: startBounds.x, y: startBounds.y });
-      const pointForPopup = new Point(startPoint.x - 125, startPoint.y - 220 - 20);
-
-      if (this.formattingPopUp) this.formattingPopUp.openInWorld(pointForPopup);
-      else this.formattingPopUp = part(TextFormattingPopUp, { viewModel: { targetMorph: this.textMorph } }).openInWorld(pointForPopup);
+      const startPoint = this.textMorph.worldPoint(startBounds.topLeft());
+      const worldBounds = this.textMorph.world().bounds();
+      if (this.formattingPopUp) this.formattingPopUp.openInWorld();
+      else this.formattingPopUp = part(TextFormattingPopUp, { viewModel: { targetMorph: this.textMorph } }).openInWorld();
+      $world.env.forceUpdate(); // FIXME: can we automatize this?
+      this.formattingPopUp.bottomRight = startPoint;
+      this.formattingPopUp.position = worldBounds.translateForInclusion(this.formattingPopUp.bounds()).topLeft();
     }
   }
 

--- a/lively.ide/text/text-formatting-popup.cp.js
+++ b/lively.ide/text/text-formatting-popup.cp.js
@@ -1,5 +1,4 @@
 import { component, TilingLayout, without, ViewModel, add, part } from 'lively.morphic';
-
 import { DarkPopupWindow } from '../studio/shared.cp.js';
 import { RichTextControl } from '../studio/controls/text.cp.js';
 import { Color } from 'lively.graphics';
@@ -55,7 +54,6 @@ const SelectionBasedRichTextControl = component(RichTextControl, {
 export const TextFormattingPopUp = component(DarkPopupWindow, {
   name: 'formatting pop up',
   defaultViewModel: TextFormattingPopUpModel,
-  fill: Color.rgb(30, 30, 30),
   layout: new TilingLayout({
     axis: 'column',
     axisAlign: 'center',


### PR DESCRIPTION
The fixes 2 issues:
1.) The fill of the richt text popup was for some reason set to a different tone than any of the other popups in the system, which was insane.
2.) I repeatedly ran into issues where the rich text popup would be outside of the world bounds, making it impossible to operate. While it is important not to overlap the text, even more important is for the popup to be usable at all if it appears (I believe)