### PR TITLE
🎨: do not inherit name from parent spec if undefined

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -503,7 +503,7 @@ export class StylePolicy {
         }
         // ensure the presence of all nodes
         if (localSpec === spec) {
-          if (!localSpec.name) localSpec.name = parentSpec.name;
+          if (!localSpec.name && parentSpec.name) localSpec.name = parentSpec.name;
           return;
         }
         if (localSpec.isPolicy) {


### PR DESCRIPTION
Fixes an issue that was introduced in #856 where parts without a name property would create morphs with the name being `undefined` causing crashes.