### PR TITLE
Fix/bundling empty assets

### DIFF
--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -843,19 +843,22 @@ export default class LivelyRollup {
       // Inside of the bundles, font.css itself is part of the assets folder.
       const fontCSSContents = (await fontCSSFile.read()).replaceAll(/\.\/assets\//g, './');
       bundledProjectFontCSS = fontCSSContents + '\n' + bundledProjectFontCSS ;
+      
+      const assetDir = await projectsDir.join(project).join('assets');
       // Each project can have multiple font files
-      const fontFiles = (await(await projectsDir.join(project).join('assets')).dirList()).filter(f => f.url.includes('woff2'))
-      for (let file of fontFiles) {
-        file.beBinary();
-        let source = await file.read();
-        if (source instanceof ArrayBuffer) source = new Uint8Array(source);
-        plugin.emitFile({
-          type: 'asset',
-          fileName: joinPath('assets', file.name()),
-          source
-        });
+      if (await assetDir.exists()) {
+        const fontFiles = (await assetDir.dirList()).filter(f => f.url.includes('woff2'))
+        for (let file of fontFiles) {
+          file.beBinary();
+          let source = await file.read();
+          if (source instanceof ArrayBuffer) source = new Uint8Array(source);
+          plugin.emitFile({
+            type: 'asset',
+            fileName: joinPath('assets', file.name()),
+            source
+          });
+        }
       }
-
     }
 
     const bundledCSS = bundledProjectFontCSS + '\n' + bundledProjectCSS;

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -3,7 +3,7 @@ import ShellClientResource from './client-resource.js';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
 
 export default class GitShellResource extends ShellClientResource {
-  constructor (url, l2lClient, options = {}) {
+  constructor (url) {
     url = url.replace('git\/', '');
     super(url);
     this.options.cwd = this.url;
@@ -51,7 +51,7 @@ export default class GitShellResource extends ShellClientResource {
   }
 
   async addRemoteToGitRepository (token, repoName, repoUser, repoDescription, orgScope = false) {
-    let repoCreationCommand = orgScope
+    const repoCreationCommand = orgScope
       ? `curl -L \
               -X POST \
               -H "Accept: application/vnd.github+json" \
@@ -118,8 +118,6 @@ export default class GitShellResource extends ShellClientResource {
     await this.runCommand(resetCmd).whenDone();
   }
 }
-
-let _defaultL2LClient;
 
 export const gitResourceExtension = {
   name: 'git-shell-client',


### PR DESCRIPTION
Copied from the extended commit message:

> Previously, the bundler would fail here remotely, as it tried scanning the contents of the assets directory. Locally, we create this directory, but empty folders are not gittable.
One solution would have been to always create an empty and hidden file inside of the assets folder, to ensure that it also exists when clean cloning the project in CI.
The solution I implemented now just skips the step when the asset folder is non-existent. I like this solution, as it reduces clutter in projects without any assets.
Since the addition of assets will be done through the asset manager in the future, which can then handle the creation of the folder if necessary, I think this is a save solution.