### PR TITLE
Add support for `RegExp` to `FileWatcher`

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1563,18 +1563,14 @@ class FileWatcher {
   registerFileAction (fileResourceOrRegex, cB) {
     if (fileResourceOrRegex.isResource) {
       const file = fileResourceOrRegex;
-      if (this.fileActions[file]) {
-        if (Array.isArray(this.fileActions[file])) this.fileActions[file].push(cB);
-        else this.fileActions[file] = [this.fileActions[file], cB];
-      } else { this.fileActions[file] = cB; }
+      if (this.fileActions[file]) { this.fileActions[file].push(cB); } else this.fileActions[file] = [cB];
       return;
     }
+
     const newRegex = String(fileResourceOrRegex);
     const alreadyRegisteredRegex = this.regexToWatch.find((item) => item.regex === newRegex);
-    if (alreadyRegisteredRegex) {
-      if (Array.isArray(alreadyRegisteredRegex.actions)) alreadyRegisteredRegex.actions.push(cB);
-      else alreadyRegisteredRegex.actions = [alreadyRegisteredRegex.actions, cB];
-    } else alreadyRegisteredRegex.actions = cB;
+    if (alreadyRegisteredRegex.actions) alreadyRegisteredRegex.actions.push(cB);
+    else alreadyRegisteredRegex.actions = [cB];
   }
 
   unregisterFileActions (fileResourceOrRegex) {

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1582,8 +1582,13 @@ class FileWatcher {
     const actions = this.filesToWatch[savedFileData.resource] || [];
 
     for (const [k, v] of Object.entries(this.regexToWatch)) {
-      const regex = new RegExp(k);
-      if (regex.test(savedFileData.url)) actions.push(v);
+      const regexAndFlags = regexString.match(/\/(.*?)\/([a-z]*)/);
+      if (regexAndFlags) { // should always be entered, given only correct regex are fed into the watcher
+        const pattern = parts[1];
+        const flags = parts[2]; // catch optional flags if present
+        const regex = new RegExp(pattern, flags);
+        if (regex.test(savedFileData.url)) actions.push(v);
+      }
     }
 
     if (!actions.length > 0) return;


### PR DESCRIPTION
This add the option to not only register a fileResource with a callback to the `FileWatcher` but, also a regex. Each time a file is saved, all actions that are registered for regexes that match the whole url of the file to be saved get executed.