### PR TITLE
❄️: preload "Noto Emoji" font to prevent default emoji font showing

### DIFF
--- a/lively.freezer/src/loading-screen.cp.js
+++ b/lively.freezer/src/loading-screen.cp.js
@@ -58,6 +58,9 @@ export class WorldLoadingScreen extends Morph {
     const serverURL = resource(window.SYSTEM_BASE_URL || document.location.origin).join('objectdb/').url;
     const { bootstrap } = await System.import('lively.freezer/src/util/bootstrap.js');
 
+    // Preload emoji font to prevent flash of unstyled emojis falling back to system font.
+    document.fonts.load('12px Noto Emoji');
+
     if (projectName) {
       const existingProjects = await Project.listAvailableProjects();
       const foundProject = existingProjects.filter(p => p.name === projectName && p.projectRepoOwner === projectRepoOwner);


### PR DESCRIPTION
When opening the save menu of projects for the first time, the default emoji font of the system was used until "Noto Emoji" was loaded. As my default font is colored, and we use a bw emoji font, that was quite striking. Preloading the font in the loading screen already fixes this problem.