### PR TITLE
🎨🧰: prevent infinite loops on console menu/command getters

### DIFF
--- a/lively.ide/debug/console.cp.js
+++ b/lively.ide/debug/console.cp.js
@@ -69,10 +69,10 @@ export function prepareConsole (platformConsole, consoleMethods = defaultConsole
     // find all methods on `platformConsole` which need to be instrumented
     let methods = Object.keys(platformConsole)
       .filter(name => typeof platformConsole[name] === 'function' &&
-                  // we back up the original function source of x() with $x() below
-                  !name.startsWith('$') &&
-                  !platformConsole.hasOwnProperty('$' + name) &&
-                  !exceptions.includes(name));
+        // we back up the original function source of x() with $x() below
+        !name.startsWith('$') &&
+        !platformConsole.hasOwnProperty('$' + name) &&
+        !exceptions.includes(name));
     let activationState = {};
 
     methods.forEach(name => {
@@ -231,7 +231,7 @@ class LocalJSConsoleModel extends ViewModel {
   }
 
   get keybindings () {
-    const viewKeybindings = this.withoutBindingsDo(() => { return this.view.keybindings; });
+    const viewKeybindings = this.withoutExposedPropsDo(() => this.view.keybindings);
     return [
       { keys: { mac: 'Meta-K', win: 'Ctrl-Alt-K' }, command: '[console] clear' },
       ...viewKeybindings
@@ -239,7 +239,7 @@ class LocalJSConsoleModel extends ViewModel {
   }
 
   get commands () {
-    const viewCommands = this.withoutBindingsDo(() => { return this.view.commands; });
+    const viewCommands = this.withoutExposedPropsDo(() => this.view.commands);
     return [
       {
         name: '[console] clear',
@@ -250,7 +250,7 @@ class LocalJSConsoleModel extends ViewModel {
   }
 
   async menuItems () {
-    const viewItems = await this.withoutBindingsDo(async () => await this.view.menuItems());
+    const viewItems = await this.withoutExposedPropsDo(() => this.view.menuItems());
     return [
       { command: '[console] clear', target: this, alias: 'clear' },
       { isDivider: true },

--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -451,6 +451,31 @@ export class ViewModel {
     }
   }
 
+  clearExposedProps () {
+    for (let prop of (this.expose || [])) {
+      if (obj.isArray(prop)) prop = prop[0];
+      delete this.view[prop];
+    }
+  }
+
+  /**
+   * Invoke the given callback function without the viewModel exposing any props.
+   * In case the function is asynchronous, the bindings will be disabled as long as the function needs to terminate.
+   * @param { function } cb - The function to invoke while the bindings are disabled.
+   * @return { } - The value returned by `cb`.
+   */
+  withoutExposedPropsDo (cb) {
+    this.clearExposedProps();
+    let res;
+    try {
+      res = cb();
+    } catch (err) {
+      console.error(err.message);
+    }
+    if (res && res.then) { return res.then(() => { this.reifyExposedProps(); return res; }); } else this.reifyExposedProps();
+    return res;
+  }
+
   disableBindings () {
     this.getBindingConnections().forEach(conn => conn.deactivate());
   }

--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -300,10 +300,7 @@ export class ViewModel {
     this.clearBindings();
     this.liveStyleClasses.forEach(klass => this.view.removeStyleClass(klass));
     if (!this.view) return;
-    for (let prop of (this.expose || [])) {
-      if (obj.isArray(prop)) prop = prop[0];
-      delete this.view[prop];
-    }
+    this.clearExposedProps();
   }
 
   onViewChange (change) {

--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -487,6 +487,7 @@ export class ViewModel {
    * unintended feedback cycles. In case the function is asynchronous, the bindings will
    * be disabled as long as the function needs to terminate.
    * @param { function } cb - The function to invoke while the bindings are disabled.
+   * @return { } - The value returned by `cb`.
    */
   withoutBindingsDo (cb) {
     this.disableBindings();
@@ -496,7 +497,7 @@ export class ViewModel {
     } catch (err) {
       console.error(err.message);
     }
-    if (res && res.then) { return res.then(() => { this.onActivate(); return res; }); } else this.enableBindings();
+    if (res && res.then) { return res.then(() => { this.enableBindings(); return res; }); } else this.enableBindings();
     return res;
   }
 


### PR DESCRIPTION
Fixes a fatal crash in the log console that is caused by a new implementation of the view model we recently merged #900.