### PR TITLE
Add remote after project creation

### DIFF
--- a/lively.ide/studio/font-manager.cp.js
+++ b/lively.ide/studio/font-manager.cp.js
@@ -5,7 +5,7 @@ import { Color } from 'lively.graphics/color.js';
 
 import { Text } from 'lively.morphic/text/morph.js';
 
-import { currentUsername } from 'lively.user';
+import { currentUsername, isUserLoggedIn } from 'lively.user';
 
 import { resource } from 'lively.resources';
 import { DarkPopupWindow, DarkThemeList, EnumSelector, RemoveButton, TextInput, PropertyLabelActive, PropertyLabelHovered, PropertyLabel } from './shared.cp.js';
@@ -102,7 +102,7 @@ class FontManagerModel extends PopupModel {
     let res;
     res = resource(System.baseURL);
     let uploadPath;
-    if (currentUsername() === 'guest') {
+    if (!isUserLoggedIn()) {
       uploadPath = 'uploads/';
     } else uploadPath = $world.openedProject ? $world.openedProject.url.replace(System.baseURL, '') + '/assets/' : 'users/' + currentUsername() + '/uploads';
     const fontFile = resource(System.baseURL).join(uploadPath).join(file.name);
@@ -364,7 +364,7 @@ const FontListEntry = component({
   }]
 });
 
