### PR TITLE
Private Projects

### DIFF
--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -56,7 +56,6 @@ class ModeSelectorModel extends ViewModel {
     }
     if (prop === 'selectedItem') {
       this.select(this.selectedItem);
-      signal(this.view, 'selectionChanged', this.selectedItem);
     }
   }
 
@@ -80,7 +79,7 @@ class ModeSelectorModel extends ViewModel {
       connect(label, 'onMouseDown', this, 'select', {
         updater: `function ($upd) {
           if (!viewModel.enabled) return;
-          $upd(label.name, true);
+          $upd(label.name, true, true);
         }`,
         varMapping: { label, viewModel: this }
       });
@@ -88,7 +87,7 @@ class ModeSelectorModel extends ViewModel {
     });
   }
 
-  async select (itemName, withAnimation = false) {
+  async select (itemName, withAnimation = false, withSignal = false) {
     // Selected Item Changed by Clicking on the View
     if (withAnimation) {
       this.ui.labels.forEach(l => {
@@ -111,7 +110,9 @@ class ModeSelectorModel extends ViewModel {
       });
       this.ui.labels.find((label) => label.name === itemName).master = { auto: ModeSelectorLabelSelected }; // eslint-disable-line no-use-before-define
     }
+
     this.selectedItem = itemName;
+    if (withSignal) signal(this.view, 'selectionChanged', this.selectedItem);
   }
 }
 

--- a/lively.ide/studio/dialogs.cp.js
+++ b/lively.ide/studio/dialogs.cp.js
@@ -1,7 +1,7 @@
 import { DarkPrompt, OKCancelButtonWrapper, ConfirmPromptModel } from 'lively.components/prompts.cp.js';
 import { DarkDropDownList, DarkList } from 'lively.components/list.cp.js';
 import { component, add, part } from 'lively.morphic/components/core.js';
-import { pt, Rectangle, rect, Color } from 'lively.graphics';
+import { pt, rect, Color } from 'lively.graphics';
 import { TilingLayout, MorphicDB, ShadowObject, Text, Label } from 'lively.morphic';
 import { InputLineDark } from 'lively.components/inputs.cp.js';
 
@@ -345,7 +345,7 @@ const SaveWorldDialog = component(DarkPrompt, {
           fontSize: 15,
           nativeCursor: 'pointer',
           position: pt(1, 116),
-          textAndAttributes: ['description:', null]
+          textAndAttributes: ['Description:', null]
         }, {
           type: Text,
           name: 'description',
@@ -370,6 +370,7 @@ const SaveWorldDialog = component(DarkPrompt, {
       }
     ]
   }), add(part(OKCancelButtonWrapper))
-]});
+  ]
+});
 
 export { SaveWorldDialog };

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -49,6 +49,11 @@ export class Project {
     return await this.gitResource.hasRemote();
   }
 
+  async changeRepositoryVisibility (visibility) {
+    this.config.lively.repositoryIsPrivate = visibility === 'private';
+    return await this.gitResource.changeRemoteVisibility(currentUsertoken(), this.name, this.repoOwner, visibility);
+  }
+
   // TODO: 🍴 Support
   // **Note** since this is a getter on an instance, we can retrieve whatever we want from the config object
   // We just need to make sure that we populate it in the correct way!
@@ -428,7 +433,7 @@ export class Project {
     }
 
     pipelineFile = join(this.url, '.github/workflows/deploy-pages-action.yml');
