### PR TITLE
🧰: ensure new empty js modules are in esm format

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -2384,7 +2384,8 @@ export class BrowserModel extends ViewModel {
     }
     if (!name) return;
     let dirPath = joinPath(dir, name);
-    await coreInterface.resourceEnsureExistance(dirPath);
+    await coreInterface.resourceEnsureExistance(dirPath, '\'format esm\';');
+
     // uncollapse the parent node of the dir
     const parentNode = columnView.getExpandedPath().find(n => n.url === dir);
     if (parentNode) await td.collapse(parentNode, false);


### PR DESCRIPTION
Closes #852.