### PR TITLE
Fix/excluded loop var detection

### DIFF
--- a/lively.ast/lib/parser.js
+++ b/lively.ast/lib/parser.js
@@ -57,7 +57,7 @@ function parseFunction (source, options = {}) {
 function fuzzyParse (source, options) {
   // options: verbose, addSource, type
   options = options || {};
-  options.ecmaVersion = options.ecmaVersion || 11;
+  options.ecmaVersion = options.ecmaVersion || 12;
   options.sourceType = options.sourceType || 'module';
   options.plugins = options.plugins || {};
   const comments = [];
@@ -172,7 +172,7 @@ function parse (source, options) {
   // }
 
   options = options || {};
-  options.ecmaVersion = options.ecmaVersion || 11;
+  options.ecmaVersion = options.ecmaVersion || 12;
   options.allowAwaitOutsideFunction = true;
   options.sourceType = options.sourceType || 'module';
   if (!options.hasOwnProperty('allowImportExportEverywhere')) { options.allowImportExportEverywhere = true; }

--- a/lively.source-transform/capturing.js
+++ b/lively.source-transform/capturing.js
@@ -479,7 +479,11 @@ function additionalIgnoredDecls (parsed, options) {
   }
 
   return topLevel.scope.catches.map(ea => ea.name)
-    .concat(ignoreDecls.map(ea => ea.id.name));
+    .concat(ignoreDecls.map(ea => {
+      if (ea.id.type === 'ArrayPattern') return ea.id;
+      else if (ea.id.type === 'ObjectPattern') return ea.id;
+      return ea.id.name;
+    }).flat());
 }
 
 function additionalIgnoredRefs (parsed, options) {
@@ -505,6 +509,7 @@ function additionalIgnoredRefs (parsed, options) {
 
 function shouldDeclBeCaptured (decl, options) {
   return options.excludeDecls.indexOf(decl.id.name) === -1 &&
+    options.excludeDecls.indexOf(decl.id) === -1 &&
     (!options.includeDecls || options.includeDecls.indexOf(decl.id.name) > -1);
 }
 


### PR DESCRIPTION
Fixes incorrect handling of loop var declarations that are supposed to be excluded from capturing by default.
The old code would introduce undefined values into the list of excluded declarations leading to incorrect source code transformations of the capturing code.