### PR TITLE
📂🎛️: stop project related prompt from being resolved multiple times

### DIFF
--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -55,6 +55,20 @@ export class AbstractPromptModel extends ViewModel {
     return this.answer.promise;
   }
 
+  disableButtons () {
+    const { okButton, cancelButton } = this.ui;
+
+    okButton.disable();
+    cancelButton.disable();
+  }
+
+  enableButtons () {
+    const { okButton, cancelButton } = this.ui;
+
+    okButton.enable();
+    cancelButton.enable();
+  }
+
   isActive () { return !!this.world() && this._isActive; }
 
   get keybindings () {


### PR DESCRIPTION
Previously, it could happen that once accidentally clicked the OK buttons on the project creation/save form multiple times, which in most cases lead to problematic situations when we triggered some operations on disk in parallel.

Now, we stop that from happening by internally blocking the resolve method via a flag and additionally stopping the user from pressing the OK button multiple times as long as we block.