### PR TITLE
🧰: fetch current remote before checking if lively is up to date

### DIFF
--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -39,6 +39,8 @@ class VersionChecker extends Morph {
 
   static async currentLivelyVersion (main) {
     const cwd = await VersionChecker.cwd();
+    const fetchCmd = `git fetch`
+    await runCommand(fetchCmd, { cwd }).whenDone();
     const hashCmd = main ? 'git merge-base origin/main HEAD' : 'git rev-parse @';
     const result = await runCommand(hashCmd, { cwd }).whenDone();
     return result.stdout.trim();


### PR DESCRIPTION
The Version Checker did not call git fetch previously, which lead to comparisons with outdated branch statuses, if one did not performed a manual fetch.