### PR TITLE
Fix/freezer lean builds

### DIFF
--- a/lively.freezer/src/plugins/rollup.js
+++ b/lively.freezer/src/plugins/rollup.js
@@ -76,7 +76,7 @@ export function lively (args) {
       if (bundler.excludedModules.length > 0) {
         opts.shimMissingExports = true; // since we are asked to exclude some of the lively modules, we set this flag to true. Can we isolate this??
       }
-      if (!opts.onwarn) opts.onwarn = (warning, warn) => { return customWarn(warning, warn); };
+      if (!opts.onwarn) opts.onwarn = (warning, warn) => { return customWarn(warning, warn, bundler); };
       opts.plugins = [
         ...bundler.resolver.supportingPlugins(bundler.asBrowserModule ? 'browser' : 'node'),
         ...opts.plugins

--- a/lively.morphic/text/commands.js
+++ b/lively.morphic/text/commands.js
@@ -1359,7 +1359,7 @@ commands.push(...usefulEditorCommands);
 import { activate as iyGotoCharActivate } from './iy-goto-char.js';
 commands.push(iyGotoCharActivate);
 
-System.import('lively.ide/text/search.js').then(textSearch => commands.push(...textSearch.searchCommands));
+System.import('lively.ide/text/search.js').then(textSearch => textSearch.searchCommands && commands.push(...textSearch.searchCommands));
 
 export default commands;
 


### PR DESCRIPTION
I noticed that lean production builds (excluding a lot of the core packages), were no longer running since:
1. We were insufficiently stubbing excluded modules in the build via the systemjs import map.
2. We had code in `lively.morphic/text` that was crashing when lively.ide was excluded from then bundle.