### PR TITLE
🧰: fix invalid code in `FileWatcher`

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1582,10 +1582,10 @@ class FileWatcher {
     const actions = this.filesToWatch[savedFileData.resource] || [];
 
     for (const [k, v] of Object.entries(this.regexToWatch)) {
-      const regexAndFlags = regexString.match(/\/(.*?)\/([a-z]*)/);
+      const regexAndFlags = k.match(/\/(.*?)\/([a-z]*)/);
       if (regexAndFlags) { // should always be entered, given only correct regex are fed into the watcher
-        const pattern = parts[1];
-        const flags = parts[2]; // catch optional flags if present
+        const pattern = regexAndFlags[1];
+        const flags = regexAndFlags[2]; // catch optional flags if present
         const regex = new RegExp(pattern, flags);
         if (regex.test(savedFileData.url)) actions.push(v);
       }


### PR DESCRIPTION
We let obviously erroneous code slide through the PR in #1044.