### PR TITLE
❄️🎨: compile available fonts statically into bundle

### DIFF
--- a/lively.freezer/package.json
+++ b/lively.freezer/package.json
@@ -14,6 +14,7 @@
     "google-closure-compiler-osx": "^20200927.0.0",
     "wasm-brotli": "1.0.2",
     "rollup": "2.68.0",
+    "css": "3.0.0",
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-json": "6.0.0",
     "rollup-plugin-polyfill-node": "0.9.0"

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -890,6 +890,7 @@ export default class LivelyRollup {
     });
 
     if (this.autoRun) {
+      depsCode += `lively.FreezerRuntime.availableFonts = ${JSON.stringify(await this.resolver.availableFonts(bundledProjectFontCSS))}`;
       plugin.emitFile({
         type: 'asset',
         fileName: 'deps.js',

--- a/lively.freezer/src/resolvers/browser.js
+++ b/lively.freezer/src/resolvers/browser.js
@@ -5,6 +5,7 @@ import { runCommand } from 'lively.ide/shell/shell-interface.js';
 import { resource } from 'lively.resources';
 import commonjs from '@rollup/plugin-commonjs';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
+import { availableFonts } from 'lively.morphic/rendering/fonts.js';
 
 function resolveModuleId (moduleName, importer) {
   // in the client, we just discard the importer. This works out almost all the time.
@@ -109,6 +110,7 @@ function supportingPlugins () {
 const builtinModules = [];
 
 const BrowserResolver = {
+  availableFonts,
   resolveModuleId,
   isBrowserResolver: true,
   normalizeFileName,

--- a/lively.morphic/rendering/fonts.js
+++ b/lively.morphic/rendering/fonts.js
@@ -154,6 +154,7 @@ export const DEFAULT_FONTS = [
 ];
 
 export function availableFonts () {
+  if (typeof lively !== 'undefined' && lively.FreezerRuntime?.availableFonts) return lively.FreezerRuntime.availableFonts;
   if (typeof $world === 'undefined' || !$world.openedProject) return DEFAULT_FONTS;
   return $world.openedProject.projectFonts.concat(DEFAULT_FONTS);
 }


### PR DESCRIPTION
Fixes the issue that within bundles `availableFonts()` would not return the correct result, since there is not project loaded inside the bundle. The solution is to statically compile the available fonts into the bundle.