### PR TITLE
Enhance check of availability for GitHub Pages

### DIFF
--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -317,7 +317,7 @@ export class TopBarModel extends ViewModel {
           $world.setStatusMessage('Only available with GitHub repositories.', StatusMessageError);
           return;
         }
-        part(ProjectSettingsPrompt, { viewModel: { project: $world.openedProject } }).openInWorld();
+        $world.openPrompt(part(ProjectSettingsPrompt, { viewModel: { project: $world.openedProject }, hasFixedPosition: true }));
       }],
       [['🧑‍💻', { fontFamily: 'Noto Emoji' }, ' Open a Terminal (advanced operation)', null], async () => {
         // This relies on the assumption, that the default directory the shell command gets dropped in is `lively.server`.

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -11,7 +11,7 @@ import { join } from 'lively.modules/src/url-helpers.js';
 import { runCommand } from 'lively.shell/client-command.js';
 import ShellClientResource from 'lively.shell/client-resource.js';
 import { semver } from 'lively.modules/index.js';
-import { currentUsertoken, currentUser, currentUsername } from 'lively.user';
+import { currentUserToken, currentUser, currentUsername } from 'lively.user';
 import { reloadPackage } from 'lively.modules/src/packages/package.js';
 import { buildScriptShell } from './templates/build-shell.js';
 import { buildScript } from './templates/build.js';
@@ -61,7 +61,7 @@ export class Project {
 
   async changeRepositoryVisibility (visibility) {
     this.config.lively.repositoryIsPrivate = visibility === 'private';
-    return await this.gitResource.changeRemoteVisibility(currentUsertoken(), this.name, this.repoOwner, visibility);
+    return await this.gitResource.changeRemoteVisibility(currentUserToken(), this.name, this.repoOwner, visibility);
   }
 
   // TODO: 🍴 Support
@@ -152,7 +152,7 @@ export class Project {
     if (remote.endsWith('/')) remote = remote.slice(0, -1);
     const remoteUrl = new URL(remote);
 
-    const userToken = currentUsertoken();
+    const userToken = currentUserToken();
     // TODO: 🍴 Support!
     // Check here if the repo to clone is a fork (GitHub API) and create hidden metadata files if necessary.
     const projectName = remote.match(repositoryOwnerAndNameRegex)[2];
@@ -397,8 +397,7 @@ export class Project {
     if (withRemote) {
       try {
         await this.regeneratePipelines();
-        const createForOrg = gitHubUser !== currentUsername();
-        await this.gitResource.addRemoteToGitRepository(currentUsertoken(), this.config.name, gitHubUser, this.config.description, createForOrg, priv);
+        await this.gitResource.addRemoteToGitRepository(currentUserToken(), this.config.name, gitHubUser, this.config.description, createForOrg, priv);
       } catch (e) {
         throw Error('Error setting up remote', { cause: e });
       }
@@ -422,7 +421,7 @@ export class Project {
   }
 
   async regeneratePipelines () {
-    await this.gitResource.activateGitHubPages(currentUsertoken(), this.name, this.repoOwner);
+    await this.gitResource.activateGitHubPages(currentUserToken(), this.name, this.repoOwner);
     let pipelineFile, content;
     const livelyConfig = this.config.lively;
 
@@ -530,7 +529,7 @@ export class Project {
         const depName = depToEnsure.name.match(/[a-zA-Z\d]*--(.*)/)[1];
         const depRepoOwner = depToEnsure.name.match(/([a-zA-Z\d]*)--/)[1];
         // This relies on the assumption, that the default directory the shell command gets dropped in is `lively.server`.
-        const cmd = runCommand(`cd ../local_projects/ && git clone https://${currentUsertoken()}@github.com/${depRepoOwner}/${depName} ${depRepoOwner}--${depName}`, { l2lClient: ShellClientResource.defaultL2lClient });
+        const cmd = runCommand(`cd ../local_projects/ && git clone https://${currentUserToken()}@github.com/${depRepoOwner}/${depName} ${depRepoOwner}--${depName}`, { l2lClient: ShellClientResource.defaultL2lClient });
         await cmd.whenDone();
         if (cmd.exitCode !== 0) throw Error('Error cloning uninstalled dependency project.');
         // Refresh the cache of available projects and their version.

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -183,6 +183,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
           this.view.setStatusMessage('Error fetching Project from remote.', StatusMessageError);
         }
       } else {
+        li = $world.showLoadingIndicatorFor(this.view, 'Creating Project...');
         const createNewRemote = createRemoteCheckbox.checked;
         const priv = privateCheckbox.checked;
         const { name: repoOwner, isOrg } = userSelector.selection;
@@ -190,8 +191,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
         const currentLivelyVersion = await VersionChecker.currentLivelyVersion(true);
         createdProject.config.lively.boundLivelyVersion = currentLivelyVersion;
         try {
-          li = $world.showLoadingIndicatorFor(this.view, 'Creating Project...');
-          createdProject.create(createNewRemote, isOrg ? repoOwner : currentUsername(), priv);
+          await createdProject.create(createNewRemote, isOrg ? repoOwner : currentUsername(), priv);
           li.remove();
           super.resolve(createdProject);
         } catch (err) {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -10,7 +10,7 @@ import { SaveWorldDialog } from 'lively.ide/studio/dialogs.cp.js';
 import { without } from 'lively.morphic/components/core.js';
 import { Label } from 'lively.morphic/text/label.js';
 import { CheckBox } from 'lively.components/widgets.js';
-import { currentUsertoken, currentUsersOrganizations, currentUsername } from 'lively.user';
+import { currentUserToken, currentUsersOrganizations, currentUsername } from 'lively.user';
 import { Project } from 'lively.project';
 import { StatusMessageError, StatusMessageConfirm } from 'lively.halos/components/messages.cp.js';
 import { EnumSelector, Spinner } from 'lively.ide/studio/shared.cp.js';
@@ -208,7 +208,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     okButton.disable();
     privateCheckbox.disable();
     if (!this.canBeCancelled) cancelButton.disable();
-    if (!currentUsertoken()) {
+    if (!currentUserToken()) {
       this.waitForLogin();
     } else {
       const li = $world.showLoadingIndicatorFor(this.view);

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -118,8 +118,8 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
               }
             },
             { model: 'cancel button', signal: 'fire', handler: 'close' },
-            { target: 'remote url', signal: 'onInputChanged', handler: 'checkValidity', converter: `() => false` },
-            { target: 'project name', signal: 'onInputChanged', handler: 'checkValidity', converter: `() => false` }
+            { target: 'remote url', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' },
+            { target: 'project name', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' }
           ];
         }
       },
@@ -167,7 +167,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     await fun.guardNamed('resolve-project-creation', async () => {
       this.disableButtons();
       let li;
-      let { remoteUrl, projectName, createRemoteCheckbox, userSelector, description } = this.ui;
+      let { remoteUrl, projectName, createRemoteCheckbox, privateCheckbox, userSelector, description } = this.ui;
       let createdProject, urlString;
       if (!this.checkValidity(true)) {
         return;
@@ -184,14 +184,14 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
         }
       } else {
         const createNewRemote = createRemoteCheckbox.checked;
-      const priv = privateCheckbox.checked;
+        const priv = privateCheckbox.checked;
         const { name: repoOwner, isOrg } = userSelector.selection;
         createdProject = new Project(projectName.textString, { author: currentUsername(), description: description.textString, repoOwner: repoOwner });
         const currentLivelyVersion = await VersionChecker.currentLivelyVersion(true);
         createdProject.config.lively.boundLivelyVersion = currentLivelyVersion;
         try {
           li = $world.showLoadingIndicatorFor(this.view, 'Creating Project...');
-        createdProject.create(createNewRemote, isOrg ? repoOwner : currentUsername(), priv);
+          createdProject.create(createNewRemote, isOrg ? repoOwner : currentUsername(), priv);
           li.remove();
           super.resolve(createdProject);
         } catch (err) {
@@ -320,23 +320,23 @@ class ProjectSavePrompt extends AbstractPromptModel {
 
   async resolve () {
     await fun.guardNamed('resolve-project-saving', async () => {
-    this.disableButtons();
+      this.disableButtons();
 
-    const { description } = this.ui;
-    const message = description.textString;
+      const { description } = this.ui;
+      const message = description.textString;
 
-    let increaseLevel;
-    if (this.increaseMajor) increaseLevel = 'major';
-    else if (this.increaseMinor) increaseLevel = 'minor';
-    else increaseLevel = 'patch';
+      let increaseLevel;
+      if (this.increaseMajor) increaseLevel = 'major';
+      else if (this.increaseMinor) increaseLevel = 'minor';
+      else increaseLevel = 'patch';
 
-    const li = $world.showLoadingIndicatorFor(this.view, 'Saving Project...');
-    const success = await this.project.save({ increaseLevel, message, tag: this.tag });
-    li.remove();
-    this.terminalWindow?.close();
-    if (success) $world.setStatusMessage('Project saved!', StatusMessageConfirm);
-    else $world.setStatusMessage('Save unsuccessful', StatusMessageError);
-    super.resolve(success);
+      const li = $world.showLoadingIndicatorFor(this.view, 'Saving Project...');
+      const success = await this.project.save({ increaseLevel, message, tag: this.tag });
+      li.remove();
+      this.terminalWindow?.close();
+      if (success) $world.setStatusMessage('Project saved!', StatusMessageConfirm);
+      else $world.setStatusMessage('Save unsuccessful', StatusMessageError);
+      super.resolve(success);
     })();
   }
 }

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -49,6 +49,7 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
                   $world.setStatusMessage('Error changing Repository visibility.', StatusMessageError);
                   return;
                 }
+                await this.project.checkPagesSupport();
                 if (this.project.canDeployToPages) deployCheck.enable();
                 else deployCheck.disable();
                 spinner.opacity = 0;

--- a/lively.user/index.js
+++ b/lively.user/index.js
@@ -20,11 +20,11 @@ export function currentUsername () {
   return currentUser().login;
 }
 
-export function currentUsertoken () {
+export function currentUserToken () {
   return localStorage.getItem('gh_access_token');
 }
 
-export function storeCurrentUsertoken (token) {
+export function storeCurrentUserToken (token) {
   localStorage.setItem('gh_access_token', token);
 }
 export function clearUserData () {

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -1,6 +1,6 @@
 import { ViewModel, ShadowObject, Image, Icon, Label, TilingLayout, component } from 'lively.morphic';
 import { pt, Color } from 'lively.graphics';
-import { currentUser, clearUserData, clearAllUserData, storeCurrentUser, storeCurrentUsersOrganizations, currentUsertoken, storeCurrentUsertoken } from 'lively.user';
+import { currentUser, clearUserData, clearAllUserData, storeCurrentUser, storeCurrentUsersOrganizations, currentUserToken, storeCurrentUserToken } from 'lively.user';
 import { signal } from 'lively.bindings';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
 import { StatusMessageError } from 'lively.halos/components/messages.cp.js';
@@ -176,7 +176,7 @@ class UserFlapModel extends ViewModel {
       $world.setStatusMessage('An unexpected error occured. Please contact the lively.next team.', StatusMessageError);
       return;
     }
-    storeCurrentUsertoken(userToken);
+    storeCurrentUserToken(userToken);
     await this.retrieveGithubUserData();
     this.toggleLoadingAnimation();
     this.showLoggedInUser();
@@ -198,7 +198,7 @@ class UserFlapModel extends ViewModel {
   }
 
   async retrieveGithubUserData () {
-    const token = currentUsertoken();
+    const token = currentUserToken();
     // retrieve general data about the authenticated user
     const cmdString = `curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${token}" https://api.github.com/user`;
     let { stdout: userRes } = await runCommand(cmdString).whenDone();


### PR DESCRIPTION
The check we currently have for the availability of GitHub pages did not result in correct values for collaborators in a repository of a paying user, as well as for organizations. This PR:

1. Solves this issue, as we know that a user needs to create a repository/project themselves. We can therefore persist this information in the lively config and update it regularly (in case a users upgrades to paid after the fact). This way, we get correct results in all cases.
2. Fixes some problems with the code I introduces when I recently "resolved" some merge conflicts.
3. Fixes a problem where the loading indicator was not visible for long enough when creating a project, which could be quite confusing. 