### PR TITLE
🐚: stop `ENOENT` from non-existing `cwd` from killing the server

### DIFF
--- a/lively.shell/server-command.js
+++ b/lively.shell/server-command.js
@@ -169,7 +169,6 @@ export default class ServerCommand extends CommandInterface {
       this.emit('error', err.stack);
       signal(this, 'error', err.stack);
       this.exitCode = 1;
-      reject(err);
     });
   }
 


### PR DESCRIPTION
Closes #897.

From the `nodeJS` docs:
> Use cwd to specify the working directory from which the process is spawned. If not given, the default is to inherit the current working directory. If given, but the path does not exist, the child process emits an ENOENT error and exits immediately. ENOENT is also emitted when the command does not exist.

For not entirely clear reasons, the now removed `reject()` call crashed the server and we were unable to fix that neither with `try/catch` nor with `Promise.catch()`.