### PR TITLE
🎨: fix style prop patching of dom nodes

### DIFF
--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -885,15 +885,15 @@ export class TilingLayout extends Layout {
         margin.right = 0;
       } else {
         style.width = 'unset';
-        style.flexGrow = 1;
-        style.flexShrink = 1;
+        style['flex-grow'] = 1;
+        style['flex-shrink'] = 1;
       } // let flex handle that
     }
     if (this.getResizeHeightPolicyFor(morph) === 'fill') {
       if (isVertical) {
         style.height = 'unset';
-        style.flexGrow = 1; // let flex handle that
-        style.flexShrink = 1;
+        style['flex-grow'] = 1; // let flex handle that
+        style['flex-shrink'] = 1;
       } else {
         style.height = `calc(100% + ${margin.offset}px)`;
         margin.bottom = 0;
@@ -907,11 +907,11 @@ export class TilingLayout extends Layout {
     style.top = 'unset';
     style.left = 'unset';
     style.order = layoutableSubmorphs.indexOf(morph);
-    style.marginTop = `${margin.top}px`;
-    style.marginBottom = `${margin.bottom}px`;
-    style.marginLeft = `${margin.left}px`;
-    style.marginRight = `${margin.right}px`;
-    if (Number.parseInt(style.flexGrow) !== 1) style.flexShrink = 0;
+    style['margin-top'] = `${margin.top}px`;
+    style['margin-bottom'] = `${margin.bottom}px`;
+    style['margin-left'] = `${margin.left}px`;
+    style['margin-right'] = `${margin.right}px`;
+    if (Number.parseInt(style['flex-grow']) !== 1) style['flex-shrink'] = 0;
     this.measureAfterRender(morph);
   }
 
@@ -976,28 +976,28 @@ export class TilingLayout extends Layout {
       ? container.borderWidthLeft + container.borderWidthRight
       : container.borderWidthTop + container.borderWidthBottom;
     style.gap = `${spacing + spacingOffset}px`;
-    style.justifyContent = ({
+    style['justify-content'] = ({
       left: 'flex-start',
       center: 'center',
       right: 'flex-end'
     })[align];
-    style.flexFlow = axis;
-    if (wrapSubmorphs) style.flexFlow += ' wrap';
-    style.alignItems = ({
+    style['flex-flow'] = axis;
+    if (wrapSubmorphs) style['flex-flow'] += ' wrap';
+    style['align-items'] = ({
       center: 'center',
       left: 'flex-start',
       right: 'flex-end'
     })[axisAlign];
-    style.alignContent = ({
+    style['align-content'] = ({
       center: 'center',
       left: 'flex-start',
       right: 'flex-end'
     })[axisAlign];
-    if (justifySubmorphs === 'spaced') style.justifyContent = 'space-between';
-    style.paddingTop = `${padding.top()}px`;
-    style.paddingLeft = `${padding.left()}px`;
-    style.paddingRight = `${padding.right()}px`;
-    style.paddingBottom = `${padding.bottom()}px`;
+    if (justifySubmorphs === 'spaced') style['justify-content'] = 'space-between';
+    style['padding-top'] = `${padding.top()}px`;
+    style['padding-left'] = `${padding.left()}px`;
+    style['padding-right'] = `${padding.right()}px`;
+    style['padding-bottom'] = `${padding.bottom()}px`;
     if (hugContentsHorizontally) {
       style.width = 'auto';
     }
@@ -3030,10 +3030,10 @@ export class GridLayout extends Layout {
     if (!area) return;
     const { minCol, maxCol, minRow, maxRow, padding } = area;
     style.margin = padding.top() + 'px ' + padding.right() + 'px ' + padding.bottom() + 'px ' + padding.left() + 'px';
-    style.gridColumnStart = minCol + 1;
-    style.gridColumnEnd = maxCol + 2;
-    style.gridRowStart = minRow + 1;
-    style.gridRowEnd = maxRow + 2;
+    style['grid-column-start'] = minCol + 1;
+    style['grid-column-end'] = maxCol + 2;
+    style['grid-row-start'] = minRow + 1;
+    style['grid-row-end'] = maxRow + 2;
     style.position = 'relative';
     style.top = 'unset';
     style.left = 'unset';
@@ -3097,8 +3097,8 @@ export class GridLayout extends Layout {
       if (row.fixed) return row.length + 'px';
       else return row.proportion + 'fr';
     });
-    style.gridTemplateColumns = cols.join(' ');
-    style.gridTemplateRows = rows.join(' ');
+    style['grid-template-columns'] = cols.join(' ');
+    style['grid-template-rows'] = rows.join(' ');
   }
 
   /**

--- a/lively.morphic/rendering/morphic-default.js
+++ b/lively.morphic/rendering/morphic-default.js
@@ -311,7 +311,6 @@ div.text-layer span {
 .Text .annotation {
   position: relative;
   float: right;
-  top: 50%;
   text-align: right;
 }
 

--- a/lively.morphic/rendering/property-dom-mapping.js
+++ b/lively.morphic/rendering/property-dom-mapping.js
@@ -11,6 +11,7 @@ const propsToDelete = [
   'margin-top',
   'margin',
   'gap',
+  'background-image',
   'place-content',
   'flex-flow', 'flex-grow', 'flex-shrink',
   'align-items', 'align-self',
@@ -114,7 +115,7 @@ export function addTransform (morph, style) {
   x = morph.renderOnGPU ? x : num.roundTo(x, 0.01);
   y = morph.renderOnGPU ? y : num.roundTo(y, 0.01);
   if (promoteToCompositionLayer) {
-    style.willChange = 'transform';
+    style['will-change'] = 'transform';
   }
   if ((owner && owner.isText && !owner.layout?.renderViaCSS) || promoteToCompositionLayer) {
     style.transform = (promoteToCompositionLayer ? `translate(${x}px, ${y}px)` : `translate(${x}px, ${y}px)`);
@@ -133,7 +134,7 @@ export function addTransform (morph, style) {
 
 function addTransformOrigin (morph, style) {
   const { origin } = morph;
-  if (origin) style.transformOrigin = `${origin.x}px ${origin.y}px`;
+  if (origin) style['transform-origin'] = `${origin.x}px ${origin.y}px`;
 }
 
 function addDisplay (morph, style) {
@@ -143,7 +144,7 @@ function addDisplay (morph, style) {
 
 function addBorderRadius (morph, style) {
   const { borderRadiusTopLeft, borderRadiusTopRight, borderRadiusBottomRight, borderRadiusBottomLeft } = morph;
-  style.borderRadius = `${borderRadiusTopLeft}px ${borderRadiusTopRight}px ${borderRadiusBottomRight}px ${borderRadiusBottomLeft}px`;
+  style['border-radius'] = `${borderRadiusTopLeft}px ${borderRadiusTopRight}px ${borderRadiusBottomRight}px ${borderRadiusBottomLeft}px`;
 }
 
 function addBorder (morph, style) {
@@ -153,19 +154,18 @@ function addBorder (morph, style) {
     borderWidthBottom, borderColorBottom, borderStyleBottom,
     borderWidthTop, borderColorTop, borderStyleTop
   } = morph;
-  const t = (s) => bowser.safari ? string.camelize(s) : s;
-  style[t('border-left-style')] = `${borderStyleLeft}`;
-  style[t('border-right-style')] = `${borderStyleRight}`;
-  style[t('border-bottom-style')] = `${borderStyleBottom}`;
-  style[t('border-top-style')] = `${borderStyleTop}`;
-  style[t('border-left-width')] = `${borderWidthLeft}px`;
-  style[t('border-right-width')] = `${borderWidthRight}px`;
-  style[t('border-bottom-width')] = `${borderWidthBottom}px`;
-  style[t('border-top-width')] = `${borderWidthTop}px`;
-  style[t('border-top-color')] = borderColorTop ? borderColorTop.toString() : 'transparent';
-  style[t('border-right-color')] = borderColorRight ? borderColorRight.toString() : 'transparent';
-  style[t('border-bottom-color')] = borderColorBottom ? borderColorBottom.toString() : 'transparent';
-  style[t('border-left-color')] = borderColorLeft ? borderColorLeft.toString() : 'transparent';
+  style['border-left-style'] = `${borderStyleLeft}`;
+  style['border-right-style'] = `${borderStyleRight}`;
+  style['border-bottom-style'] = `${borderStyleBottom}`;
+  style['border-top-style'] = `${borderStyleTop}`;
+  style['border-left-width'] = `${borderWidthLeft}px`;
+  style['border-right-width'] = `${borderWidthRight}px`;
+  style['border-bottom-width'] = `${borderWidthBottom}px`;
+  style['border-top-width'] = `${borderWidthTop}px`;
+  style['border-top-color'] = borderColorTop ? borderColorTop.toString() : 'transparent';
+  style['border-right-color'] = borderColorRight ? borderColorRight.toString() : 'transparent';
+  style['border-bottom-color'] = borderColorBottom ? borderColorBottom.toString() : 'transparent';
+  style['border-left-color'] = borderColorLeft ? borderColorLeft.toString() : 'transparent';
   if (borderColor && borderColor.isGradient) style['border-image'] = borderColor.toString();
 }
 
@@ -179,7 +179,7 @@ function addFill (morph, style) {
     // we need to set the background color to something
     // that does not interfere with the opaque fill.
     style.background = Color.transparent.toString();
-    style.backgroundImage = fill.toString();
+    style['background-image'] = fill.toString();
   } else style.background = fill.toString();
 }
 
@@ -198,9 +198,9 @@ function addShadowStyle (morph, style) {
 
   const { dropShadow } = morph;
   if ((dropShadow && dropShadow.fast) || (dropShadow && dropShadow.inset)) {
-    style.boxShadow = dropShadow ? dropShadow.toCss() : 'none';
+    style['box-shadow'] = dropShadow ? dropShadow.toCss() : 'none';
   } else {
-    style.boxShadow = '';
+    style['box-shadow'] = '';
     style.filter = dropShadow ? dropShadow.toFilterCss() : '';
   }
 }

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -668,7 +668,7 @@ export default class Renderer {
 
     canvasNode.style.width = `${this.width}px`;
     canvasNode.style.height = `${this.height}px`;
-    canvasNode.style.pointerEvents = 'none';
+    canvasNode.style['pointer-events'] = 'none';
     canvasNode.style.position = 'absolute';
 
     node.appendChild(canvasNode);
@@ -1018,24 +1018,24 @@ export default class Renderer {
           if (link && link.startsWith('http')) chunkNodeAttributes.target = '_blank';
         }
 
-        if (link || nativeCursor) chunkNodeStyle.pointerEvents = 'auto';
+        if (link || nativeCursor) chunkNodeStyle['pointer-events'] = 'auto';
 
         if (obj.isNumber(opacity)) chunkNodeStyle.opacity = opacity;
-        if (fontSize) chunkNodeStyle.fontSize = fontSize;
-        if (fontFamily) chunkNodeStyle.fontFamily = fontFamily;
-        if (fontWeight) chunkNodeStyle.fontWeight = fontWeight;
-        if (fontStyle) chunkNodeStyle.fontStyle = fontStyle;
-        if (textDecoration) chunkNodeStyle.textDecoration = textDecoration;
+        if (fontSize) chunkNodeStyle['font-size'] = fontSize;
+        if (fontFamily) chunkNodeStyle['font-family'] = fontFamily;
+        if (fontWeight) chunkNodeStyle['font-weight'] = fontWeight;
+        if (fontStyle) chunkNodeStyle['font-style'] = fontStyle;
+        if (textDecoration) chunkNodeStyle['text-decoration'] = textDecoration;
         if (fontColor) chunkNodeStyle.color = String(fontColor);
-        if (backgroundColor) chunkNodeStyle.backgroundColor = String(backgroundColor);
+        if (backgroundColor) chunkNodeStyle['background-color'] = String(backgroundColor);
         if (nativeCursor) chunkNodeStyle.cursor = nativeCursor;
-        if (paddingRight) chunkNodeStyle.paddingRight = paddingRight;
-        if (paddingLeft) chunkNodeStyle.paddingLeft = paddingLeft;
-        if (paddingTop) chunkNodeStyle.paddingTop = paddingTop;
-        if (paddingBottom) chunkNodeStyle.paddingBottom = paddingBottom;
-        if (verticalAlign) chunkNodeStyle.verticalAlign = verticalAlign;
+        if (paddingRight) chunkNodeStyle['padding-right'] = paddingRight;
+        if (paddingLeft) chunkNodeStyle['padding-left'] = paddingLeft;
+        if (paddingTop) chunkNodeStyle['padding-top'] = paddingTop;
+        if (paddingBottom) chunkNodeStyle['padding-bottom'] = paddingBottom;
+        if (verticalAlign) chunkNodeStyle['vertical-align'] = verticalAlign;
         if (textStroke) chunkNodeStyle['-webkit-text-stroke'] = textStroke;
-        if (attributes.doit) { chunkNodeStyle.pointerEvents = 'auto'; chunkNodeStyle.cursor = 'pointer'; }
+        if (attributes.doit) { chunkNodeStyle['pointer-events'] = 'auto'; chunkNodeStyle.cursor = 'pointer'; }
 
         const chunkNode = this.doc.createElement(tagname);
         chunkNode.textContent = content || '&nbsp';
@@ -1049,10 +1049,10 @@ export default class Renderer {
 
     const lineStyle = {};
 
-    if (lineHeight) lineStyle.lineHeight = lineHeight;
-    if (textAlign) lineStyle.textAlign = textAlign;
-    if (letterSpacing) lineStyle.letterSpacing = letterSpacing + 'px';
-    if (wordSpacing) lineStyle.wordSpacing = wordSpacing + 'px';
+    if (lineHeight) lineStyle['line-height'] = lineHeight;
+    if (textAlign) lineStyle['text-align'] = textAlign;
+    if (letterSpacing) lineStyle['letter-spacing'] = letterSpacing + 'px';
+    if (wordSpacing) lineStyle['word-spacing'] = wordSpacing + 'px';
     let node = this.doc.createElement('div');
     node.className = 'line';
     if (lineObject.isLine) {


### PR DESCRIPTION
Inconsistent mixing of dashed and camel case notation of css style prop names inside the renderer, would cause the render update logic to have difficulty clearing old, unused props for the DOM.