### PR TITLE
Disable navigate back gesture in browser on swipe input

### DIFF
--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -411,6 +411,8 @@ export class TopBarModel extends ViewModel {
           }
           if (!changeMode) return;
           config.ide.studio.canvasModeEnabled = !config.ide.studio.canvasModeEnabled;
+          if (config.ide.studio.canvasModeEnabled) document.body.style['overscroll-behavior-x'] = 'none';
+          else document.body.style['overscroll-behavior-x'] = 'auto';
           $world.resetScaleFactor();
           !config.ide.studio.canvasModeEnabled ? this.toggleMiniMap(false) : this.toggleMiniMap();
         }

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -404,6 +404,7 @@ export class LivelyWorld extends World {
     this.opacity = 0;
     this.onWindowResize();
     // some meta stuff...
+    if (config.ide.studio.canvasModeEnabled) { document.body.style['overscroll-behavior-x'] = 'none'; }
     if (lively.modules) lively.modules.removeHook('fetch', window.__logFetch);
     this.animate({ opacity: 1, blur: 3, duration: 1000, easing: easings.inOutExpo }).then(async () => {
       let li;


### PR DESCRIPTION
When scrolling the world to the right via a touch input (trackpad on a laptop) this can trigger the back navigation gesture on some devices (at least mac OS). We not disable this feature by patching the document body inline style when the canvas mode is enabled on world load.