### PR TITLE
Fix/test result stringification

### DIFF
--- a/lively.server/plugins/test-runner.js
+++ b/lively.server/plugins/test-runner.js
@@ -27,7 +27,13 @@ export default class TestRunner {
     const runner = new TestRunner();
     await promise.waitFor(()=> !!window.chai && !!window.Mocha);
     const results = await runner.runTestsInPackage('${module_to_test}');
-    JSON.stringify(results)
+    results.forEach(r => {
+      r.tests?.forEach(t => {
+        if (t.error) t.error = true
+        else t.error = false;
+      })
+    });
+    JSON.stringify(results);
     `)
     } catch (err) {
       results = JSON.stringify({ error: err.message });

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -54,10 +54,10 @@ const req = http.request(options, res => {
       }
       if (data.error) {
         if (CI) {
-          console.log(`::error:: Running the tests produced the following error: ${JSON.stringify(data.error)}`);
-          fs.appendFileSync('summary.txt', `❌ Running the tests produced the following error: ${JSON.stringify(data.error)}`);
+          console.log(`::error:: Running the tests produced the following error:\n${JSON.stringify(data.error)}`);
+          fs.appendFileSync('summary.txt', `❌ Running the tests produced the following error:\n${JSON.stringify(data.error)}\n`);
         }
-        else console.log(`❌ Running the tests produced the following error: ${JSON.stringify(data.error)}`);
+        else console.log(`❌ Running the tests produced the following error:\n${JSON.stringify(data.error)}`);
         return;
       }
       data.forEach((testfile) => {
@@ -126,10 +126,10 @@ const req = http.request(options, res => {
       }
     } catch (err) {
       if (CI) {
-        console.log(`::error:: Running the tests produced the following error: "${err}"`);
-        fs.appendFileSync('summary.txt', `❌ Running the tests produced the following error: "${err}"\n`);
+        console.log(`::error:: Running the tests produced the following error:\n"${err}"`);
+        fs.appendFileSync('summary.txt', `❌ Running the tests produced the following error:\n"${err}"\n`);
       } else {
-        console.log(`❌ Running the tests produced the following error: "${err}"`);
+        console.log(`❌ Running the tests produced the following error:\n"${err}"`);
       }
     }
   });


### PR DESCRIPTION
Sometimes the stringification would fail due to circular objects which would in turn lead to the whole output of the test-runner being useless, despite the actual data inside of `error` not being used.

This resolves the issue one can observe in the current runs of our CI test action, where the lively.modules output is messed up.