### PR TITLE
`partsbin` integration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,39 @@ eval $(node -p 'let PWD=process.cwd();let packages = JSON.parse(require("fs").re
 mkdir lively.next-node_modules
 mkdir esm_cache
 mkdir local_projects
+PROJECT_FOLDER_CREATED=$?
+# When we just created the local_projects folder, the partsbin inside cannot exist.
+if (( PROJECT_FOLDER_CREATED == 0 ));
+then
+  git clone https://github.com/LivelyKernel/partsbin ./local_projects/LivelyKernel--partsbin
+  echo "Downloaded up-to-date version of lively.nexts partsbin"
+else
+  cd local_projects
+  if [ -d "LivelyKernel--partsbin" ];
+  # `partsbin` exists, we need to update the repository, while preservering its local state.
+  then
+    echo "Found an existing lively.next partsbin"
+    cd LivelyKernel--partsbin
+    currentBranchName=$(git rev-parse --abbrev-ref HEAD)
+    stashOutput=$(git stash)
+    git checkout main
+    git pull origin main --ff-only
+    git checkout "$currentBranchName"
+    # https://stackoverflow.com/a/12973694/4418325
+    stashOutputWithoutWhiteSpace=$(echo "$stashOutput" | xargs)
+    if [ "$stashOutputWithoutWhiteSpace" != "No local changes to save" ];
+    then
+      git stash pop
+    fi
+    echo "Updated existing lively.next partsbin"
+    cd ..
+  else
+    # `partsbin` does not exist yet, we can just clone it.
+    git clone https://github.com/LivelyKernel/partsbin LivelyKernel--partsbin
+    echo "Downloaded up-to-date version of lively.nexts partsbin"
+  fi
+  cd ..
+fi
 
 node --no-experimental-fetch --no-warnings --experimental-loader $lv_next_dir/flatn/resolver.mjs \
      lively.installer/bin/install.cjs $PWD \

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -17,6 +17,7 @@ import { Console } from './debug/console.cp.js';
 import { WindowSwitcher } from './window-switcher.cp.js';
 import { browserForFile } from './js/browser/ui.cp.js';
 import { SaveProjectDialog } from 'lively.project/prompts.cp.js';
+import { Project } from 'lively.project';
 
 const commands = [
 
@@ -836,6 +837,8 @@ const commands = [
     name: 'browse and load component',
     exec: async function (world) {
       const li = LoadingIndicator.open('loading component browser');
+      const p = $world.openedProject;
+      if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('partsbin', 'LivelyKernel', true);
       const { ComponentBrowser } = await System.import('lively.ide/studio/component-browser.cp.js');
       const componentBrowser = world._componentBrowser || (world._componentBrowser = part(ComponentBrowser, { name: 'lively component browser' }));
       li.remove();

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1207,7 +1207,7 @@ export class LivelyWorld extends World {
    */
   showLoadingIndicatorFor (requester, label) {
     const li = LoadingIndicator.open(label, { target: requester });
-    if (requester.hasFixedPosition) li.hasFixedPosition = true;
+    if (requester?.hasFixedPosition) li.hasFixedPosition = true;
     return li;
   }
 


### PR DESCRIPTION
This makes it so that we clone/update the official partsbin during `install.sh` and automatically load it when opening the components browser. Thus, the partsbin can move more in the direction of its original idea, being a "wundertüte" to be used easily by all lively.next users. 

# To Do

- [x] `partsbin` should auto update even when one does not execute `install.sh`