### PR TITLE
🎛️: do not retrieve image data if either height or width of canvas 0

### DIFF
--- a/lively.components/canvas.js
+++ b/lively.components/canvas.js
@@ -121,12 +121,12 @@ export class Canvas extends Morph {
     let contents;
     const { width: w, height: h } = this._canvas;
     if (this.renderingState.width !== this.width) {
-      if (this.context.getImageData) { contents = this.context.getImageData(0, 0, w, h); }
+      if (this.context.getImageData && h > 0 && w > 0) { contents = this.context.getImageData(0, 0, w, h); }
       node.firstChild.width = this.width;
       this.renderingState.width = this.width;
     }
     if (this.renderingState.height !== this.height) {
-      if (this.context.getImageData) { contents = this.context.getImageData(0, 0, w, h); }
+      if (this.context.getImageData && h > 0 && w > 0) { contents = this.context.getImageData(0, 0, w, h); }
       node.firstChild.height = this.height;
       this.renderingState.height = this.height;
     }


### PR DESCRIPTION
Fixes a crash in the renderer that would happen when the height of a canvas morph was set to `fill` in either height or width when controlled by a tiling layout.