### PR TITLE
🧰: fix incorrect signal input when setting `currentBackend`

### DIFF
--- a/lively.ide/js/eval-backend-ui.js
+++ b/lively.ide/js/eval-backend-ui.js
@@ -29,7 +29,7 @@ export class EvalBackendButtonModel extends ButtonModel {
         get () { return this.evalbackendChooser.backendWithName(this.currentBackendName); },
         set (backend) {
           this.currentBackendName = backend ? backend.name : 'local';
-          if (this.view) signal(this.view, 'currentBackend', this.currentBackendName);
+          if (this.view) signal(this.view, 'currentBackend', backend);
         }
       },
 


### PR DESCRIPTION
This resulted in an inform morph being generated each time one opened the browser or the workspace, containing a message about the currently selected eval backend.