### PR TITLE
📂🧰🐚: do not create empty commits in projects

### DIFF
--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -18,6 +18,7 @@ import { WindowSwitcher } from './window-switcher.cp.js';
 import { browserForFile } from './js/browser/ui.cp.js';
 import { SaveProjectDialog } from 'lively.project/prompts.cp.js';
 import { Project } from 'lively.project';
+import { StatusMessageConfirm } from 'lively.halos/components/messages.cp.js';
 
 const commands = [
 
@@ -1216,6 +1217,11 @@ const commands = [
     exec: async (world, args, _, evt) => {
       let saved;
       if ($world.openedProject) {
+        await $world.openedProject.saveConfigData();
+        if (!(await $world.openedProject.hasUncommitedChanges())) {
+          $world.setStatusMessage('All changes are saved. Nothing to do.', StatusMessageConfirm);
+          return;
+        }
         saved = await $world.openPrompt(part(SaveProjectDialog, { viewModel: { project: $world.openedProject } }));
       } else { // in case there is another morph implementing save...
         const relayed = evt && world.relayCommandExecutionToFocusedMorph(evt);

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -53,6 +53,10 @@ export class Project {
     return await this.gitResource.hasRemote();
   }
 
+  async hasUncommitedChanges () {
+    return await this.gitResource.hasUncommitedChanges();
+  }
+
   async changeRepositoryVisibility (visibility) {
     this.config.lively.repositoryIsPrivate = visibility === 'private';
     return await this.gitResource.changeRemoteVisibility(currentUserToken(), this.name, this.repoOwner, visibility);

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -312,12 +312,6 @@ class ProjectSavePrompt extends AbstractPromptModel {
     };
   }
 
-  async viewDidLoad () {
-    this.ui.diffButton.disable();
-    await this.project.saveConfigData();
-    this.ui.diffButton.enable();
-  }
-
   async resolve () {
     await fun.guardNamed('resolve-project-saving', async () => {
       this.disableButtons();

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -149,6 +149,13 @@ export default class GitShellResource extends ShellClientResource {
     const resetCmd = `git checkout ${fileName}`;
     await this.runCommand(resetCmd).whenDone();
   }
+
+  async hasUncommitedChanges () {
+    const checkCmd = '(git add * || true) && git diff --cached --exit-code && git diff --exit-code';
+    const check = this.runCommand(checkCmd);
+    await check.whenDone();
+    return !!check.exitCode;
+  }
 }
 
 export const gitResourceExtension = {


### PR DESCRIPTION
Previously, it was possible to create effectively empty commits, since one could always press the save button, which in turn would lead to an increase of the patch number of the projects version, which then could be commited. We prevent this now, by just not opening the save dialogue when no files in the project have changed.