### PR TITLE
🎨: fix order rendering of paths in css layouts

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -3398,7 +3398,7 @@ export class Path extends Morph {
 
   renderStyles (style) {
     style = obj.select(style, ['position', 'filter', 'display', 'opacity',
-      'transform', 'top', 'left', 'transformOrigin', 'cursor', 'overflow']);
+      'transform', 'top', 'left', 'transformOrigin', 'cursor', 'overflow', 'order']);
 
     style.width = this.width + 'px';
     style.height = this.height + 'px';


### PR DESCRIPTION
Fixes the rendering of path/polygon morphs when positioned by css layouts.