### PR TITLE
🎛️: only fit menu items, when font has been loaded

### DIFF
--- a/lively.components/menus.js
+++ b/lively.components/menus.js
@@ -307,7 +307,7 @@ export class Menu extends Morph {
     return invalidItem;
   }
 
-  updateMorphs () {
+  async updateMorphs () {
     this.submorphs = [];
 
     const pLeft = this.padding.left();
@@ -335,7 +335,7 @@ export class Menu extends Morph {
       maxWidth = Math.max(title.width, maxWidth);
     }
 
-    this.items.forEach(({ label, string, annotation, action, submenu, isDivider, tooltip }) => {
+    for (let { label, string, annotation, action, submenu, isDivider, tooltip } of this.items) {
       const itemMorph = this.addMorph(
         isDivider
           ? new MenuDivider({ position: pos })
@@ -348,10 +348,13 @@ export class Menu extends Morph {
             position: pos,
             ...defaultStyle
           }));
-      if (itemMorph.fit) itemMorph.fit();
+      if (itemMorph.fit) {
+        await itemMorph.whenFontLoaded();
+        itemMorph.fit();
+      }
       pos = itemMorph.bottomLeft;
       maxWidth = Math.max(itemMorph.width, maxWidth);
-    });
+    }
 
     this.submorphs.forEach(ea => {
       ea.fixedWidth = true;


### PR DESCRIPTION
Fixes an issue where upon first opening the shape menu would look like this:
<img width="269" alt="messed-up-menu" src="https://github.com/LivelyKernel/lively.next/assets/1296388/2736f56e-01b7-48b3-b496-60547f0dfdfb">