-const DragArea = component ({
+const DragArea = component({
   name: 'drag and drop area',
   fill: Color.rgba(255, 255, 255, 0),
   layout: new TilingLayout({
@@ -416,11 +416,11 @@ const DragArea = component ({
 
     }]
   })]
-})
+});
 
 const DragAreaActive = component(DragArea, {
   borderWidth: 8
-})
+});
 
 const FontManager = component({
   name: 'font manager',

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -42,7 +42,7 @@ import ObjectPackage from 'lively.classes/object-classes.js';
 import { toggleSidebar, relayoutSidebarFlapInWorld, openSidebarFlapInWorld } from './studio/sidebar-flap.js';
 import { localInterface } from 'lively-system-interface';
 import { ProjectCreationPrompt } from 'lively.project/prompts.cp.js';
-import { currentUsername, currentUser } from 'lively.user';
+import { currentUsername, isUserLoggedIn, currentUser } from 'lively.user';
 import { subscribe } from 'lively.notifications/index.js';
 
 export class LivelyWorld extends World {
@@ -594,7 +594,7 @@ export class LivelyWorld extends World {
       const proj = this.openedProject;
       if (proj) {
         uploadPath = `local_projects/${proj.repoOwner}--${proj.name}/assets`;
-      } else uploadPath = currentUsername() === 'guest' ? 'uploads/' : 'users/' + currentUser() + '/uploads';
+      } else uploadPath = !isUserLoggedIn() ? 'uploads/' : 'users/' + currentUser() + '/uploads';
       if (evt.isAltDown() && !proj) {
         uploadPath = await this.prompt('Choose upload location', {
           history: 'lively.morphic-html-drop-file-upload-location',

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -480,7 +480,7 @@ export class LivelyWorld extends World {
         if (!anonymousMode) worldName = await this.askForName();
         else if (anonymousMode) worldName = 'aLivelyWorld';
       } else if (openNewProjectPrompt) { // We open a **new** Project
-        const project = await this.openPrompt(part(ProjectCreationPrompt, { viewModel: { canBeCancelled: false }, hasFixedPosition: true }));
+        const project = await this.openPrompt(part(ProjectCreationPrompt, { hasFixedPosition: true }));
         $world.openedProject = project;
         worldName = project.name;
       } else if (projectToBeOpened) { // We open an existing Project

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -11,7 +11,7 @@ import { join } from 'lively.modules/src/url-helpers.js';
 import { runCommand } from 'lively.shell/client-command.js';
 import ShellClientResource from 'lively.shell/client-resource.js';
 import { semver } from 'lively.modules/index.js';
-import { currentUserToken, currentUser, currentUsername } from 'lively.user';
+import { currentUserToken, isUserLoggedIn, currentUser, currentUsername } from 'lively.user';
 import { reloadPackage } from 'lively.modules/src/packages/package.js';
 import { buildScriptShell } from './templates/build-shell.js';
 import { buildScript } from './templates/build.js';
@@ -505,7 +505,7 @@ export class Project {
   }
 
   async save (opts = {}) {
-    if (currentUsername() === 'guest') {
+    if (!isUserLoggedIn()) {
       $world.setStatusMessage('Please log in.');
       return false;
     }

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -509,6 +509,81 @@ export const ProjectSettingsPrompt = component(LightPrompt, {
   }), add(part(OKCancelButtonWrapper, { name: 'button wrapper' }))]
 });
 
+const RepoSettings = component(
+  {
+    name: 'repo settings',
+    fill: Color.transparent,
+    layout: new TilingLayout({
+      axis: 'column',
+      hugContentsHorizontally: true,
+      orderByIndex: true,
+      spacing: 5
+    }),
+    submorphs: [
+      {
+        name: 'user holder',
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          orderByIndex: true,
+          spacing: 5
+        }),
+        submorphs: [
+          part(EnumSelector, {
+            name: 'user selector',
+            master: SystemButton,
+            layout: new TilingLayout(
+              {
+                align: 'center',
+                axisAlign: 'center',
+                justifySubmorphs: 'spaced',
+                orderByIndex: true,
+                padding: rect(5, 0, 5, 0),
+                resizePolicies: [['label', [{ height: 'fixed', width: 'fill' }]]]
+              }),
+            viewModel: {
+              listMaster: SystemList,
+              openListInWorld: true,
+              listAlign: 'selection'
+            }
+          }), part(InformIconOnLight, {
+            viewModel: { information: 'For which entity should the project be created? This corresponds to the repository owner on GitHub.' },
+            name: 'label_1'
+          })
+        ]
+      },
+      {
+        name: 'remote holder',
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center'
+        }),
+        submorphs: [
+          part(LabeledCheckBox, { name: 'create remote checkbox', viewModel: { label: 'Create new GitHub repository?' } }),
+          part(InformIconOnLight, {
+            viewModel: { information: 'Should a new GitHub repository with the projects name automatically be created under the specified GitHub entity?' },
+            name: 'morph_1'
+          })
+        ]
+      }, {
+        name: 'private repo holder',
+        fill: Color.transparent,
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center'
+        }),
+        submorphs: [
+          part(LabeledCheckBox, { name: 'private checkbox', viewModel: { label: 'Should the new GitHub repository be private?' } }),
+          part(InformIconOnLight, {
+            viewModel: { information: 'Should the new GitHub repository for the project be private?' },
+            name: 'morph_2'
+          })
+        ]
+      }]
+  });
+
 export const ProjectCreationPrompt = component(LightPrompt, {
   defaultViewModel: ProjectCreationPromptModel,
   extent: pt(385, 345),
@@ -577,46 +652,8 @@ export const ProjectCreationPrompt = component(LightPrompt, {
           nativeCursor: 'text',
           textAndAttributes: ['Project Name', null]
         }]
-      }), part(EnumSelector, {
-        name: 'user selector',
-        master: SystemButton,
-        layout: new TilingLayout(
-          {
-            align: 'center',
-            axisAlign: 'center',
-            justifySubmorphs: 'spaced',
-            orderByIndex: true,
-            padding: rect(5, 0, 5, 0),
-            resizePolicies: [['label', [{ height: 'fixed', width: 'fill' }]]]
-          }),
-        viewModel: {
-          listMaster: SystemList,
-          openListInWorld: true,
-          listAlign: 'selection'
-        }
-      }),
-      {
-        fill: Color.transparent,
-        layout: new TilingLayout({
-          align: 'center',
-          axisAlign: 'center'
-        }),
-        submorphs: [
-          part(LabeledCheckBox, { name: 'create remote checkbox', viewModel: { label: 'Create new GitHub repository?' } }),
-          part(InformIconOnLight, { viewModel: { information: 'Should a new GitHub repository with the projects name automatically be created under the specified GitHub entity?' } })
-        ]
-      }, {
-        name: 'private repo holder',
-        fill: Color.transparent,
-        layout: new TilingLayout({
-          align: 'center',
-          axisAlign: 'center'
-        }),
-        submorphs: [
-          part(LabeledCheckBox, { name: 'private checkbox', viewModel: { label: 'Should the new GitHub repository be private?' } }),
-          part(InformIconOnLight, { viewModel: { information: 'Should the new GitHub repository for the project be private?' } })
-        ]
-      }, part(InputLineDefault, {
+      }), part(RepoSettings),
+      part(InputLineDefault, {
         name: 'description',
         extent: pt(318.1, 106.3),
         placeholder: 'Project Description',

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -97,10 +97,6 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
 class ProjectCreationPromptModel extends AbstractPromptModel {
   static get properties () {
     return {
-      projectBrowser: {},
-      canBeCancelled: {
-        defaultValue: true
-      },
       bindings: {
         get () {
           return [
@@ -117,7 +113,6 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
                 else privateCheckbox.disable();
               }
             },
-            { model: 'cancel button', signal: 'fire', handler: 'close' },
             { target: 'remote url', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' },
             { target: 'project name', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' }
           ];
@@ -125,6 +120,10 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
       },
       label: 'Create new Project'
     };
+  }
+
+  reject () {
+    // noop, just to stop users from cancelling the prompt
   }
 
   checkValidity (onlyCheck = false) {
@@ -151,16 +150,6 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     }
     if (!onlyCheck) okButton.enable();
     return true;
-  }
-
-  close () {
-    this.projectBrowser?.toggleFader(true);
-    this.view.remove();
-  }
-
-  reject () {
-    if (!this.canBeCancelled) false;
-    else super.reject();
   }
 
   async resolve () {
@@ -208,7 +197,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     const { promptTitle, cancelButton, okButton, userFlap, privateCheckbox } = this.ui;
     okButton.disable();
     privateCheckbox.disable();
-    if (!this.canBeCancelled) cancelButton.disable();
+    cancelButton.disable();
     if (!currentUserToken()) {
       this.waitForLogin();
     } else {

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -50,7 +50,7 @@ export default class GitShellResource extends ShellClientResource {
     return true;
   }
 
-  async addRemoteToGitRepository (token, repoName, repoUser, repoDescription, orgScope, priv) {
+  async createAndAddRemoteToGitRepository (token, repoName, repoUser, repoDescription, orgScope, priv) {
     const repoCreationCommand = orgScope
       ? `curl -L \
               -X POST \

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -106,8 +106,8 @@ export default class GitShellResource extends ShellClientResource {
     if (cmd.exitCode !== 0) console.error(`Activating GitHub Pages for ${repoUser}/${repoName} was not successful. Proceeding.`);
   }
 
-  async commitRepo (message, tag = false, tagName) {
-    let cmdString = `git add . && git commit -m "${message}"`;
+  async commitRepo (message, tag = false, tagName, filesToCommit = '.') {
+    let cmdString = `git add ${filesToCommit} && git commit -m "${message}"`;
     let cmd = this.runCommand(cmdString);
     await cmd.whenDone();
     if (cmd.exitCode !== 0 && !cmd.stdout.includes('nothing to commit')) throw Error('Error committing');

--- a/lively.user/index.js
+++ b/lively.user/index.js
@@ -5,6 +5,10 @@ export function currentUser () {
   } else return { login: 'guest' };
 }
 
+export function isUserLoggedIn () {
+  return currentUser().login !== 'guest';
+}
+
 export function storeCurrentUser (userData) {
   localStorage.setItem('gh_user_data', userData);
 }
@@ -32,7 +36,7 @@ export function clearUserData () {
   localStorage.removeItem('gh_user_organizations');
 }
 
-export function clearAllUserData (){
+export function clearAllUserData () {
   clearUserData();
   localStorage.removeItem('gh_access_token');
 }

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -1,6 +1,6 @@
 import { ViewModel, ShadowObject, Image, Icon, Label, TilingLayout, component } from 'lively.morphic';
 import { pt, Color } from 'lively.graphics';
-import { currentUser, clearUserData, clearAllUserData, storeCurrentUser, storeCurrentUsersOrganizations, currentUserToken, storeCurrentUserToken } from 'lively.user';
+import { currentUser, isUserLoggedIn, clearUserData, clearAllUserData, storeCurrentUser, storeCurrentUsersOrganizations, currentUserToken, storeCurrentUserToken } from 'lively.user';
 import { signal } from 'lively.bindings';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
 import { StatusMessageError } from 'lively.halos/components/messages.cp.js';
@@ -63,18 +63,18 @@ class UserFlapModel extends ViewModel {
     };
   }
 
-  async update (){
+  async update () {
     clearUserData();
     await this.retrieveGithubUserData();
-    this.showUserData()
+    this.showUserData();
   }
 
   leftUserLabelClicked () {
-    if (currentUser().login === 'guest') this.login();
+    if (!isUserLoggedIn()) this.login();
   }
 
   rightUserLabelClicked () {
-    if (currentUser().login !== 'guest') this.logout();
+    if (isUserLoggedIn()) this.logout();
   }
 
   toggleLoadingAnimation () {
@@ -85,7 +85,7 @@ class UserFlapModel extends ViewModel {
 
   async viewDidLoad () {
     const { loginButton, leftUserLabel, rightUserLabel, avatar } = this.ui;
-    if (currentUser().login === 'guest') {
+    if (!isUserLoggedIn()) {
       if (this.withLoginButton) {
         avatar.visible = false;
         loginButton.visible = loginButton.isLayoutable = true;
@@ -249,7 +249,7 @@ class UserFlapModel extends ViewModel {
     const { avatar, leftUserLabel, rightUserLabel } = this.ui;
     try {
       const userData = currentUser();
-      if (userData.login === 'guest') return;
+      if (!isUserLoggedIn()) return;
       avatar.loadUrl(userData.avatar_url, false);
       leftUserLabel.textString = userData.login;
       rightUserLabel.textAndAttributes = Icon.textAttribute('right-from-bracket');


### PR DESCRIPTION
Previously, one could only create a remote repository for a project while creating the project. Afterwards, this option was not accessible for the average `lively.next` user, but only with some knowledge about how `lively.project`s work internally.

This PR changes that:
When one has a project that only exists locally, instead of the "Project Settings", which are only available with a remote, an option to add a remote appears in the save menu:

![image](https://github.com/LivelyKernel/lively.next/assets/14252419/87fd038d-6e53-4cc8-9d46-5994e95f986e)

Clicking that will open the prompt that can be seen in the screenshot. There, one can choose if the repository should be private or not. Pressing OK will then create a repository, commit the changed config and pipeline files (and leave unsaved progress in the rest of the project alone) and push that to GitHub.

Afterwards, the "Project Settings" are available instead of this option in the save menu.

**Note, that the user under which the repository is created is determined at time of project creation!** This is not entirely satisfactory and I'd like to change that, as well as moving project between users (especially guest users, which would be very important to allow for an offline first workflow again). I nevertheless think this feature can stand on its own and is a step in the right direction.
