### PR TITLE
🛠️🧰: enforce `LF` line-endings in repository and system browser

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -815,10 +815,14 @@ export class BrowserModel extends ViewModel {
 
   updateSource (source, cursorPos) {
     const ed = this.ui.sourceEditor;
+
+    source = source.split(objectReplacementChar).join('');
+    source = source.replaceAll(/\r\n/g, '\n');
+
     if (ed.textString !== source) {
       ed.textString = source;
     }
-    source = source.split(objectReplacementChar).join('');
+
     this.resetChangedContentIndicator();
     this.state.moduleChangeWarning = null;
     if (cursorPos) ed.cursorPosition = cursorPos;


### PR DESCRIPTION
See https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_formatting_and_whitespace for more information.

The git conversion kicks in only when a file is actually committed. Therefore, I also enforced the line ending on system browser level. Doing this, is think I also discovered a bug in `updateSource`, which would never actually apply the source cleanups? 

Closes #187.