### PR TITLE
🧰🎨: ignore underscore style props in reconciler

### DIFF
--- a/lively.ide/components/change-tracker.js
+++ b/lively.ide/components/change-tracker.js
@@ -94,6 +94,7 @@ export class ComponentChangeTracker {
   ignoreChange (change) {
     if (!change.meta?.reconcileChanges) return true;
     if (change.prop === 'name') return false;
+    if (change.prop?.startsWith('_')) return true;
     if (change.prop === 'position' && (change.target === this.trackedComponent || this.isPositionedByLayout(change.target))) return true;
     if (change.prop &&
         change.prop !== 'textAndAttributes' &&

--- a/lively.serializer2/plugins/expression-serializer.js
+++ b/lively.serializer2/plugins/expression-serializer.js
@@ -547,7 +547,7 @@ function handleSpecProps (morph, exported, styleProto, path, masterInScope, opts
       if (masterInScope?.isResizedByLayout(morph)) continue;
     }
     if (name === 'submorphs' || name === 'type') continue;
-    if (skipAttributes.includes(name)) continue;
+    if (skipAttributes.includes(name) || name.startsWith('_')) continue;
     if (name === 'metadata' && Path('commit.__serialize__').get(val)) {
       exported[name] = { ...val, commit: getExpression(name + '.commit', val.commit, opts) };
       continue;


### PR DESCRIPTION
We currently have several internal underscore style properties which have been introduced as part of #538. These incorrectly got reconciled upon component definition creation.