### PR TITLE
🧰: ensure names present for buttons in top bar def

### DIFF
--- a/lively.collab/comments/comment-browser.js
+++ b/lively.collab/comments/comment-browser.js
@@ -158,8 +158,6 @@ export class CommentBrowserModel extends ViewModel {
       }
     });
     if (earlyReturn) return false;
-    const topbar = $world.getSubmorphNamed('lively top bar');
-    if (topbar) topbar.colorTopbarButton('comment browser button', false);
     let badge = $world.get('comment count badge');
     if (badge) badge.abandon();
     this.removeAllCommentIndicators();

--- a/lively.ide/studio/top-bar-buttons.cp.js
+++ b/lively.ide/studio/top-bar-buttons.cp.js
@@ -6,11 +6,15 @@ class TopBarButtonModel extends ViewModel {
     return {
       expose: {
         get () {
-          return ['activateButton', 'deactivateButton'];
+          return ['activateButton', 'deactivateButton', 'changeIcon'];
         }
       },
       opts: {}
     };
+  }
+
+  changeIcon (iconAttributes) {
+    this.ui.symbol.textAndAttributes = iconAttributes;
   }
 
   activateButton () {
@@ -44,7 +48,7 @@ class TopBarButtonDropDownModel extends ViewModel {
     return {
       expose: {
         get () {
-          return ['dropdown', 'symbol', 'activateButton', 'deactivateButton', 'removeDropdown'];
+          return ['activateButton', 'deactivateButton', 'removeDropdown'];
         }
       },
       opts: {}
@@ -52,31 +56,19 @@ class TopBarButtonDropDownModel extends ViewModel {
   }
 
   activateButton () {
-    this.symbol.master = TopBarButtonSelected;
+    this.ui.symbol.master = TopBarButtonSelected;
   }
 
   deactivateButton () {
-    this.symbol.master = null;
-  }
-
-  get dropdown () {
-    return this.view.get(this.opts.dropdown.name);
-  }
-
-  get symbol () {
-    return this.view.get(this.opts.symbol.name);
+    this.ui.symbol.master = null;
   }
 
   viewDidLoad () {
     const { view, opts } = this;
-    view.name = opts.name;
     view.tooltip = opts.tooltip;
-    const symbolButton = view.get('symbol');
-    const dropdownButton = view.get('dropdown');
-    symbolButton.name = opts.symbol.name;
+    const symbolButton = this.ui.symbol;
     symbolButton.tooltip = opts.symbol.tooltip;
     symbolButton.textAndAttributes = opts.symbol.textAndAttributes;
-    dropdownButton.name = opts.dropdown.name;
   }
 
   /**
@@ -85,8 +77,7 @@ class TopBarButtonDropDownModel extends ViewModel {
    * or actually dealing with exchanging the button where we want to downgrade
    */
   removeDropdown () {
-    const dropdown = this.view.get(this.opts.dropdown.name);
-    dropdown.remove();
+    this.ui.dropdown.remove();
   }
 }
 

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -919,6 +919,7 @@ const TopBar = component({
         tooltip: 'Redo'
       }),
       part(TopBarButtonDropDown, {
+        name: 'save button',
         viewModel: {
           opts: {
             name: 'save button',
@@ -935,6 +936,7 @@ const TopBar = component({
         }
       }),
       part(TopBarButtonDropDown, {
+        name: 'hand or halo mode button',
         viewModel: {
           opts: {
             name: 'hand or halo mode button',
@@ -955,6 +957,7 @@ const TopBar = component({
         textAndAttributes: Icon.textAttribute('font'),
         tooltip: 'Create textbox mode'
       }), part(TopBarButtonDropDown, {
+        name: 'shape mode button',
         viewModel: {
           opts: {
             name: 'shape mode button',
@@ -989,6 +992,7 @@ const TopBar = component({
         tooltip: 'Toggle Comment Browser'
       }),
       part(TopBarButtonDropDown, {
+        name: 'canvas mode button',
         viewModel: {
           opts: {
             name: 'canvas mode button',


### PR DESCRIPTION
The top bar component definition included a bunch of button parts, that did not have their name directly declared. This currently does not bode well with our component tooling, and I would suggests for the time being to keep the names around,  even though it is sort of "redundant" in this case.