-    if (livelyConfig.deployActionEnabled) {
+    if (livelyConfig.deployActionEnabled && !livelyConfig.repositoryIsPrivate) {
       content = this.fillPipelineTemplate(deployScript);
       await (await resource(pipelineFile).ensureExistance()).write(content);
     } else {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -461,15 +461,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
               borderWidth: 0,
               extent: pt(195.5, 28.5),
               submorphs: [part(LabeledCheckBox, { name: 'deploy check', viewModel: { label: 'Deploy Build to GitHub Pages:' } }), part(InformIconOnLight, { viewModel: { information: 'Deploying to GitHub Pages is only available for public repositories.' } })]
-            }, part(ModeSelector, {
-              name: 'deploy mode selector',
-              viewModel: {
-                // TODO: This is not yet configurable and no infrastructure is in place for it to be.
-                enabled: false,
-                items: [{ text: 'Manually', name: 'manual' }, { text: 'On each push to `main` branch', name: 'push' }],
-                selectedItem: 'manual'
-              }
-            })]
+            }, { fill: Color.transparent, width: 255 }]
           }]
       },
       {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -371,6 +371,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
     submorphs: [
       {
         name: 'ci settings',
+        fill: Color.rgba(255, 255, 255, 0),
         layout: new TilingLayout({
           align: 'center',
           axis: 'column',
@@ -386,6 +387,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
           },
           {
             name: 'row 11',
+            fill: Color.rgba(255, 255, 255, 0),
             extent: pt(480, 42),
             layout: new TilingLayout({
               align: 'center',
@@ -395,6 +397,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
             }),
             submorphs: [{
               name: 'wrapper 11',
+              borderColor: Color.rgba(255, 255, 255, 0),
               layout: new TilingLayout({
                 axisAlign: 'center',
                 orderByIndex: true
@@ -413,6 +416,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
           },
           {
             name: 'row 21',
+            fill: Color.rgba(255, 255, 255, 0),
             extent: pt(297, 29),
             layout: new TilingLayout({
               align: 'center',
@@ -439,6 +443,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
             })]
           }, {
             name: 'row 31',
+            fill: Color.rgba(255, 255, 255, 0),
             extent: pt(480, 41.5),
             layout: new TilingLayout({
               align: 'center',
@@ -469,6 +474,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
       },
       {
         name: 'repo settings',
+        fill: Color.rgba(255, 255, 255, 0),
         layout: new TilingLayout({
           align: 'center',
           axis: 'column',
@@ -483,6 +489,7 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
             fontWeight: '600'
           }, {
             name: 'row 12',
+            fill: Color.rgba(255, 255, 255, 0),
             extent: pt(480, 42),
             layout: new TilingLayout({
               axisAlign: 'center',

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -34,8 +34,8 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
                 this.view.remove();
               }
             },
-            { target: 'test check', signal: 'checked', handler: (val) => this.ui.testModeSelector.enabled = val },
-            { target: 'build check', signal: 'checked', handler: (val) => this.ui.buildModeSelector.enabled = val },
+            { model: 'test check', signal: 'checked', handler: (val) => this.ui.testModeSelector.enabled = val },
+            { model: 'build check', signal: 'checked', handler: (val) => this.ui.buildModeSelector.enabled = val },
             { model: 'ok button', signal: 'fire', handler: 'resolve' }
           ];
         }
@@ -60,6 +60,8 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
   viewDidLoad () {
     const { testCheck, buildCheck, deployCheck, testModeSelector, buildModeSelector } = this.ui;
     const conf = this.project.config.lively;
+
+    if (conf.repositoryIsPrivate) deployCheck.disable();
 
     testCheck.checked = conf.testActionEnabled;
     buildCheck.checked = conf.buildActionEnabled;
@@ -349,8 +351,8 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
         name: 'row 1',
         extent: pt(480, 42),
         layout: new TilingLayout({
-          align: 'right',
-          justifySubmorphs: 'spaced',
+          align: 'center',
+          axisAlign: 'center',
           orderByIndex: true,
           padding: rect(11, 11, 0, 0),
           spacing: 20
@@ -359,23 +361,12 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
           name: 'wrapper',
           layout: new TilingLayout({
             axisAlign: 'center',
-            orderByIndex: true,
-            spacing: 10
+            orderByIndex: true
           }),
           fill: Color.transparent,
           borderWidth: 0,
           extent: pt(195.5, 28.5),
-          submorphs: [{
-            type: CheckBox,
-            name: 'test check',
-            borderWidth: 0
-          }, {
-            type: Label,
-            name: 'aText',
-            dynamicCursorColoring: true,
-            fill: Color.white,
-            textAndAttributes: ['Run Tests remotely:', null]
-          }]
+          submorphs: [part(LabeledCheckBox, { name: 'test check', viewModel: { label: 'Run Tests Remotely:' } }), { extent: pt(64, 12), fill: Color.transparent, borderWidth: 0 }]
         }, part(ModeSelector, {
           name: 'test mode selector',
           viewModel: {
@@ -388,8 +379,8 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
         name: 'row 2',
         extent: pt(480, 42),
         layout: new TilingLayout({
-          align: 'right',
-          justifySubmorphs: 'spaced',
+          align: 'center',
+          axisAlign: 'center',
           orderByIndex: true,
           padding: rect(11, 11, 0, 0),
           spacing: 20
@@ -397,24 +388,14 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
         submorphs: [{
           name: 'wrapper',
           layout: new TilingLayout({
-            axisAlign: 'center',
             orderByIndex: true,
-            spacing: 10
+            axisAlign: 'center'
           }),
+
           fill: Color.transparent,
           borderWidth: 0,
           extent: pt(195.5, 28.5),
-          submorphs: [{
-            type: CheckBox,
-            name: 'build check',
-            borderWidth: 0
-          }, {
-            type: Label,
-            name: 'aText',
-            dynamicCursorColoring: true,
-            fill: Color.white,
-            textAndAttributes: ['Build Project Remotely:', null]
-          }]
+          submorphs: [part(LabeledCheckBox, { name: 'build check', viewModel: { label: 'Build Project Remotely:' } }), { extent: pt(47.5, 12), fill: Color.transparent, borderWidth: 0 }]
         }, part(ModeSelector, {
           name: 'build mode selector',
           viewModel: {
@@ -426,8 +407,8 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
         name: 'row 3',
         extent: pt(480, 41.5),
         layout: new TilingLayout({
+          align: 'center',
           axisAlign: 'center',
-          justifySubmorphs: 'spaced',
           orderByIndex: true,
           padding: rect(11, 11, 0, 0),
           spacing: 20
@@ -435,23 +416,13 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
         submorphs: [{
           name: 'wrapper',
           layout: new TilingLayout({
-            axisAlign: 'center',
             orderByIndex: true,
-            spacing: 10
+            axisAlign: 'center'
           }),
           fill: Color.transparent,
           borderWidth: 0,
           extent: pt(195.5, 28.5),
-          submorphs: [{
-            type: CheckBox,
-            name: 'deploy check',
-            borderWidth: 0
-          }, {
-            type: Label,
-            name: 'aText',
-            dynamicCursorColoring: true,
-            textAndAttributes: ['Deploy build to GitHub Pages:', null]
-          }]
+          submorphs: [part(LabeledCheckBox, { name: 'deploy check', viewModel: { label: 'Deploy Build to GitHub Pages:' } }), part(InformIconOnLight, { viewModel: { information: 'Deploying to GitHub Pages is only available for public repositories.' } })]
         }, part(ModeSelector, {
           name: 'deploy mode selector',
           viewModel: {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -49,8 +49,8 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
                   $world.setStatusMessage('Error changing Repository visibility.', StatusMessageError);
                   return;
                 }
-                if (visibility === 'private') deployCheck.disable();
-                else deployCheck.enable();
+                if (this.project.canDeployToPages) deployCheck.enable();
+                else deployCheck.disable();
                 spinner.opacity = 0;
                 visibilitySelector.enabled = true;
               }
@@ -80,8 +80,8 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
     const conf = this.project.config.lively;
 
     if (conf.repositoryIsPrivate) {
-      deployCheck.disable();
       visibilitySelector.selectedItem = 'private';
+      if (!this.project.canDeployToPages) deployCheck.disable();
     }
 
     testCheck.checked = conf.testActionEnabled;

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -600,7 +600,7 @@ export const SaveProjectDialog = component(SaveWorldDialog, {
           fontFamily: '"IBM Plex Sans"',
           fontSize: 15,
           nativeCursor: 'pointer',
-          textAndAttributes: ['bump minor version:', null]
+          textAndAttributes: ['Bump Minor Version:', null]
         }, {
           type: CheckBox,
           name: 'minor check',
@@ -625,7 +625,7 @@ export const SaveProjectDialog = component(SaveWorldDialog, {
           fontFamily: '"IBM Plex Sans"',
           fontSize: 15,
           nativeCursor: 'pointer',
-          textAndAttributes: ['bump major version:', null]
+          textAndAttributes: ['Bump Major Version:', null]
         }, {
           type: CheckBox,
           name: 'major check',
@@ -649,7 +649,7 @@ export const SaveProjectDialog = component(SaveWorldDialog, {
           fontFamily: '"IBM Plex Sans"',
           fontSize: 15,
           nativeCursor: 'pointer',
-          textAndAttributes: ['tag this version as release:', null]
+          textAndAttributes: ['Tag this Version as Release:', null]
         }, {
           type: CheckBox,
           name: 'tag check',

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable no-console */
 import ShellClientResource from './client-resource.js';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
 
@@ -73,6 +73,24 @@ export default class GitShellResource extends ShellClientResource {
     cmd = this.runCommand(addingRemoteCommand);
     await cmd.whenDone();
     if (cmd.exitCode !== 0) throw Error('Error adding the remote to local repository');
+  }
+
+  async changeRemoteVisibility (token, repoName, repoUser, visibility) {
+    const changeVisbilityCommand = `curl -L \
+  -X PATCH \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${token}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/${repoUser}/${repoName} \
+  -d '{"private":${visibility === 'private'}}'`;
+    const cmd = this.runCommand(changeVisbilityCommand);
+    await cmd.whenDone();
+    if (cmd.exitCode !== 0) {
+      console.error('Error updating repository settings.');
+      return false;
+    }
+    console.log('Repository settings updated.');
+    return true;
   }
 
   async activateGitHubPages (token, repoName, repoUser) {

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -50,7 +50,7 @@ export default class GitShellResource extends ShellClientResource {
     return true;
   }
 
-  async addRemoteToGitRepository (token, repoName, repoUser, repoDescription, orgScope = false) {
+  async addRemoteToGitRepository (token, repoName, repoUser, repoDescription, orgScope, priv) {
     const repoCreationCommand = orgScope
       ? `curl -L \
               -X POST \
@@ -58,13 +58,13 @@ export default class GitShellResource extends ShellClientResource {
               -H "Authorization: Bearer ${token}"\
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/orgs/${repoUser}/repos \
-              -d '{"name":"${repoName}","description":"${repoDescription}"}'`
+              -d '{"name":"${repoName}","description":"${repoDescription}", "private":${!!priv}}'`
       : `curl -L \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${token}" \
               https://api.github.com/user/repos \
-              -d '{"name":"${repoName}", "description": "${repoDescription}"}'`;
+              -d '{"name":"${repoName}", "description": "${repoDescription}", "private":${!!priv}}'`;
     let cmd = this.runCommand(repoCreationCommand);
     await cmd.whenDone();
     if (cmd.exitCode !== 0) throw Error('Error executing curl call to create GitHub repository');


### PR DESCRIPTION
With this PR, we properly support the creation of projects whose github repositories are private.
When creating a Project, one can choose to create a private repository. This option is only available when a repository gets created:

![private_repo_creation](https://github.com/LivelyKernel/lively.next/assets/14252419/90ce12c2-06f1-47f9-953d-735c2e1b14d4)

When a private repository is created, we do not create the deployment action, since github pages is not available for non-paying users on private repositories. We make an exception from this rule if the owner of the repository is logged in and on a payed github plan. This is not a perfect solution, since collaborators on a free plan would also benefit from the repo belonging to a paying user.
We also allow changing the visibility of a project inside of the project settings. Doing so allows/disallows the addition of the deployment action.
The change gets executed upon selecting the mode, indicated by the appearing spinner:

![changin_visibility_of_repo](https://github.com/LivelyKernel/lively.next/assets/14252419/7e05cb5c-ef1a-4aab-a365-d7b30c356f2f)

 