### PR TITLE
🧰: don't exclude vars with underscore in name from `no-unused-vars` rule

### DIFF
--- a/lively.ide/js/linter.js
+++ b/lively.ide/js/linter.js
@@ -91,7 +91,7 @@ const rules = {
   'no-debugger': 'warn',
   'no-unreachable': 'warn',
   'no-const-assign': 'warn',
-  'no-unused-vars': ['warn', { args: 'none', varsIgnorePattern: '_' }],
+  'no-unused-vars': 'warn',
   'no-use-before-define': ['error', { functions: true, classes: true, variables: true }],
   'no-constructor-return': 'error',
   'no-console': 'warn'


### PR DESCRIPTION
Variables that contained a underscore matched the provided pattern and thus did not trigger a warning when they were imported/defined without being used.

I suspect that we just copied that from somewhere and had no special thoughts when originally setting this rule. :woman_shrugging: 