### PR TITLE
🚨allow pointer events on canvas

### DIFF
--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -665,7 +665,6 @@ export default class Renderer {
 
     canvasNode.style.width = `${this.width}px`;
     canvasNode.style.height = `${this.height}px`;
-    canvasNode.style['pointer-events'] = 'none';
     canvasNode.style.position = 'absolute';
 
     node.appendChild(canvasNode);


### PR DESCRIPTION
For ominous reasons, the canvas inside the rendered canvas morph would not accept any pointer events. This made it impossible for some 3rd part libraries to work properly.
We hereby enable events on the canvas.