### PR TITLE
📂: better explain the capabilities of `index.css` in new `project`s

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -273,13 +273,12 @@ export class Project {
     return term;
   }
 
-
-  async checkPagesSupport(){
+  async checkPagesSupport () {
     const currUser = currentUser();
     const currUserName = currUser.login;
 
     // GH Pages is possible for non-private repositories in any case
-    if (!this.config.lively.repositoryIsPrivate) this.config.lively.canUsePages = true
+    if (!this.config.lively.repositoryIsPrivate) this.config.lively.canUsePages = true;
     // Each time the repository is saved by its owner, check if they have a non-free plan, allowing to use GH Pages on private repositories
     if (this.repoOwner === currUserName && this.config.lively.repositoryIsPrivate) {
       if (currUser.plan.name !== 'free') this.config.lively.canUsePages = true;
@@ -309,7 +308,7 @@ export class Project {
    */
   async saveConfigData () {
     await this.checkPagesSupport();
-    
+
     await this.removeUnusedProjectDependencies();
     await this.addMissingProjectDependencies();
     if (!this.configFile) {
@@ -396,7 +395,7 @@ export class Project {
         workspaces: {
           'default.workspace.js': ''
         },
-        'index.css': '/* Use this file to add custom CSS to be used for this project! */\n/* Do NOT use @import rules in this file! */',
+        'index.css': '/* Use this file to add custom CSS to be used for this project. */\n/* Do NOT create other CSS files in this folder, as they will not be available in the bundled application! */\n/* `@imports` fetching remote CSS are okay. */',
         'fonts.css': fontCSSWarningString
       });
       await this.generateBuildScripts();


### PR DESCRIPTION
This should make the auto-generated comment in the `index.css` of projects more clear.
One can use `@import` rules to fetch remote CSS. However, the use of `@import` to use other, local CSS files is not recommended. There are two reasons for this:

1. When bundling an application, we only respect two CSS files per project: the `fonts.css` and the `index.css`. Other CSS files are not copied, and therefore will not be available in the bundled application.
2. Additionally, the location of `index.css` inside of the bundled application is different than in the project. Inside of the bundle, `index.css` is moved into the `assets` folder.