### PR TITLE
🧰: fix typo in fixedWidth control

### DIFF
--- a/lively.ide/studio/controls/shape.cp.js
+++ b/lively.ide/studio/controls/shape.cp.js
@@ -356,7 +356,7 @@ export class ShapeControlModel extends ViewModel {
         if (target.layout?.hugContentsHorizontally) target.layout.hugContentsHorizontally = false;
 
         target.withMetaDo({ reconcileChanges: true }, () => {
-          if (target.isText) target.fixedWith = true;
+          if (target.isText) target.fixedWidth = true;
         });
 
         this.ui.widthInput.enable();


### PR DESCRIPTION
There was a typo in the logic of the resize mode control of the side bar. It failed to set the `fixedWidth` of a text morph if instructed to do so.