### PR TITLE
🗒️: add requirements for project feature to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Make sure you have the following software installed.
 1. `node.js v18.12.1`
 2. `git`
 
+> **Warning**
+> To use all features of `lively.next`, please note the following:
+> - `git` needs to be at least version `2.28`
+> - make sure that you have configured git with a committer name and e-mail address
+> - you need SSH keys (usually in `~/.ssh`) that are set up with your GitHub account.
+
 For some more advanced development operations (bulk testing from the command line), you will also need 
 
 - `sed` or `gsed` on MacOs


### PR DESCRIPTION
We recently discovered that not having setup SSH access with `git` and GitHub, as well as a `git` version below `2.28` will crash the creation/opening of projects. The version requirement stems from `git init -b`.
This PR mentions these requirements in the README.