### PR TITLE
📂: update generated build script for `lively.project`s

### DIFF
--- a/lively.project/templates/build.js
+++ b/lively.project/templates/build.js
@@ -32,7 +32,7 @@ const build = await rollup({
       ],
       resolver
     }),
-    jsonPlugin(),
+    jsonPlugin({ exclude: /https\\\:\\\/\\\/jspm.dev\\\/.*\\\.json/}),
     babel({
      babelHelpers: 'bundled', 
      presets: [PresetEnv]
@@ -44,5 +44,5 @@ await build.write({
   format: 'system',
   dir: 'build'
 });
-`
+`;
 


### PR DESCRIPTION
Since #1002, we need to change the configuration of the `jsonPlugin` in the bundler. This PR generates a working `build.mjs` for newly created projects.

See https://stackoverflow.com/a/10042082/4418325 for why we need so many backslashes.

---

This PR showcases a problem that occurs with generated but customizable files: We sometimes would need to regenerate a file in order to keep everything working. However, we cannot just nuke the `build.mjs` file of each project on save, as people might have made customizations to their build, e.g., by excluding additional modules. How do we want to handle this? Do we want to handle this? Would a visible hint inside of release notes eventually resolve this problem? Or a button that forces updates but that would one need to press explicitly? In the last case, we would probably need a structure similar to the object migrations, correct? Any thoughts, @merryman?