### PR TITLE
Fix/auto update

### DIFF
--- a/lively.2lively/client.js
+++ b/lively.2lively/client.js
@@ -121,12 +121,12 @@ export default class L2LClient extends L2LConnection {
 
     const origin = urlHelper.root(url).replace(/\/+$/, '');
     const path = urlHelper.path(url);
-    const key = this.clientKey(origin, path, namespace || '');
-    let client = this.clients.get(key);
+    const key = L2LClient.clientKey(origin, path, namespace || '');
+    let client = L2LClient.clients.get(key);
 
     if (!client) {
-      this.clients.set(key,
-        client = this.create({ ...options, url, namespace }));
+      L2LClient.clients.set(key,
+        client = L2LClient.create({ ...options, url, namespace }));
     }
 
     return client;
@@ -478,8 +478,8 @@ export default class L2LClient extends L2LConnection {
       const peer = { ...obj.dissoc(record, ['info']), id, world, location, type };
       userToken = userToken || l2lUserToken;
       if (userToken && userToken !== 'null') {
-          peer.userToken = userToken;
-          peer.userRealm = userRealm;
+        peer.userToken = userToken;
+        peer.userRealm = userRealm;
       }
       return peer;
     });

--- a/lively.server/plugins/l2l.js
+++ b/lively.server/plugins/l2l.js
@@ -1,4 +1,6 @@
 import Tracker from "lively.2lively/tracker.js";
+import L2LClient from "lively.2lively/client.js"
+import { runCommand } from 'lively.shell/client-command.js';
 
 export default class Lively2LivelyPlugin {
 
@@ -29,7 +31,28 @@ export default class Lively2LivelyPlugin {
     this.l2lTracker = Tracker.ensure({namespace: l2lNamespace, io, hostname, port});
 
     this.l2lTracker.whenOnline(1000)
-      .then(() => livelyServer.debug && console.log(`[lively.server] started ${this.l2lTracker}`))
+      .then(
+        () => { livelyServer.debug && console.log(`[lively.server] started ${this.l2lTracker}`);
+          let {hostname, port} = livelyServer
+
+          const client = new L2LClient.ensure({
+              url: `http://${hostname}:${port}/lively-socket.io`,
+              namespace: "l2l",
+              info: {
+                type: 'git version checker'
+              }
+          });
+          client.whenRegistered().then(
+              async () => {
+                const fetchCmd = 'git fetch';
+                await runCommand(fetchCmd, {l2lClient: client}).whenDone();
+                const hashCmd = 'git merge-base origin/main HEAD';
+                const result = await runCommand(hashCmd, {l2lClient: client}).whenDone();
+                const hash = result.stdout.trim();
+                client.addService('check git version', (tracker, msg, ackFn, sender) => { ackFn(msg.data.payload === hash) })
+              }
+          );
+      })
       .catch(err => console.error(`[lively.server] Error starting l2l tracker ${err.stack}`));
   }
 


### PR DESCRIPTION
This adds a reliable mechanism for the client to get notified when the server has started, which is important for the GUI controlled update mechanism.
Previously, we used `onReconnect` of the l2l client, which got fired on other occasions too (e.g., returning to a lively that was in the background for some time).