### PR TITLE
🎨: fix getSubSpecAt() call policy.__serialize__() expressions

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -300,7 +300,7 @@ export class StylePolicy {
       return;
     }
     return expressionSerializer.exprStringEncode({
-      __expr__: meta.exportedName + (meta.path.length ? `.stylePolicy.getSubSpecAt(${meta.path.map(name => JSON.stringify(name)).join(',')})` : ''),
+      __expr__: meta.exportedName + (meta.path.length ? `.stylePolicy.getSubSpecAt([${meta.path.map(name => JSON.stringify(name)).join(',')}])` : ''),
       bindings: { [meta.moduleId]: meta.exportedName }
     });
   }


### PR DESCRIPTION
Adds a missing line to #839 that somehow was not included in the PR but is essential for making things work. Closes #844.