### PR TITLE
Fix/clear epi morph flag from component defs

### DIFF
--- a/lively.collab/comments/comment-count-badge.js
+++ b/lively.collab/comments/comment-count-badge.js
@@ -18,9 +18,10 @@ export class CommentCountBadgeModel extends ViewModel {
         }
       },
       morph: {},
+      isEpiMorph: { get () { return true; } },
       expose: {
         get () {
-          return ['text', 'addToMorph'];
+          return ['text', 'addToMorph', 'isEpiMorph'];
         }
       },
       bindings: {

--- a/lively.collab/comments/comment-indicator.js
+++ b/lively.collab/comments/comment-indicator.js
@@ -22,9 +22,10 @@ export class CommentIndicatorModel extends ViewModel {
             { signal: 'abandon', handler: 'abandon' }];
         }
       },
+      isEpiMorph: { get () { return true; } },
       expose: {
         get () {
-          return ['isCommentIndicator'];
+          return ['isCommentIndicator', 'isEpiMorph'];
         }
       }
     };

--- a/lively.collab/comments/components/comment-count-badge.cp.js
+++ b/lively.collab/comments/components/comment-count-badge.cp.js
@@ -9,6 +9,7 @@ const CommentCountBadge = component({
   fill: Color.rgb(255, 23, 68),
   borderRadius: 50,
   hasFixedPosition: true,
+  tooltip: '10 unresolved comment',
   layout: new TilingLayout({
     hugContentsVertically: true,
     hugContentsHorizontally: true,
@@ -20,9 +21,7 @@ const CommentCountBadge = component({
     name: 'badge label',
     fontColor: Color.rgb(255, 255, 255),
     textAndAttributes: ['10', null]
-  }],
-  tooltip: '10 unresolved comment',
-  epiMorph: true
+  }]
 });
 
 export { CommentCountBadge };

--- a/lively.collab/comments/components/comment-indicator.cp.js
+++ b/lively.collab/comments/components/comment-indicator.cp.js
@@ -12,8 +12,7 @@ const CommentIndicator = component({
   nativeCursor: 'pointer',
   padding: rect(0, 2, 4, 0),
   textAndAttributes: Icon.textAttribute('comment-alt'),
-  enableHalos: false,
-  epiMorph: true
+  enableHalos: false
 });
 
 const ResolvedIndicator = component({

--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -22,9 +22,14 @@ export class AbstractPromptModel extends ViewModel {
       isPrompt: {
         get () { return true; }
       },
+      isEpiMorph: {
+        get () {
+          return true;
+        }
+      },
       expose: {
         get () {
-          return ['keybindings', 'commands', 'activate', 'isActive', 'isPrompt'];
+          return ['keybindings', 'commands', 'activate', 'isActive', 'isPrompt', 'isEpiMorph'];
         }
       }
     };
@@ -707,7 +712,6 @@ const ChoiceButtonUnselected = component(ChoiceButtonSelected, {
 const LightPrompt = component({
   name: 'light prompt',
   borderRadius: 8,
-  epiMorph: true,
   dropShadow: new ShadowObject({ distance: 5, rotation: 75, color: Color.rgba(0, 0, 0, 0.37), blur: 60, fast: false }),
   extent: pt(387, 60),
   fill: Color.rgb(251, 252, 252),

--- a/lively.freezer/src/ui.cp.js
+++ b/lively.freezer/src/ui.cp.js
@@ -83,7 +83,6 @@ export default class FreezerPromptModel extends AbstractPromptModel {
           return this.ui.dirInput.input;
         }
       },
-      epiMorph: { defaultValue: true },
       isModuleBundle: { defaultValue: true },
       excludedPackages: {
         derived: true,

--- a/lively.ide/studio/flap.cp.js
+++ b/lively.ide/studio/flap.cp.js
@@ -19,9 +19,10 @@ export class FlapModel extends ViewModel {
           ];
         }
       },
+      isEpiMorph: { get () { return true; } },
       expose: {
         get () {
-          return ['onWorldResize', 'isFlap', 'executeAction'];
+          return ['onWorldResize', 'isFlap', 'executeAction', 'isEpiMorph'];
         }
       }
     };
@@ -44,7 +45,6 @@ export class FlapModel extends ViewModel {
   }
 }
 
-// part(Flap, {viewModel: {target: 'properties panel'} }).openInWorld();
 const Flap = component({
   name: 'flap',
   nativeCursor: 'pointer',
@@ -60,7 +60,6 @@ const Flap = component({
   extent: pt(30, 120),
   fill: Color.rgb(30, 30, 30).withA(0.95),
   halosEnabled: false,
-  epiMorph: true,
   submorphs: [
     {
       type: 'label',

--- a/lively.ide/studio/zoom-indicator.cp.js
+++ b/lively.ide/studio/zoom-indicator.cp.js
@@ -6,8 +6,11 @@ class WorldZoomIndicatorModel extends ViewModel {
     return {
       expose: {
         get () {
-          return ['isZoomIndicator', 'onMouseDown', 'relayout', 'updateZoomLevel'];
+          return ['isZoomIndicator', 'onMouseDown', 'relayout', 'updateZoomLevel', 'isEpiMorph'];
         }
+      },
+      isEpiMorph: {
+        get () { return true; }
       },
       bindings: {
         get () {
@@ -44,10 +47,7 @@ class WorldZoomIndicatorModel extends ViewModel {
   }
 }
 
-// part(WorldZoomIndicator).openInWorld();
 export const WorldZoomIndicator = component({
-  type: Morph,
-  epiMorph: true,
   defaultViewModel: WorldZoomIndicatorModel,
   name: 'zoom indicator',
   borderColor: Color.rgb(23, 160, 251),

--- a/lively.ide/styling/shared.cp.js
+++ b/lively.ide/styling/shared.cp.js
@@ -21,7 +21,9 @@ const CloseButtonDefault = component({
   textAndAttributes: ['', { }]
 });
 
-const CloseButtonHovered = component(CloseButtonDefault, { name: 'close button hovered', fill: Color.gray });
+const CloseButtonHovered = component(CloseButtonDefault, {
+  name: 'close button hovered', fill: Color.gray
+});
 
 const CloseButton = component(CloseButtonDefault, {
   name: 'close button',
@@ -78,7 +80,6 @@ const PopupWindow = component({
   styleClasses: ['Popups'],
   submorphs: [{
     name: 'header menu',
-    epiMorph: true,
     borderWidth: { top: 0, left: 0, right: 0, bottom: 1 },
     borderColor: Color.rgb(215, 219, 221),
     extent: pt(241, 40.5),
@@ -95,7 +96,6 @@ const PopupWindow = component({
       {
         type: Label,
         name: 'title',
-        epiMorph: true,
         padding: rect(10, 0, -10, 0),
         fontWeight: 'bold',
         textString: 'Window title'


### PR DESCRIPTION
Eradicates the hard coded `epiMorph` property directly on the component definitions, since this will break reconciliation as reported in #842. We instead move over to an exposed `isEpiMorph` getter, which is activated once the view model is attached.