### PR TITLE
🎨: refit `Text` after resizePolicies` of `TilingLayout` kicked in

### DIFF
--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -913,6 +913,7 @@ export class TilingLayout extends Layout {
     style['margin-right'] = `${margin.right}px`;
     if (Number.parseInt(style['flex-grow']) !== 1) style['flex-shrink'] = 0;
     this.measureAfterRender(morph);
+    if (morph.isText) morph.renderingState.needsFit = true;
   }
 
   measureAfterRender (layoutableSubmorph) {


### PR DESCRIPTION
Previously, the effect of the resizePolicies came after the Text had already fit itself. Since the flag was not set, wrong extents manifested itself afterwards.