### PR TITLE
Support node.js > 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note, that these instructions currently are not recommended for openly de
 Currently, MacOS, Linux, and the Linux Subsystem for Windows are supported.
 Make sure you have the following software installed:
 
-1. `node.js v18.12.1`
+1. `node.js v18.12.1` or higher.
 2. `git`.
 
 > **Warning**

--- a/lively.freezer/package.json
+++ b/lively.freezer/package.json
@@ -15,7 +15,7 @@
     "wasm-brotli": "1.0.2",
     "rollup": "2.68.0",
     "@rollup/plugin-babel": "5.3.1",
-    "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-json": "6.0.0",
     "rollup-plugin-polyfill-node": "0.9.0"
   },
   "scripts": {

--- a/lively.freezer/tools/build.landing-page.mjs
+++ b/lively.freezer/tools/build.landing-page.mjs
@@ -17,6 +17,7 @@ const build = await rollup({
         title: 'lively.next',
       },
       minify,
+      isResurrectionBuild: true,
       asBrowserModule: true,
       excludedModules: [
 	'lively.collab',
@@ -32,7 +33,7 @@ const build = await rollup({
       ],
       resolver
     }),
-    jsonPlugin(),
+    jsonPlugin({ exclude: /https\:\/\/jspm.dev\/.*\.json/}),
     babel({
      babelHelpers: 'bundled', 
      presets: [PresetEnv]

--- a/lively.freezer/tools/build.loading-screen.mjs
+++ b/lively.freezer/tools/build.loading-screen.mjs
@@ -16,7 +16,6 @@ const build = await rollup({
       autoRun: { title: 'lively.next' },
       minify,
       asBrowserModule: true,
-      isResurrectionBuild: true,
       excludedModules: [
 	'lively.collab',
         'mocha-es6','mocha', 'picomatch', // references old lgtg that breaks the build
@@ -30,7 +29,7 @@ const build = await rollup({
       ],
       resolver
     }),
-    jsonPlugin(),
+    jsonPlugin({ exclude: /https\:\/\/jspm.dev\/.*\.json/}),
     babel({
      babelHelpers: 'bundled', 
      presets: [PresetEnv]

--- a/scripts/node_version_checker.sh
+++ b/scripts/node_version_checker.sh
@@ -4,11 +4,6 @@ NODE_VERSION=$(node -v)
 NODE_VERSION=$(echo "$NODE_VERSION" | sed -En 's/v([0-9]+)\..*/\1/p')
 
 if [[ $NODE_VERSION -lt 18 ]]; then
-  echo -n "Your node version is not supported. Please use node 18.X"; echo;
-  exit 1;
-fi
-
-if [[ $NODE_VERSION -ge 19 ]]; then
-  echo -n 'Your node version is not supported. Please use node 18.X.'; echo;
+  echo -n "Your node version is not supported. Please use node 18.X or higher."; echo;
   exit 1;
 fi


### PR DESCRIPTION
Minor fix to the json-plugin in rollup, that allows us to now support any node version > 18.