### PR TITLE
❄️: fix invalid `fontWeight` values leading to error on load attempt

### DIFF
--- a/lively.freezer/src/loading-screen.cp.js
+++ b/lively.freezer/src/loading-screen.cp.js
@@ -257,7 +257,7 @@ const Stage = component({
     fill: Color.rgba(255, 255, 255, 0),
     fontColor: Color.rgb(64, 64, 64),
     fontSize: 16,
-    fontWeight: 'Medium',
+    fontWeight: '500',
     nativeCursor: 'pointer',
     textAndAttributes: ['lang', null]
   }, {

--- a/lively.freezer/src/ui.cp.js
+++ b/lively.freezer/src/ui.cp.js
@@ -269,7 +269,7 @@ const FreezerPrompt = component(LightPrompt, {
     fill: Color.rgba(255, 255, 255, 0),
     fontColor: Color.rgb(45, 45, 45),
     fontSize: 16,
-    fontWeight: 'Medium',
+    fontWeight: '500',
     nativeCursor: 'pointer',
     textAndAttributes: ['Directory to write files to:', null]
   }), add(part(InputLineDefault, {
@@ -329,7 +329,7 @@ const FreezerPrompt = component(LightPrompt, {
     fill: Color.rgba(255, 255, 255, 0),
     fontColor: Color.rgb(45, 45, 45),
     fontSize: 16,
-    fontWeight: 'Medium',
+    fontWeight: '500',
     nativeCursor: 'pointer',
     textAndAttributes: ['Packages to exclude from bundle:', null]
   }), add({


### PR DESCRIPTION
This should resolve this error

![image](https://github.com/LivelyKernel/lively.next/assets/14252419/44301064-09e0-40a4-80d4-4c8c0e18d970)

that occurred during the loading-screen. Only the default CSS string values are valid ('normal', 'bold') and numbers as Strings (we convert them internally).