### PR TITLE
🧰🎨: enable `reactsToPointer` on `Text` when interactively editing

### DIFF
--- a/lively.ide/text/rich-text-commands.js
+++ b/lively.ide/text/rich-text-commands.js
@@ -34,7 +34,9 @@ export const editingCommand = {
     // this makes sense even if target is not readonly
     // in the case we are in halo mode, this allows for editing which would be otherwise blocked by the halo
     t.prevReadOnly = t.readOnly;
+    t.prevReactsToPointer = t.reactsToPointer;
     t.tmpEdit = true;
+    t.reactsToPointer = true;
     t.readOnly = false;
     t.focus();
     setTimeout(() => {

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -1097,6 +1097,7 @@ export class Text extends Morph {
     spec.textString = this.textString;
     if (this.tmpEdit) {
       spec.readOnly = this.prevReadOnly;
+      spec.reactsToPointer = this.prevReactsToPointer;
       if (skipIfUnchangedFromDefault && spec.readOnly === true) {
         delete spec.readOnly;
       }
@@ -4092,6 +4093,7 @@ export class Text extends Morph {
     this.tmpEdit = false;
     topBar.setEditMode(topBar.recoverMode, true);
     this.readOnly = this.prevReadOnly;
+    this.reactsToPointer = this.prevReactsToPointer;
     this.collapseSelection();
 
     topBar.showHaloFor(this);


### PR DESCRIPTION
Closes #1052.