### PR TITLE
📂🧰: only bind and check projects against (shared) commits on main

### DIFF
--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -769,6 +769,8 @@ const InformPrompt = component(LightPrompt, {
   }, add({
     type: Text,
     name: 'additional text',
+    fontFamily: '"IBM Plex Sans"',
+    fontSize: 16,
     visible: false
   }),
   add(part(GreenButton, {


### PR DESCRIPTION
This intends to make it easier to work with feature branches in combination with projects while developing the core of lively.next. Previously, we would bind projects against the currently checked out commit. When developing on a feature branch, especially when using `git rebase`, this often lead to situations where projects would not open anymore due to incompatible versions.

We now only bind against commits on `main`.
The check for a compatible version also checks the relationship between the latest commit that is shared with `main` and the currently checked out branch and the version specified in the `package.json` of the project.

The following scenarios are possible:
1. Both are the same and we are good to go.
2. The latest shared commit is newer than the previous commit from `main` we bound the project against. In this case, we update the bound version in the `package.json` of the project.
3. If the version of `main` in the `package.json` is newer than the latest shared commit of the running lively and `main`, we need to update our lively. Previously, we aborted the loading of the project in these cases. Now, we only display an explicit warning, but continue loading the project. This is an additional change that intends to make quickly testing stuff easier.

@merryman I tested this and I think it works as expected, but a thorough review for content and not "only" code would be appreciated!