### PR TITLE
🛠️: enable `--debug` flag for `start.sh` again after auto-update

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-trap './start-server.sh' TERM
+debug=''
+trap './start-server.sh "$debug"' TERM
+if [ "$1" = "--debug" ]; then
+  debug='--debug'
+  ./start-server.sh --debug
+fi
 ./start-server.sh


### PR DESCRIPTION
The detour via the temporary variable is for input sanitation, as we do not want to pass any arguments expect for `--debug`.