### PR TITLE
🧰: ensure side bar connections are not being serialized on copy

### DIFF
--- a/lively.ide/studio/controls/body.cp.js
+++ b/lively.ide/studio/controls/body.cp.js
@@ -1,7 +1,7 @@
 import { TilingLayout, ShadowObject, component, ViewModel, part } from 'lively.morphic';
 import { Color, rect, pt } from 'lively.graphics';
 import { obj, arr } from 'lively.lang';
-import { once, noUpdate, connect } from 'lively.bindings';
+import { once, noUpdate, epiConnect } from 'lively.bindings';
 
 import { ShadowPopup, OpacityPopup, FlipPopup, TiltPopup, CursorPopup, BlurPopup, InsetShadowPopup } from './popups.cp.js';
 import { PropertySection, PropertySectionModel } from './section.cp.js';
@@ -131,7 +131,7 @@ export class BodyControlModel extends PropertySectionModel {
       this.disableAddEffectButton();
     }
     once(control.viewModel, 'remove', this, 'deactivate');
-    connect(control.viewModel, 'selectedProp', this, 'refreshItemLists');
+    epiConnect(control.viewModel, 'selectedProp', this, 'refreshItemLists');
   }
 
   /**
@@ -333,7 +333,7 @@ export class DynamicPropertyModel extends ViewModel {
     p.topRight = this.view.globalBounds().topLeft();
     p.topLeft = this.world().visibleBounds().translateForInclusion(p.globalBounds()).topLeft();
     once(p, 'remove', this, 'closePopup');
-    connect(p.viewModel, 'value', this, 'confirm');
+    epiConnect(p.viewModel, 'value', this, 'confirm');
   }
 
   /**

--- a/lively.ide/studio/controls/border.cp.js
+++ b/lively.ide/studio/controls/border.cp.js
@@ -4,7 +4,7 @@ import { AddButton, PropertyLabel, DarkPopupWindow, DarkThemeList, PropertyLabel
 import { ColorInput } from '../../styling/color-picker.cp.js';
 
 import { arr, string } from 'lively.lang';
-import { once, connect, signal } from 'lively.bindings';
+import { once, epiConnect, signal } from 'lively.bindings';
 import { PropertySection, PropertySectionModel } from './section.cp.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { PopupModel } from './popups.cp.js';
@@ -230,7 +230,7 @@ export class BorderControlModel extends PropertySectionModel {
     p.topRight = this.ui.moreButton.globalBounds().bottomRight().addXY(0, 5);
     p.topLeft = this.world().visibleBounds().translateForInclusion(p.globalBounds()).topLeft();
     once(p.viewModel, 'close', this, 'closePopup');
-    connect(p.viewModel, 'target updated', this, 'update');
+    epiConnect(p.viewModel, 'target updated', this, 'update');
   }
 
   /**

--- a/lively.ide/studio/controls/layout.cp.js
+++ b/lively.ide/studio/controls/layout.cp.js
@@ -1,7 +1,7 @@
 import { Morph, TilingLayout, component, without, ViewModel, part, add } from 'lively.morphic';
 import { pt, rect, Rectangle, Color } from 'lively.graphics';
 import { arr } from 'lively.lang';
-import { connect, signal, disconnect, once } from 'lively.bindings';
+import { epiConnect, signal, disconnect, once } from 'lively.bindings';
 import {
   AddButton, DarkFlap, DarkThemeList, EnumSelector, PropertyLabel,
   LabeledCheckbox, DarkNumberIconWidget, PropertyLabelHovered
@@ -204,7 +204,7 @@ export class AutoLayoutControlModel extends PropertySectionModel {
     if (this.popup) return;
     // fixme: How to make this parametrizable?
     const p = this.popup = part(this.controlFlapComponent, { viewModel: { targetMorph: this.targetMorph } });
-    connect(p.viewModel, 'update', this, 'update');
+    epiConnect(p.viewModel, 'update', this, 'update');
     once(p.viewModel, 'close', this, 'closePopup');
     p.openInWorld();
     p.topRight = this.ui.miniLayoutPreview.globalBounds().bottomRight().addXY(0, 2);
@@ -310,7 +310,7 @@ export class AutoLayoutAlignmentFlapModel extends ViewModel {
   }
 
   start () {
-    connect($world, 'onMouseDown', this, 'closeIfClickedOutside');
+    epiConnect($world, 'onMouseDown', this, 'closeIfClickedOutside');
   }
 
   closeIfClickedOutside (evt) {

--- a/lively.ide/studio/controls/text.cp.js
+++ b/lively.ide/studio/controls/text.cp.js
@@ -12,7 +12,7 @@ import {
 } from '../shared.cp.js';
 import { ColorInput } from '../../styling/color-picker.cp.js';
 import { PropertySection } from './section.cp.js';
-import { disconnect, connect } from 'lively.bindings';
+import { disconnect, epiConnect } from 'lively.bindings';
 import { sanitizeFont } from 'lively.morphic/helpers.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { PaddingControlsDark } from './popups.cp.js';
@@ -91,7 +91,7 @@ export class RichTextControlModel extends ViewModel {
 
     // also watch for changes in selection
     if (target.isText && !this.globalMode) {
-      connect(target, 'selectionChange', this, 'update');
+      epiConnect(target, 'selectionChange', this, 'update');
     }
   }
 

--- a/lively.ide/studio/properties-panel.cp.js
+++ b/lively.ide/studio/properties-panel.cp.js
@@ -1,8 +1,8 @@
-import { TilingLayout, easings, touchInputDevice, component, without, add, ensureFont, ViewModel, part } from 'lively.morphic';
+import { TilingLayout, easings, touchInputDevice, component, without, add, ViewModel, part } from 'lively.morphic';
 import { Color, Rectangle } from 'lively.graphics';
 import { pt, rect } from 'lively.graphics/geometry-2d.js';
 import { ColorInput } from 'lively.ide/styling/color-picker.cp.js';
-import { connect, disconnect } from 'lively.bindings';
+import { epiConnect, disconnect } from 'lively.bindings';
 
 import { RichTextControl } from './controls/text.cp.js';
 import { ShapeControl } from './controls/shape.cp.js';
@@ -120,10 +120,10 @@ export class PropertiesPanelModel extends ViewModel {
    */
   attachToTarget (aMorph) {
     this.models.backgroundControl.focusOn(aMorph);
-    connect(aMorph, 'onHaloOpened', this, 'focusOn', {
+    epiConnect(aMorph, 'onHaloOpened', this, 'focusOn', {
       garbageCollect: true
     });
-    connect(aMorph, 'onHaloRemoved', this, 'clearFocus', {
+    epiConnect(aMorph, 'onHaloRemoved', this, 'clearFocus', {
       garbageCollect: true
     });
   }
@@ -137,10 +137,10 @@ export class PropertiesPanelModel extends ViewModel {
 
   attachToWorld (aWorld) {
     this.models.backgroundControl.focusOn(aWorld);
-    connect(aWorld, 'showHaloFor', this, 'focusOn', {
+    epiConnect(aWorld, 'showHaloFor', this, 'focusOn', {
       garbageCollect: true
     });
-    connect(aWorld, 'onHaloRemoved', this, 'clearFocus', {
+    epiConnect(aWorld, 'onHaloRemoved', this, 'clearFocus', {
       garbageCollect: true
     });
   }
@@ -201,8 +201,8 @@ export class PropertiesPanelModel extends ViewModel {
       disconnect(this.targetMorph, 'remove', this, 'clearFocusIfRemoved');
     }
     this.targetMorph = aMorph;
-    connect(aMorph, 'onOwnerChanged', this, 'onTargetMovedInHierarchy');
-    connect(aMorph, 'remove', this, 'clearFocusIfRemoved');
+    epiConnect(aMorph, 'onOwnerChanged', this, 'onTargetMovedInHierarchy');
+    epiConnect(aMorph, 'remove', this, 'clearFocusIfRemoved');
 
     this.toggleDefaultControls(true);
 


### PR DESCRIPTION
Previously copy-pasting a morph would lead to side bar view models being retained via dangling connections on the new instance, causing errors.