### PR TITLE
Fix/freezer plugin

### DIFF
--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -186,7 +186,7 @@ export default class LivelyRollup {
    * @param { string } id - The id of the module.
    */
   normalizedId (id) {
-    return id.replace(baseURL, '').replace('local://lively-object-modules/', '');
+    return id.replace(baseURL, '').replace('local://lively-object-modules/', '').replace('local_projects/', '');
   }
 
   /**

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -197,7 +197,7 @@ export default class LivelyRollup {
    * @returns { object } The transform options.
    */
   getTransformOptions (modId, parsedSource) {
-    if (modId === '@empty') return {};
+    if (modId === '@empty.js') return {};
     let version, name;
     const pkg = this.resolver.resolvePackage(modId);
     if (pkg) {
@@ -727,7 +727,7 @@ export default class LivelyRollup {
         importMap = '<script type="systemjs-importmap">\n{\n"imports": {\n';
         importMap += this.excludedModules
           .concat(this.asBrowserModule ? ['fs', 'events'] : [])
-          .map(id => `"${id}": "./@empty"`).join(',\n');
+          .map(id => `"${id}": "./@empty.js"`).join(',\n');
         importMap += '\n  }\n}\n</script>';
       }
     } else {
@@ -885,7 +885,7 @@ export default class LivelyRollup {
     // add the blank import file to make systemjs happy
     plugin.emitFile({
       type: 'asset',
-      fileName: '@empty',
+      fileName: '@empty.js',
       source: ''
     });
 

--- a/lively.freezer/src/resolvers/browser.js
+++ b/lively.freezer/src/resolvers/browser.js
@@ -71,7 +71,7 @@ function spawn ({ command, cwd }) {
   return runCommand(command, { cwd });
 }
 
-async function fetchFile(url) {
+async function fetchFile (url) {
   while (true) {
     let attempts = 0;
     const maxAttempts = 3;
@@ -90,7 +90,7 @@ async function fetchFile(url) {
 }
 
 async function load (url) {
-  if (url === '@empty') return '';
+  if (url === '@empty.js') return '';
   return await fetchFile(url);
 }
 

--- a/lively.freezer/src/util/runtime.js
+++ b/lively.freezer/src/util/runtime.js
@@ -150,7 +150,10 @@ export function runtimeDefinition () {
     options: {},
     // this is for lively.serializer2 locateClass()
     moduleEnv (id) {
-      const m = System.get(id, false) || System.fetchStandaloneFor(id) || System.get(id + 'index.js', false);
+      const m = System.get(id, false) ||
+            lively.FreezerRuntime.get(id) ||
+            lively.FreezerRuntime.fetchStandaloneFor(id) ||
+            System.get(id + 'index.js', false);
       return { recorder: m.recorder || m.exports };
     }
   };

--- a/lively.freezer/src/util/runtime.js
+++ b/lively.freezer/src/util/runtime.js
@@ -171,7 +171,7 @@ export function runtimeDefinition () {
     registry,
     globalModules,
     get (moduleId, recorder = true) {
-      if (moduleId && moduleId.startsWith('@')) return this.globalModules[moduleId];
+      if (moduleId?.startsWith('@')) return this.globalModules[moduleId];
       let mod = this.registry[moduleId];
       return recorder ? mod && mod.recorder : mod;
     },


### PR DESCRIPTION
This fixes three things about the freezer bundles:
1.) makes copying via the serializer work again in bundles
2.) fixes incorrect normalization of project modules ids leading to incorrect recorder ids in the bundle
3.) changes name of the `@empty` module to `@empty.js` to simplify the serving of this file via servers that are enforce strict mimetypes in their served files (i.e. uberspace). 