### PR TITLE
🛠️: enforce consistent emoji output with GitHubs markdown renderer

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -24,7 +24,7 @@ if (CI) {
   console.log(`::notice:: Tests for ${targetPackage} 📦`);
   fs.appendFileSync('summary.txt', `### Tests for ${targetPackage} 📦\n`);
 } else {
-  console.log(`🛈 Tests for ${targetPackage} 📦`);
+  console.log(`ℹ️ Tests for ${targetPackage} 📦`);
   console.log('');
 }
 const options = {
@@ -45,9 +45,9 @@ const req = http.request(options, res => {
       if (!Object.keys(data).length) {
         if (CI) {
           console.log(`::notice:: ${targetPackage} does not contain any tests\n`);
-          fs.appendFileSync('summary.txt', `🛈 ${targetPackage} does not contain any tests.\n`);
+          fs.appendFileSync('summary.txt', `ℹ️ ${targetPackage} does not contain any tests.\n`);
         } else {
-          console.log(`🛈 ${targetPackage} does not contain any tests`);
+          console.log(`ℹ️ ${targetPackage} does not contain any tests`);
         }
 
         return;
@@ -75,9 +75,9 @@ const req = http.request(options, res => {
           }
         } else if (testfile.tests.every((test) => !test.state)) {
           if (CI) {
-            console.log(`::group:: ${testfileName} ⏭️`);
+            console.log(`::group:: ${testfileName} ⏩`);
           } else {
-            console.log(`${testfileName} ⏭️`);
+            console.log(`${testfileName} ⏩`);
             console.log('---');
           }
         } else {
@@ -92,7 +92,7 @@ const req = http.request(options, res => {
           if (test.type !== 'test') return;
           if (!test.state) {
             skipped += 1;
-            console.log(`${test.fullTitle} skipped ⏭️`);
+            console.log(`${test.fullTitle} skipped ⏩`);
             return;
           }
           if (test.state === 'succeeded') {
@@ -114,7 +114,7 @@ const req = http.request(options, res => {
         console.log(`SUMMARY-passed:${passed}`);
         fs.appendFileSync('summary.txt', `✅ ${passed} tests passed\n`);
         console.log(`SUMMARY-skipped:${skipped}`);
-        fs.appendFileSync('summary.txt', `⏭️ ${skipped} tests skipped\n`);
+        fs.appendFileSync('summary.txt', `⏩ ${skipped} tests skipped\n`);
         console.log(`SUMMARY-failed:${failed}`);
         fs.appendFileSync('summary.txt', `❌ ${failed} tests failed\n`);
         if (markdownListOfFailingTests !== '') {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -164,6 +164,16 @@ elif [ "$CI" ];
   fi
 fi
 
+if [ "$CI" ];
+then
+  sed 's/✅/<g-emoji class="g-emoji" alias="white_check_mark" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png"><img class="emoji" alt="white_check_mark" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png" width="20" height="20"><\/g-emoji>/g' "$GITHUB_STEP_SUMMARY" |
+  sed 's/🧪/<g-emoji class="g-emoji" alias="test_tube" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f9ea.png"><img class="emoji" alt="test_tube" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f9ea.png" width="20" height="20"><\/g-emoji>/g' |
+  sed 's/⏩/<g-emoji class="g-emoji" alias="fast_forward" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/23e9.png"><img class="emoji" alt="fast_forward" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/23e9.png" width="20" height="20"><\/g-emoji>/g' |
+  sed 's/❌/<g-emoji class="g-emoji" alias="x" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/274c.png"><img class="emoji" alt="x" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/274c.png" width="20" height="20"><\/g-emoji>/g' |
+  sed 's/ℹ️/<g-emoji class="g-emoji" alias="information_source" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2139.png"><img class="emoji" alt="information_source" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2139.png" width="20" height="20"><\/g-emoji>/g' |
+  sed 's/📦/<g-emoji class="g-emoji" alias="package" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png"><img class="emoji" alt="package" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png" width="20" height="20"><\/g-emoji>/g' > "$GITHUB_STEP_SUMMARY"
+fi
+
 if ((RED_TESTS > 0 || ALL_TESTS == 0)); 
 then
   exit 1


### PR DESCRIPTION
GitHub does not render Emojis consistently. What happens is that GitHub runs a detection for emojis, and renders them as some special HTML, fetching their images and stuff. However, this detection is somewhat flaky. This caused inconsistent output in our "Run Tests" pipeline. I also reported that [here](https://github.com/orgs/community/discussions/62382).

I found a fix for this, as we do not need super many emojis for the test summary: I just replace all affected characters with the HTML GitHub *should* generate anyways.

See https://github.com/LivelyKernel/lively.next/actions/runs/5796307806 for a demonstration of the change working.