### PR TITLE
Revert "🎨: fix layout hugging getter"

### DIFF
--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -548,7 +548,7 @@ export class TilingLayout extends Layout {
     for (let m of this.layoutableSubmorphs) {
       const h = this._resizePolicies.get(m)?.height;
       if (!h) continue;
-      if (this.axis === 'column' && h === 'fill') return false;
+      if (h === 'fill') return false;
     }
     return this._hugContentsVertically;
   }
@@ -568,7 +568,7 @@ export class TilingLayout extends Layout {
     for (let m of this.layoutableSubmorphs) {
       const w = this._resizePolicies.get(m)?.width;
       if (!w) continue;
-      if (this.axis === 'row' && w === 'fill') return false;
+      if (w === 'fill') return false;
     }
     return this._hugContentsHorizontally;
   }


### PR DESCRIPTION
This reverts commit d422b5021c5c86f95b97f9956579458976a354c4.

We could not reconstruct the reason as to why this change was made exactly. However, it lead to situations in which Popups had their layouts applied with wrong settings. With a quick glance, we could not find any morphs breaking reversing this.