### PR TITLE
🛠️🗒️: build landing page in docker container and advise against docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This is the repository of the [lively.next project](https://lively-next.org).
 You can install lively.next "natively" on your system or use Docker for your development environment.
 Please note, that these instructions currently are are not recommended for openly deploying lively.next in the web!
 
+> **Warning**
+> If there are no technically constraining reasons that prevent you from using the native installation, we highly advise to do so!
+
 ### Native Installation
 
 Currently, the MacOS, Linux, and the Linux Subsystem for Windows are supported.

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,9 @@ mkdir esm_cache
 node --no-experimental-fetch --no-warnings --experimental-loader $lv_next_dir/flatn/resolver.mjs \
      lively.installer/bin/install.cjs $PWD \
 
-if [ ! "$CI" ];
+# Inside of docker, we have CI set to never minify the code
+# but we still want the loading page to be built! 
+if [[ -z "${CI}" || "${CONTAINERIZED}" == "true" ]];
 then
   npm --prefix $lv_next_dir/lively.freezer/ run build-landing-page
 fi


### PR DESCRIPTION
The problem was that the CI variable is "overloaded" in the sense that we use it to skip minification locally and skip entire build steps remotely.
The advanced condition will now build the landing page in the docker container as well, while not minifying the code (at least for the loading-screen, skipping the minification in the landing page is in #684. 