### PR TITLE
🧰: fix `ProjectIcon` after renaming `tabler-icons` font `Tabler Icons`

### DIFF
--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -1165,9 +1165,9 @@ const ProjectIcon = component({
     padding: rect(0, 0, 1, 0),
     position: pt(3.5, 89),
     textAndAttributes: ['', {
-      fontFamily: 'tabler-icons',
+      fontFamily: 'Tabler Icons',
       fontWeight: '900'
-    }, ' ', {}]
+    }]
   })]
 });
 


### PR DESCRIPTION
# Before:
![image](https://github.com/LivelyKernel/lively.next/assets/14252419/84606578-b216-41e3-853b-4573586dae90)


# After:
![image](https://github.com/LivelyKernel/lively.next/assets/14252419/5a3474a4-52cb-4510-93e8-d2accbdd41ba)
