### PR TITLE
Add "Asset Browser"

### DIFF
--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -39,6 +39,12 @@ class ModeSelectorModel extends ViewModel {
       selectedItem: {},
       enabled: {
         defaultValue: true
+      },
+      selectedLabelMaster: {
+        defaultValue: ModeSelectorLabelSelected // eslint-disable-line no-use-before-define
+      },
+      unselectedLabelMaster: {
+        defaultValue: ModeSelectorLabel // eslint-disable-line no-use-before-define
       }
     };
   }
@@ -71,7 +77,7 @@ class ModeSelectorModel extends ViewModel {
 
   createLabels () {
     this.view.submorphs = this.items.map((item) => {
-      const label = part(ModeSelectorLabel, { // eslint-disable-line no-use-before-define
+      const label = part(this.selectedLabelMaster, { // eslint-disable-line no-use-before-define
         textString: item.text,
         name: item.name,
         tooltip: item.tooltip
@@ -93,22 +99,22 @@ class ModeSelectorModel extends ViewModel {
       this.ui.labels.forEach(l => {
         if (l.name !== itemName) {
           l.withAnimationDo(() => {
-            l.master = { auto: ModeSelectorLabel };// eslint-disable-line no-use-before-define
+            l.master = { auto: this.unselectedLabelMaster };// eslint-disable-line no-use-before-define
           }, { duration: 200 });
         }
       });
       const labelToSelect = this.ui.labels.find((label) => label.name === itemName);
       await labelToSelect.withAnimationDo(() => {
-        labelToSelect.master = { auto: ModeSelectorLabelSelected }; // eslint-disable-line no-use-before-define
+        labelToSelect.master = { auto: this.selectedLabelMaster }; // eslint-disable-line no-use-before-define
       }, { duration: 200 });
     } else {
       // Selected Item changed programmatically
       this.ui.labels.forEach(l => {
         if (l.name !== itemName) {
-          l.master = { auto: ModeSelectorLabel }; // eslint-disable-line no-use-before-define
+          l.master = { auto: this.unselectedLabelMaster }; // eslint-disable-line no-use-before-define
         }
       });
-      this.ui.labels.find((label) => label.name === itemName).master = { auto: ModeSelectorLabelSelected }; // eslint-disable-line no-use-before-define
+      this.ui.labels.find((label) => label.name === itemName).master = { auto: this.selectedLabelMaster }; // eslint-disable-line no-use-before-define
     }
 
     this.selectedItem = itemName;
@@ -128,9 +134,19 @@ const ModeSelectorLabel = component({
   textString: 'a mode selector label'
 });
 
+const ModeSelectorLabelDark = component(ModeSelectorLabel, {
+  fill: Color.transparent,
+  fontColor: Color.white
+});
+
 const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
   fill: Color.black.withA(0.4),
   fontColor: Color.white
+});
+
+const ModeSelectorLabelSelectedDark = component(ModeSelectorLabel, {
+  fill: Color.white.withA(0.8),
+  fontColor: Color.black
 });
 
 const ModeSelector = component({
@@ -152,4 +168,12 @@ const ModeSelector = component({
   ]
 });
 
-export { ModeSelector };
+const ModeSelectorDark = component(ModeSelector, {
+  viewModelClass: ModeSelectorModel,
+  viewModel: {
+    selectedLabelMaster: ModeSelectorLabelSelectedDark,
+    unselectedLabelMaster: ModeSelectorLabelDark
+  }
+});
+
+export { ModeSelector, ModeSelectorDark };

--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -3,7 +3,7 @@ import { connect, signal } from 'lively.bindings';
 import { Color } from 'lively.graphics';
 import { pt } from 'lively.graphics/geometry-2d.js';
 
-const ModeSelectorLabel = component({
+export const ModeSelectorLabel = component({
   type: Label,
   nativeCursor: 'pointer',
   name: 'mode selector label',
@@ -20,7 +20,7 @@ const ModeSelectorLabelDark = component(ModeSelectorLabel, {
   fontColor: Color.white
 });
 
-const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
+export const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
   fill: Color.black.withA(0.4),
   fontColor: Color.white
 });

--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -3,7 +3,7 @@ import { connect, signal } from 'lively.bindings';
 import { Color } from 'lively.graphics';
 import { pt } from 'lively.graphics/geometry-2d.js';
 
-export const ModeSelectorLabel = component({
+const ModeSelectorLabelUnselected = component({
   type: Label,
   nativeCursor: 'pointer',
   name: 'mode selector label',
@@ -15,19 +15,35 @@ export const ModeSelectorLabel = component({
   textString: 'a mode selector label'
 });
 
-const ModeSelectorLabelDark = component(ModeSelectorLabel, {
-  fill: Color.transparent,
-  fontColor: Color.white
-});
-
-export const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
+const ModeSelectorLabelSelected = component(ModeSelectorLabelUnselected, {
   fill: Color.black.withA(0.4),
   fontColor: Color.white
 });
 
-const ModeSelectorLabelSelectedDark = component(ModeSelectorLabel, {
+export const ModeSelectorLabel = component(ModeSelectorLabelUnselected, {
+  master: {
+    states: {
+      selected: ModeSelectorLabelSelected
+    }
+  }
+});
+
+const ModeSelectorLabelUnselectedDark = component(ModeSelectorLabelUnselected, {
+  fill: Color.transparent,
+  fontColor: Color.white
+});
+
+const ModeSelectorLabelSelectedDark = component(ModeSelectorLabelUnselected, {
   fill: Color.white.withA(0.8),
   fontColor: Color.black
+});
+
+export const ModeSelectorLabelDark = component(ModeSelectorLabelUnselectedDark, {
+  master: {
+    states: {
+      selected: ModeSelectorLabelSelectedDark
+    }
+  }
 });
 
 /**
@@ -67,11 +83,8 @@ class ModeSelectorModel extends ViewModel {
       enabled: {
         defaultValue: true
       },
-      selectedLabelMaster: {
-        defaultValue: ModeSelectorLabelSelected // eslint-disable-line no-use-before-define
-      },
-      unselectedLabelMaster: {
-        defaultValue: ModeSelectorLabel // eslint-disable-line no-use-before-define
+      labelMaster: {
+        defaultValue: ModeSelectorLabelDark
       }
     };
   }
@@ -104,7 +117,7 @@ class ModeSelectorModel extends ViewModel {
 
   createLabels () {
     this.view.submorphs = this.items.map((item) => {
-      const label = part(this.selectedLabelMaster, { // eslint-disable-line no-use-before-define
+      const label = part(this.labelMaster, {
         textString: item.text,
         name: item.name,
         tooltip: item.tooltip
@@ -126,22 +139,22 @@ class ModeSelectorModel extends ViewModel {
       this.ui.labels.forEach(l => {
         if (l.name !== itemName) {
           l.withAnimationDo(() => {
-            l.master = { auto: this.unselectedLabelMaster };// eslint-disable-line no-use-before-define
+            l.master.setState(null);
           }, { duration: 200 });
         }
       });
       const labelToSelect = this.ui.labels.find((label) => label.name === itemName);
       await labelToSelect.withAnimationDo(() => {
-        labelToSelect.master = { auto: this.selectedLabelMaster }; // eslint-disable-line no-use-before-define
+        labelToSelect.master.setState('selected');
       }, { duration: 200 });
     } else {
       // Selected Item changed programmatically
       this.ui.labels.forEach(l => {
         if (l.name !== itemName) {
-          l.master = { auto: this.unselectedLabelMaster }; // eslint-disable-line no-use-before-define
+          l.master.setState(null);
         }
       });
-      this.ui.labels.find((label) => label.name === itemName).master = { auto: this.selectedLabelMaster }; // eslint-disable-line no-use-before-define
+      this.ui.labels.find((label) => label.name === itemName).master.setState('selected');
     }
 
     this.selectedItem = itemName;
@@ -171,8 +184,7 @@ const ModeSelector = component({
 const ModeSelectorDark = component(ModeSelector, {
   viewModelClass: ModeSelectorModel,
   viewModel: {
-    selectedLabelMaster: ModeSelectorLabelSelectedDark,
-    unselectedLabelMaster: ModeSelectorLabelDark
+    labelMaster: ModeSelectorLabelDark
   }
 });
 

--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -3,6 +3,33 @@ import { connect, signal } from 'lively.bindings';
 import { Color } from 'lively.graphics';
 import { pt } from 'lively.graphics/geometry-2d.js';
 
+const ModeSelectorLabel = component({
+  type: Label,
+  nativeCursor: 'pointer',
+  name: 'mode selector label',
+  fontWeight: 'bold',
+  fill: Color.transparent,
+  fontColor: Color.black,
+  padding: 5,
+  borderRadius: 3,
+  textString: 'a mode selector label'
+});
+
+const ModeSelectorLabelDark = component(ModeSelectorLabel, {
+  fill: Color.transparent,
+  fontColor: Color.white
+});
+
+const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
+  fill: Color.black.withA(0.4),
+  fontColor: Color.white
+});
+
+const ModeSelectorLabelSelectedDark = component(ModeSelectorLabel, {
+  fill: Color.white.withA(0.8),
+  fontColor: Color.black
+});
+
 /**
  * Allows to switch between different items by clicking on them. The selected Item can also be changed by calling the exposed `select` function.
  * A change in the selected item is signalled with the `selectionChanged` signal providing the newly selected item.
@@ -121,33 +148,6 @@ class ModeSelectorModel extends ViewModel {
     if (withSignal) signal(this.view, 'selectionChanged', this.selectedItem);
   }
 }
-
-const ModeSelectorLabel = component({
-  type: Label,
-  nativeCursor: 'pointer',
-  name: 'mode selector label',
-  fontWeight: 'bold',
-  fill: Color.transparent,
-  fontColor: Color.black,
-  padding: 5,
-  borderRadius: 3,
-  textString: 'a mode selector label'
-});
-
-const ModeSelectorLabelDark = component(ModeSelectorLabel, {
-  fill: Color.transparent,
-  fontColor: Color.white
-});
-
-const ModeSelectorLabelSelected = component(ModeSelectorLabel, {
-  fill: Color.black.withA(0.4),
-  fontColor: Color.white
-});
-
-const ModeSelectorLabelSelectedDark = component(ModeSelectorLabel, {
-  fill: Color.white.withA(0.8),
-  fontColor: Color.black
-});
 
 const ModeSelector = component({
   defaultViewModel: ModeSelectorModel,

--- a/lively.ide/assets.js
+++ b/lively.ide/assets.js
@@ -1,1 +1,2 @@
 export const supportedImageFormats = new RegExp('gif|jpeg|jpg|png|webp|jxl');
+export const supportedImageFormatsForFilePickerAPI = ['.jpg', '.jpeg', '.gif', '.png', '.webp', '.jxl'];

--- a/lively.ide/assets.js
+++ b/lively.ide/assets.js
@@ -1,0 +1,1 @@
+export const supportedImageFormats = new RegExp('gif|jpeg|jpg|png|webp|jxl');

--- a/lively.ide/components/helpers.js
+++ b/lively.ide/components/helpers.js
@@ -128,6 +128,12 @@ export function getValueExpr (prop, value, depth = 0) {
     value = `num.toRadians(${num.toDegrees(value).toFixed(1)})`;
     bindings['lively.lang'] = ['num'];
   }
+  if (prop === 'imageUrl' && $world.openedProject && value.includes($world.openedProject.name)) {
+    value = value.replaceAll('"', '');
+    value = `projectAsset('${value.split('/').pop()}')`;
+    bindings['lively.project'] = ['projectAsset'];
+  }
+
   if (value && !value.isMorph && value.__serialize__) {
     return value.__serialize__();
   } else if (['borderColor', 'borderWidth', 'borderStyle', 'borderRadius'].includes(prop)) {

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -218,9 +218,20 @@ class AssetBrowserModel extends ViewModel {
   }
 
   confirm () {
-    this._promise.resolve(this.selectedAsset.imageUrl);
-    if ($world._assetBrowserPopup) signal($world._assetBrowserPopup, 'close');
-    this.container.remove();
+    // _promise is initialized inside of the popup, but not the window
+    if (this._promise) {
+      this._promise.resolve(this.selectedAsset.imageUrl);
+      this.container.remove();
+    } else {
+      const image = new Image({ imageUrl: this.selectedAsset.imageUrl });
+      image.determineNaturalExtent().then((extent) => {
+        const maxWidth = 500;
+        const maxHeight = 500;
+        const scaleFactor = Math.min(maxWidth / extent.x, maxHeight / extent.y);
+        image.extent = extent.scaleBy(scaleFactor);
+        image.openInWorld();
+      });
+    }
   }
 
   async initialize () {
@@ -376,8 +387,7 @@ class AssetBrowserModel extends ViewModel {
   }
 
   close () {
-    if (this._promise) this._promise.resolve(null);
-
+    this._promise?.resolve(null);
     this.view.remove();
   }
 }

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -28,7 +28,14 @@ class AssetPreviewModel extends ViewModel {
       assetBrowserAsPopup: {},
       expose: {
         get () {
-          return ['onMouseDown', 'assetName', 'isAssetPreview', 'onDragStart'];
+          return ['assetName', 'isAssetPreview', 'onDragStart'];
+        }
+      },
+      bindings: {
+        get () {
+          return [
+            { signal: 'onMouseDown', handler: () => this.assetBrowser.selectAssetEntry(this), override: true }
+          ];
         }
       }
     };
@@ -60,10 +67,6 @@ class AssetPreviewModel extends ViewModel {
 
   get isAssetPreview () {
     return true;
-  }
-
-  onMouseDown () {
-    this.assetBrowser.selectAssetEntry(this);
   }
 
   async viewDidLoad () {

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -601,10 +601,10 @@ export const AssetBrowserDark = component({
       extent: pt(440, 33.9000),
       fill: Color.transparent,
       layout: new TilingLayout({
-        align: 'right',
+        align: 'center',
         axisAlign: 'center',
         justifySubmorphs: 'spaced',
-        padding: rect(10, 10, 0, 0),
+        padding: rect(0, 10, 0, 0),
         spacing: 15
       }),
       submorphs: [

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -13,7 +13,7 @@ import { resource } from 'lively.resources';
 import { FileStatusWarning } from '../js/browser/ui.cp.js';
 import { promise } from 'lively.lang';
 import { once, signal } from 'lively.bindings';
-import { ModeSelectorDark, ModeSelectorLabel, ModeSelectorLabelSelected, ModeSelector } from 'lively.components/widgets/mode-selector.cp.js';
+import { ModeSelector, ModeSelectorLabelDark, ModeSelectorLabel } from 'lively.components/widgets/mode-selector.cp.js';
 import { InputLineDefault } from 'lively.components/inputs.cp.js';
 import { Spinner } from './shared.cp.js';
 
@@ -511,7 +511,7 @@ export const AssetBrowserDark = component({
         axisAlign: 'center'
       }),
       fill: Color.rgba(255, 255, 255, 0),
-      submorphs: [part(ModeSelectorDark, {
+      submorphs: [part(ModeSelector, {
         name: 'asset type selector',
         nativeCursor: 'not-allowed',
         tooltip: 'Currently, only Images are supported.',
@@ -520,6 +520,7 @@ export const AssetBrowserDark = component({
           spacing: 30
         }),
         viewModel: {
+          labelMaster: ModeSelectorLabelDark,
           items: [
             { text: 'Images', name: 'images', tooltip: 'Image' },
             { text: 'Video', name: 'video', tooltip: 'Video Assets' },
@@ -733,7 +734,7 @@ export const AssetBrowserDark = component({
           lineWrapping: true
         },
         part(DarkButton, {
-          name: 'proceed button ',
+          name: 'proceed button',
           extent: pt(80, 20),
           opacity: 0.8,
           submorphs: [{
@@ -743,7 +744,7 @@ export const AssetBrowserDark = component({
           }]
         }),
         part(DarkButton, {
-          name: 'cancel button ',
+          name: 'cancel button',
           opacity: .8,
           extent: pt(79.9, 19.7),
           submorphs: [{
@@ -762,12 +763,15 @@ export const AssetBrowserLight = component(AssetBrowserDark, {
   },
   submorphs: [
     {
-      name: 'asset type selector',
-      master: ModeSelector,
-      viewModel: {
-        selectedLabelMaster: ModeSelectorLabelSelected,
-        unselectedLabelMaster: ModeSelectorLabel
-      }
+      name: 'asset type selector wrapper',
+      submorphs: [
+        {
+          name: 'asset type selector',
+          viewModel: {
+            labelMaster: ModeSelectorLabel
+          }
+        }
+      ]
     },
     {
       name: 'assets',
@@ -789,7 +793,6 @@ export const AssetBrowserLight = component(AssetBrowserDark, {
               }, ' Upload', {
                 fontFamily: 'IBM Plex Sans'
               }]
-
             }]
           },
           {

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -478,12 +478,13 @@ export const AssetBrowserDark = component({
   name: 'asset browser',
   defaultViewModel: AssetBrowserModel,
   extent: pt(440.0000, 324),
+  reactsToPointer: false,
   layout: new TilingLayout({
     axis: 'column',
     axisAlign: 'center',
     hugContentsHorizontally: true,
     padding: rect(10, 10, 0, 0),
-    resizePolicies: [['asset type selector', {
+    resizePolicies: [['asset type selector wrapper', {
       height: 'fixed',
       width: 'fill'
     }], ['search input wrapper', {
@@ -500,22 +501,30 @@ export const AssetBrowserDark = component({
   }),
   fill: Color.rgba(255, 255, 255, 0),
   submorphs: [
-    part(ModeSelectorDark, {
-      name: 'asset type selector',
-      nativeCursor: 'not-allowed',
-      tooltip: 'Currently, only Images are supported.',
+    {
+      name: 'asset type selector wrapper',
       layout: new TilingLayout({
         align: 'center',
-        spacing: 30
+        axisAlign: 'center'
       }),
-      viewModel: {
-        items: [
-          { text: 'Images', name: 'images', tooltip: 'Image' },
-          { text: 'Video', name: 'video', tooltip: 'Video Assets' },
-          { text: 'Audio', name: 'audio', tooltip: 'Audio Assets' }
-        ]
-      }
-    }), {
+      fill: Color.rgba(255, 255, 255, 0),
+      submorphs: [part(ModeSelectorDark, {
+        name: 'asset type selector',
+        nativeCursor: 'not-allowed',
+        tooltip: 'Currently, only Images are supported.',
+        layout: new TilingLayout({
+          align: 'center',
+          spacing: 30
+        }),
+        viewModel: {
+          items: [
+            { text: 'Images', name: 'images', tooltip: 'Image' },
+            { text: 'Video', name: 'video', tooltip: 'Video Assets' },
+            { text: 'Audio', name: 'audio', tooltip: 'Audio Assets' }
+          ]
+        }
+      })]
+    }, {
       name: 'search input wrapper',
       extent: pt(440.0000, 42.6000),
       layout: new TilingLayout({

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -16,6 +16,7 @@ import { once, signal } from 'lively.bindings';
 import { ModeSelector, ModeSelectorLabelDark, ModeSelectorLabel } from 'lively.components/widgets/mode-selector.cp.js';
 import { InputLineDefault } from 'lively.components/inputs.cp.js';
 import { Spinner } from './shared.cp.js';
+import { supportedImageFormatsForFilePickerAPI } from '../assets.js';
 
 class AssetPreviewModel extends ViewModel {
   static get properties () {
@@ -73,8 +74,8 @@ class AssetPreviewModel extends ViewModel {
     const img = this.ui.previewHolder;
     img.imageUrl = this.imageUrl;
     const naturalExtent = await img.determineNaturalExtent();
-    const maxWidth = 105;
-    const maxHeight = 45;
+    const maxWidth = img.owner.width - 15;
+    const maxHeight = img.owner.height - 35;
     const scaleFactor = Math.min(maxWidth / naturalExtent.x, maxHeight / naturalExtent.y);
     img.extent = naturalExtent.scaleBy(scaleFactor);
     img.opacity = 1;
@@ -295,7 +296,7 @@ class AssetBrowserModel extends ViewModel {
         {
           description: 'asset files',
           accept: {
-            'image/*': ['.jpg', '.jpeg', '.gif', '.png', '.webp', '.jxl']
+            'image/*': supportedImageFormatsForFilePickerAPI
           }
         }
       ],

--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -23,9 +23,9 @@ class AssetPreviewModel extends ViewModel {
       imageUrl: {},
       assetName: {},
       fullFileName: {},
-      assetManager: {},
+      assetBrowser: {},
       allowDragging: {},
-      assetManagerAsPopup: {},
+      assetBrowserAsPopup: {},
       expose: {
         get () {
           return ['onMouseDown', 'assetName', 'isAssetPreview', 'onDragStart'];
@@ -63,7 +63,7 @@ class AssetPreviewModel extends ViewModel {
   }
 
   onMouseDown () {
-    this.assetManager.selectAssetEntry(this);
+    this.assetBrowser.selectAssetEntry(this);
   }
 
   async viewDidLoad () {
@@ -149,7 +149,7 @@ const AssetPreview = component(AssetPreviewUnselected, {
   }
 });
 
-class AssetManagerModel extends ViewModel {
+class AssetBrowserModel extends ViewModel {
   static get properties () {
     return {
       container: {},
@@ -159,7 +159,7 @@ class AssetManagerModel extends ViewModel {
     };
   }
 
-  get assetManagerAsPopup () {
+  get assetBrowserAsPopup () {
     return !this.view.ownerChain().some(m => m.isWindow);
   }
 
@@ -219,6 +219,7 @@ class AssetManagerModel extends ViewModel {
 
   confirm () {
     this._promise.resolve(this.selectedAsset.imageUrl);
+    if ($world._assetBrowserPopup) signal($world._assetBrowserPopup, 'close');
     this.container.remove();
   }
 
@@ -243,7 +244,6 @@ class AssetManagerModel extends ViewModel {
     $world.addMorph(fader);
     const li = $world.showLoadingIndicatorFor(this.container, 'Changing Assets in Properties Panel...');
     once($world._assetBrowserPopup, 'close', () => {
-      debugger;
       fader.remove();
       li.remove();
       this.updateAtRuntime = true;
@@ -270,7 +270,7 @@ class AssetManagerModel extends ViewModel {
     if (this.selectedAsset) this.selectedAsset.view.master.setState(this.view.getWindow() ? 'unselectedLight' : null);
     this.selectedAsset = assetEntryModel;
     this.ui.deleteButton.visible = true;
-    assetEntryModel.view.master.setState(this.assetManagerAsPopup ? 'selectedDark' : 'selectedLight');
+    assetEntryModel.view.master.setState(this.assetBrowserAsPopup ? 'selectedDark' : 'selectedLight');
     this.ui.selectionButton.enable();
   }
 
@@ -361,7 +361,7 @@ class AssetManagerModel extends ViewModel {
             assetName,
             fullFileName: a.name(),
             imageUrl: a.url,
-            assetManager: this,
+            assetBrowser: this,
             allowDragging: this.allowDraggingAssets
           }
         });
@@ -464,9 +464,9 @@ const NoAssetsIndicator = component({
   }]
 });
 
-export const AssetManagerDark = component({
-  name: 'asset manager',
-  defaultViewModel: AssetManagerModel,
+export const AssetBrowserDark = component({
+  name: 'asset browser',
+  defaultViewModel: AssetBrowserModel,
   extent: pt(440.0000, 324),
   layout: new TilingLayout({
     axis: 'column',
@@ -734,7 +734,7 @@ export const AssetManagerDark = component({
   ]
 });
 
-export const AssetManagerLight = component(AssetManagerDark, {
+export const AssetBrowserLight = component(AssetBrowserDark, {
   viewModel: {
     allowDraggingAssets: true
   },
@@ -818,7 +818,7 @@ export const AssetManagerLight = component(AssetManagerDark, {
   ]
 });
 
-class AssetManagerPopupModel extends ViewModel {
+class AssetBrowserPopupModel extends ViewModel {
   static get properties () {
     return {
       isPrompt: { get () { return true; } },
@@ -843,12 +843,12 @@ class AssetManagerPopupModel extends ViewModel {
   }
 
   viewDidLoad () {
-    this.ui.assetManager.container = this.view;
+    this.ui.assetBrowser.container = this.view;
   }
 
   close () {
     signal($world._assetBrowserPopup, 'close');
-    this.ui.assetManager?.close();
+    this.ui.assetBrowser?.close();
     this.view.remove();
     $world._assetBrowserPopup = null;
   }
@@ -860,12 +860,12 @@ class AssetManagerPopupModel extends ViewModel {
     if (!pos) view.center = $world.visibleBounds().center();
     else view.position = pos;
 
-    return this.ui.assetManager.activate();
+    return this.ui.assetBrowser.activate();
   }
 }
-export const AssetManagerPopup = component(DarkPopupWindow, {
+export const AssetBrowserPopup = component(DarkPopupWindow, {
   styleClasses: [],
-  defaultViewModel: AssetManagerPopupModel,
+  defaultViewModel: AssetBrowserPopupModel,
   extent: pt(450, 365),
   hasFixedPosition: false,
   layout: new TilingLayout({
@@ -892,8 +892,8 @@ export const AssetManagerPopup = component(DarkPopupWindow, {
         reactsToPointer: false,
         textAndAttributes: ['Browse Assets', null]
       }]
-    }, add(part(AssetManagerDark, {
-      name: 'asset manager',
+    }, add(part(AssetBrowserDark, {
+      name: 'asset browser',
       extent: pt(440, 324)
     }))]
 });

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -241,7 +241,7 @@ class AssetManagerModel extends ViewModel {
   async deleteAsset () {
     const assetToDelete = resource($world.openedProject.url).join('assets/' + this.selectedAsset.fullFileName);
     await assetToDelete.remove();
-
+    this.ui.selectionButton.disable();
     this.selectedAsset.view.remove();
     this.ui.deleteButton.visible = false;
     this.selectedAsset = null;

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -34,9 +34,15 @@ class AssetPreviewModel extends ViewModel {
     };
   }
 
-  onDragStart () {
+  async onDragStart () {
     if (!this.allowDragging) return;
     const imageForGrab = new Image({ imageUrl: this.imageUrl });
+    const naturalExtent = await imageForGrab.determineNaturalExtent();
+    const maxWidth = 500;
+    const maxHeight = 500;
+    const scaleFactor = Math.min(maxWidth / naturalExtent.x, maxHeight / naturalExtent.y);
+    imageForGrab.extent = naturalExtent.scaleBy(scaleFactor);
+    imageForGrab.scale = 0;
     $world.firstHand.grab(imageForGrab);
     imageForGrab.onBeingDroppedOn = (hand, recipient) => {
       if (recipient !== $world) imageForGrab.remove();
@@ -46,7 +52,7 @@ class AssetPreviewModel extends ViewModel {
       }
     };
     imageForGrab.animate({
-      extent: pt(200, 100),
+      scale: 1,
       duration: 300,
       easing: easings.outSine
     });
@@ -60,8 +66,16 @@ class AssetPreviewModel extends ViewModel {
     this.assetManager.selectAssetEntry(this);
   }
 
-  viewDidLoad () {
-    this.ui.previewHolder.imageUrl = this.imageUrl;
+  async viewDidLoad () {
+    const img = this.ui.previewHolder;
+    img.imageUrl = this.imageUrl;
+    const naturalExtent = await img.determineNaturalExtent();
+    const maxWidth = 105;
+    const maxHeight = 45;
+    const scaleFactor = Math.min(maxWidth / naturalExtent.x, maxHeight / naturalExtent.y);
+    img.extent = naturalExtent.scaleBy(scaleFactor);
+    img.opacity = 1;
+
     this.ui.componentName.value = this.assetName;
     this.view.nativeCursor = this.allowDragging ? 'pointer' : 'auto';
   }

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -524,7 +524,7 @@ export const AssetManagerDark = component({
     },
     {
       name: 'assets',
-      extent: pt(440, 280),
+      extent: pt(420, 165),
       fill: Color.transparent,
       clipMode: 'auto',
       layout: new TilingLayout({
@@ -694,6 +694,7 @@ export const AssetManagerLight = component(AssetManagerDark, {
   viewModel: {
     allowDraggingAssets: true
   },
+  extent: pt(440.0000, 291),
   submorphs: [
     {
       name: 'asset type selector',

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -492,6 +492,8 @@ export const AssetManagerDark = component({
   submorphs: [
     part(ModeSelectorDark, {
       name: 'asset type selector',
+      nativeCursor: 'not-allowed',
+      tooltip: 'Currently, only Images are supported.',
       layout: new TilingLayout({
         align: 'center',
         spacing: 30

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -148,7 +148,8 @@ class AssetManagerModel extends ViewModel {
   get bindings () {
     return [
       { target: 'upload button', signal: 'onMouseDown', handler: 'openFilePicker' },
-      { target: 'delete button', signal: 'onMouseDown', handler: 'deleteAsset' },
+      // See https://github.com/LivelyKernel/lively.next/issues/1057
+      { target: 'delete button', signal: 'onMouseUp', handler: 'deleteAsset' },
       { target: 'selection button', signal: 'onMouseDown', handler: 'confirm' },
       { target: 'search input', signal: 'inputChanged', handler: 'filterAssets' },
       {

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -303,6 +303,12 @@ class AssetManagerModel extends ViewModel {
       li = $world.showLoadingIndicatorFor(this.container, 'Enumerating project assets');
     }
     const assets = $world.openedProject ? await $world.openedProject.getAssets('image') : await $world.getAssets('image');
+    if (!assets) {
+      this.ui.noAssetsIndicator.visible = true;
+      return;
+    }
+    this.ui.noAssetsIndicator.visible = false;
+
     assets.forEach(a => {
       const assetName = a.nameWithoutExt();
       if (!this.view.get(assetName)) {
@@ -368,6 +374,48 @@ const NoResultIndicator = component({
     fontWeight: '600',
     position: pt(106.0000, 66.0000),
     textAndAttributes: ['No matching assets...', null]
+  }]
+});
+
+const NoAssetsIndicator = component({
+  name: 'no assets indicator',
+  fill: Color.rgba(255, 255, 255, 0),
+  borderColor: Color.rgba(23, 160, 251, 0),
+  borderWidth: 1,
+  extent: pt(316.0000, 164.0000),
+  position: pt(-104.0000, 21.0000),
+  submorphs: [{
+    type: Text,
+    name: 'icon',
+    borderColor: Color.rgba(23, 160, 251, 0),
+    borderWidth: 1,
+    cursorWidth: 1.5,
+    dynamicCursorColoring: true,
+    extent: pt(80.0000, 64.5000),
+    fill: Color.rgba(255, 255, 255, 0),
+    fixedHeight: true,
+    fixedWidth: true,
+    fontColor: Color.rgba(126, 126, 126, 0.75),
+    fontSize: 73,
+    lineWrapping: 'by-words',
+    padding: rect(1, 1, 0, 0),
+    position: pt(67.0000, 22.5000),
+    textAndAttributes: ['懶', {
+      fontFamily: 'Tabler Icons',
+      fontWeight: '900'
+    }, '  ', {}]
+
+  }, {
+    type: Text,
+    name: 'text',
+    dynamicCursorColoring: true,
+    fill: Color.rgba(255, 255, 255, 0),
+    fontColor: Color.rgba(126, 126, 126, 0.75),
+    fontSize: 20,
+    fontWeight: '600',
+    position: pt(152.0000, 61.5000),
+    textAndAttributes: ['No assets...', null]
+
   }]
 });
 
@@ -485,6 +533,10 @@ export const AssetManagerDark = component({
       submorphs: [part(NoResultIndicator, {
         visible: false,
         name: 'no results indicator'
+      }),
+      part(NoAssetsIndicator, {
+        visible: false,
+        name: 'no assets indicator'
       })]
     }, {
       name: 'button wrapper',

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -102,7 +102,7 @@ class AssetManagerModel extends ViewModel {
   }
 
   get expose () {
-    return ['activate', 'container', 'close'];
+    return ['activate', 'container', 'close', 'initialize'];
   }
 
   get bindings () {
@@ -159,7 +159,7 @@ class AssetManagerModel extends ViewModel {
     this.container.remove();
   }
 
-  async activate () {
+  async initialize () {
     this.ui.assetTypeSelector.enabled = false;
     this.view.visible = false;
     const li = $world.showLoadingIndicatorFor(null, 'Enumerating project assets...');
@@ -167,6 +167,10 @@ class AssetManagerModel extends ViewModel {
     this.ui.selectionButton.disable();
     this.view.visible = true;
     li.remove();
+  }
+
+  async activate () {
+    await this.initialize();
     this._promise = promise.deferred();
     return this._promise.promise;
   }
@@ -259,7 +263,8 @@ class AssetManagerModel extends ViewModel {
       $world.addMorph(fader);
       li = $world.showLoadingIndicatorFor(this.container, 'Enumerating project assets');
     }
-    (await $world.openedProject.getAssets('image')).forEach(a => {
+    const assets = $world.openedProject ? await $world.openedProject.getAssets('image') : await $world.getAssets('image');
+    assets.forEach(a => {
       const assetName = a.nameWithoutExt();
       if (!this.view.get(assetName)) {
         this.view.get('assets').addMorph(part(AssetPreview, {

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -90,19 +90,26 @@ const AssetPreviewUnselected = component(ComponentPreviewDark, {
       }
       ]
     }, {
-      name: 'component name',
-      textAndAttributes: ['hello', null]
+      name: 'component name', textAndAttributes: ['hello', null]
     }
   ]
 });
 
-const AssetPreviewSelectedLight = component(AssetPreviewUnselected, {
-  borderColor: Color.rgb(69, 151, 230),
-  borderWidth: 2,
-  fill: Color.rgba(69, 151, 230, 0.6),
+const AssetPreviewUnselectedLight = component(AssetPreviewUnselected, {
   submorphs: [{
     name: 'component name',
-    fontColor: Color.rgb(255, 255, 255)
+    fontColor: Color.rgb(102, 102, 102)
+  }
+  ]
+});
+
+const AssetPreviewSelectedLight = component(AssetPreviewUnselected, {
+  borderColor: Color.rgb(33, 150, 243),
+  borderWidth: 2,
+  fill: Color.rgba(3, 169, 244, 0.75),
+  submorphs: [{
+    name: 'component name',
+    fontColor: Color.white
   }
   ]
 });
@@ -122,6 +129,7 @@ const AssetPreview = component(AssetPreviewUnselected, {
   master: {
     states: {
       selectedDark: AssetPreviewSelected,
+      unselectedLight: AssetPreviewUnselectedLight,
       selectedLight: AssetPreviewSelectedLight
     }
   }
@@ -226,7 +234,7 @@ class AssetManagerModel extends ViewModel {
   }
 
   selectAssetEntry (assetEntryModel) {
-    if (this.selectedAsset) this.selectedAsset.view.master.setState(null);
+    if (this.selectedAsset) this.selectedAsset.view.master.setState(this.view.getWindow() ? 'unselectedLight' : null);
     this.selectedAsset = assetEntryModel;
     this.ui.deleteButton.visible = true;
     assetEntryModel.view.master.setState(this.assetManagerAsPopup ? 'selectedDark' : 'selectedLight');
@@ -314,7 +322,7 @@ class AssetManagerModel extends ViewModel {
     assets.forEach(a => {
       const assetName = a.nameWithoutExt();
       if (!this.view.getSubmorphNamed(assetName)) {
-        this.view.getSubmorphNamed('assets').addMorph(part(AssetPreview, {
+        const addedPreviewMorph = part(AssetPreview, {
           name: assetName,
           viewModel: {
             assetName,
@@ -323,7 +331,9 @@ class AssetManagerModel extends ViewModel {
             assetManager: this,
             allowDragging: this.allowDraggingAssets
           }
-        }));
+        });
+        if (true) addedPreviewMorph.master.setState('unselectedLight');
+        this.view.getSubmorphNamed('assets').addMorph(addedPreviewMorph);
       }
     });
     if (updateAtRuntime) {
@@ -424,8 +434,7 @@ const NoAssetsIndicator = component({
 export const AssetManagerDark = component({
   name: 'asset manager',
   defaultViewModel: AssetManagerModel,
-  extent: pt(440.0000, 390.0000),
-  width: 440,
+  extent: pt(440.0000, 324),
   layout: new TilingLayout({
     axis: 'column',
     axisAlign: 'center',
@@ -443,7 +452,8 @@ export const AssetManagerDark = component({
     }], ['button wrapper', {
       height: 'fixed',
       width: 'fill'
-    }]]
+    }]],
+    spacing: 10
   }),
   fill: Color.rgba(255, 255, 255, 0),
   submorphs: [
@@ -451,7 +461,6 @@ export const AssetManagerDark = component({
       name: 'asset type selector',
       layout: new TilingLayout({
         align: 'center',
-        axisAlign: 'center',
         spacing: 30
       }),
       viewModel: {
@@ -463,6 +472,7 @@ export const AssetManagerDark = component({
       }
     }), {
       name: 'search input wrapper',
+      extent: pt(440.0000, 42.6000),
       layout: new TilingLayout({
         axisAlign: 'center',
         padding: rect(8, 0, -8, 0),
@@ -529,6 +539,7 @@ export const AssetManagerDark = component({
       clipMode: 'auto',
       layout: new TilingLayout({
         align: 'center',
+        padding: rect(5, 5, 0, 0),
         spacing: 5,
         wrapSubmorphs: true
       }),
@@ -576,9 +587,9 @@ export const AssetManagerDark = component({
                 name: 'label',
                 type: Label,
                 fill: Color.transparent,
-                fontColor: Color.rgb(255, 255, 255),
+                fontColor: Color.white,
                 textAndAttributes: ['', {
-                  fontColor: Color.rgb(178, 235, 242),
+                  fontColor: Color.white,
                   fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
                   fontWeight: '900',
                   lineHeight: 1
@@ -604,9 +615,8 @@ export const AssetManagerDark = component({
                 name: 'label',
                 type: Label,
                 fill: Color.transparent,
-                fontColor: Color.rgb(255, 255, 255),
+                fontColor: Color.white,
                 textAndAttributes: ['', {
-                  fontColor: Color.rgb(178, 235, 242),
                   fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
                   fontWeight: '900',
                   lineHeight: 1
@@ -628,9 +638,9 @@ export const AssetManagerDark = component({
             name: 'label',
             type: Label,
             fill: Color.transparent,
-            fontColor: Color.rgb(255, 255, 255),
+            fontColor: Color.white,
             textAndAttributes: ['', {
-              fontColor: Color.rgb(178, 235, 242),
+              fontColor: Color.rgb(74, 214, 87),
               fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
               fontWeight: '900',
               lineHeight: 1
@@ -682,7 +692,6 @@ export const AssetManagerDark = component({
           submorphs: [{
             name: 'label',
             textAndAttributes: ['Cancel', null]
-
           }]
         })
       ]
@@ -694,14 +703,9 @@ export const AssetManagerLight = component(AssetManagerDark, {
   viewModel: {
     allowDraggingAssets: true
   },
-  extent: pt(440.0000, 291),
   submorphs: [
     {
       name: 'asset type selector',
-      layout: new TilingLayout({
-        align: 'center',
-        spacing: 30
-      }),
       master: ModeSelector,
       viewModel: {
         selectedLabelMaster: ModeSelectorLabelSelected,
@@ -709,6 +713,9 @@ export const AssetManagerLight = component(AssetManagerDark, {
       }
     },
     {
+      name: 'assets',
+      fill: Color.rgb(238, 238, 238)
+    }, {
       name: 'button wrapper',
       submorphs: [
         {
@@ -719,7 +726,6 @@ export const AssetManagerLight = component(AssetManagerDark, {
             submorphs: [{
               name: 'label',
               textAndAttributes: ['', {
-                fontColor: Color.rgb(69, 151, 230),
                 fontFamily: 'Font Awesome',
                 fontWeight: '900',
                 lineHeight: 1
@@ -735,7 +741,6 @@ export const AssetManagerLight = component(AssetManagerDark, {
             submorphs: [{
               name: 'label',
               textAndAttributes: ['', {
-                fontColor: Color.rgb(55, 151, 236),
                 fontFamily: 'Font Awesome',
                 fontWeight: '900',
                 lineHeight: 1
@@ -752,7 +757,7 @@ export const AssetManagerLight = component(AssetManagerDark, {
           submorphs: [{
             name: 'label',
             textAndAttributes: ['', {
-              fontColor: Color.rgb(55, 151, 236),
+              fontColor: Color.rgb(74, 174, 79),
               fontFamily: 'Font Awesome',
               fontWeight: '900',
               lineHeight: 1
@@ -761,7 +766,6 @@ export const AssetManagerLight = component(AssetManagerDark, {
             }]
           }]
         }]
-
     },
     {
       name: 'status prompt',
@@ -775,12 +779,6 @@ export const AssetManagerLight = component(AssetManagerDark, {
           master: SystemButton
         }
       ]
-    }, {
-      name: 'search input wrapper',
-      extent: pt(440.0000, 42.6000)
-    }, {
-      name: 'search input wrapper',
-      extent: pt(440.0000, 42.6000)
     }
   ]
 });
@@ -831,13 +829,11 @@ class AssetManagerPopupModel extends ViewModel {
 export const AssetManagerPopup = component(DarkPopupWindow, {
   styleClasses: [],
   defaultViewModel: AssetManagerPopupModel,
+  extent: pt(450, 365),
   hasFixedPosition: false,
-  extent: pt(440, 140),
   layout: new TilingLayout({
     axis: 'column',
     axisAlign: 'center',
-    hugContentsHorizontally: true,
-    hugContentsVertically: true,
     resizePolicies: [['header menu', {
       height: 'fixed',
       width: 'fill'
@@ -861,16 +857,6 @@ export const AssetManagerPopup = component(DarkPopupWindow, {
       }]
     }, add(part(AssetManagerDark, {
       name: 'asset manager',
-      extent: pt(10.0000, 476.0000),
-      layout: new TilingLayout({
-        axis: 'column',
-        axisAlign: 'center',
-        hugContentsHorizontally: true,
-        hugContentsVertically: true,
-        resizePolicies: [['search input wrapper', {
-          height: 'fixed',
-          width: 'fill'
-        }]]
-      })
+      extent: pt(440, 324)
     }))]
 });

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -1,0 +1,419 @@
+/* global FormData */
+import { component, Text, Label, Image, part, add, TilingLayout, ViewModel } from 'lively.morphic';
+
+import { pt, Color } from 'lively.graphics';
+import { DarkPopupWindow } from './shared.cp.js';
+import { rect } from 'lively.graphics/geometry-2d.js';
+import { without } from 'lively.morphic/components/core.js';
+import { ComponentPreviewDark } from './component-browser.cp.js';
+import { LinearGradient } from 'lively.graphics/color.js';
+
+import { ButtonDarkDefault, DarkButton } from 'lively.components/buttons.cp.js';
+import { resource } from 'lively.resources';
+import { FileStatusWarning } from '../js/browser/ui.cp.js';
+import { promise } from 'lively.lang';
+import { once } from 'lively.bindings';
+import { ModeSelector } from 'lively.components/widgets/mode-selector.cp.js';
+
+class AssetPreviewModel extends ViewModel {
+  static get properties () {
+    return {
+      imageUrl: {},
+      assetName: {},
+      fullFileName: {},
+      assetManager: {},
+      expose: {
+        get () {
+          return ['onMouseDown'];
+        }
+      }
+    };
+  }
+
+  onMouseDown () {
+    this.assetManager.selectAssetEntry(this);
+  }
+
+  viewDidLoad () {
+    this.ui.previewHolder.imageUrl = this.imageUrl;
+    this.ui.componentName.value = this.assetName;
+  }
+}
+
+const AssetPreviewUnselected = component(ComponentPreviewDark, {
+  name: 'asset preview',
+  defaultViewModel: AssetPreviewModel,
+  submorphs: [
+    {
+      name: 'preview container',
+      submorphs: [{
+        name: 'preview holder',
+        type: Image
+      }
+      ]
+    }, {
+      name: 'component name',
+      textAndAttributes: ['hello', null]
+    }
+  ]
+});
+
+const AssetPreviewSelected = component(AssetPreviewUnselected, {
+  borderColor: Color.rgb(52, 138, 117),
+  borderWidth: 2,
+  fill: Color.rgba(100, 255, 218, 0.6),
+  submorphs: [{
+    name: 'component name',
+    fontColor: Color.rgb(255, 255, 255)
+  }
+  ]
+});
+
+const AssetPreview = component(AssetPreviewUnselected, {
+  master: {
+    states: {
+      selected: AssetPreviewSelected
+    }
+  }
+});
+
+class AssetManagerPopupModel extends ViewModel {
+  get bindings () {
+    return [
+      {
+        target: 'close button',
+        signal: 'onMouseUp',
+        handler: 'close'
+      },
+      { target: 'upload button', signal: 'onMouseDown', handler: 'openFilePicker' },
+      { target: 'delete button', signal: 'onMouseDown', handler: 'deleteAsset' },
+      { target: 'selection button', signal: 'onMouseDown', handler: 'confirm' }
+
+    ];
+  }
+
+  async deleteAsset () {
+    const assetToDelete = resource($world.openedProject.url).join('assets/' + this.selectedAsset.fullFileName);
+    await assetToDelete.remove();
+
+    this.selectedAsset.view.remove();
+    this.ui.deleteButton.visible = false;
+    this.selectedAsset = null;
+  }
+
+  selectAssetEntry (assetEntryModel) {
+    if (this.selectedAsset) this.selectedAsset.view.master.setState = null;
+    this.selectedAsset = assetEntryModel;
+    this.ui.deleteButton.visible = true;
+    assetEntryModel.view.master.setState('selected');
+    this.ui.selectionButton.enable();
+  }
+
+  async openFilePicker () {
+    const pickerOpts = {
+      multiple: true,
+      types: [
+        {
+          description: 'asset files',
+          accept: {
+            'image/*': ['.jpg', '.jpeg', '.gif', '.png', '.webp', '.jxl']
+          }
+        }
+      ],
+      excludeAcceptAllOption: true
+
+    };
+    const files = await window.showOpenFilePicker(pickerOpts);
+    for (let assetFile of files) {
+      let asset = await assetFile.getFile();
+      await this.uploadAsset(asset);
+    }
+
+    await this.listAssets();
+  }
+
+  async uploadAsset (file) {
+    let overwriteAsset = false;
+    const fd = new FormData();
+    fd.append('file', file, file.name);
+
+    let res;
+    res = resource(System.baseURL);
+    const uploadPath = $world.openedProject.url.replace(System.baseURL, '') + '/assets/';
+    const assetFile = resource(System.baseURL).join(uploadPath).join(file.name);
+    if (await assetFile.exists()) {
+      const { statusText, statusPrompt, cancelButton, proceedButton } = this.ui;
+      statusPrompt.visible = true;
+      statusText.textString = 'This asset file already exists, do you want to proceed and override?';
+      const p = promise.deferred();
+      once(cancelButton, 'onMouseDown', () => p.resolve(false));
+      once(proceedButton, 'onMouseDown', () => p.resolve(true));
+      if (!await p.promise) {
+        this.resetStatusText();
+        return;
+      }
+      overwriteAsset = true;
+      await assetFile.remove();
+      this.resetStatusText();
+    }
+    res = res.join(`/upload?uploadPath=${encodeURIComponent(uploadPath)}`);
+    await res.write(fd);
+
+    await this.listAssets(overwriteAsset);
+  }
+
+  resetStatusText () {
+    this.ui.statusPrompt.visible = false;
+  }
+
+  async viewDidLoad () {
+    await this.listAssets();
+    this.ui.selectionButton.disable();
+  }
+
+  async listAssets (forceUpdate) {
+    if (forceUpdate) this.view.get('assets').submorphs = [];
+    (await $world.openedProject.getAssets('image')).forEach(a => {
+      const assetName = a.nameWithoutExt();
+      if (!this.view.get(assetName)) {
+        this.view.get('assets').addMorph(part(AssetPreview, {
+          name: assetName,
+          viewModel: {
+            assetName,
+            fullFileName: a.name(),
+            imageUrl: a.url,
+            assetManager: this
+          }
+        }));
+      }
+    });
+  }
+
+  async activate (pos) {
+    // popup specific
+    const { view } = this;
+    view.doNotAcceptDropsForThisAndSubmorphs();
+    view.openInWorld();
+    view.clipMode = 'hidden';
+    if (!pos) view.center = $world.visibleBounds().center();
+    else view.position = pos;
+  }
+
+  close () {
+    this.view.remove();
+  }
+}
+
+export const AssetManagerPopup = component(DarkPopupWindow, {
+  defaultViewModel: AssetManagerPopupModel,
+  styleClasses: [],
+  hasFixedPosition: false,
+  extent: pt(515.0000, 41.0000),
+  layout: new TilingLayout({
+    axis: 'column',
+    axisAlign: 'center',
+    hugContentsHorizontally: true,
+    hugContentsVertically: true,
+    resizePolicies: [['header menu', {
+      height: 'fixed',
+      width: 'fill'
+    }], ['mode selector', {
+      height: 'fixed',
+      width: 'fill'
+    }], ['status prompt', {
+      height: 'fixed',
+      width: 'fill'
+    }]]
+  }),
+  submorphs: [
+    without('controls'),
+    {
+      name: 'header menu',
+      layout: new TilingLayout({
+        align: 'right',
+        axisAlign: 'center',
+        justifySubmorphs: 'spaced',
+        padding: rect(5, 0, 0, 0)
+      }),
+      submorphs: [{
+        name: 'title',
+        fontSize: 18,
+        reactsToPointer: false,
+        textAndAttributes: ['Browse Components', null]
+      }]
+    }, {
+      name: 'mode selector',
+      layout: new TilingLayout({
+        align: 'center',
+        axisAlign: 'center',
+        spacing: 5
+      })
+    }, add(part(ModeSelector, {
+      viewModel: {
+        items: [
+          { text: 'Images', name: 'images', tooltip: 'demo one' },
+          { text: 'Video', name: 'demo two', tooltip: 'demo two' },
+          { text: 'Audio', name: 'demo three', tooltip: 'demo three' }
+        ]
+      },
+      name: 'assets'
+    })),
+    add({
+      name: 'assets',
+      extent: pt(515.0000, 16.5000),
+      fill: Color.transparent,
+      layout: new TilingLayout({
+        hugContentsVertically: true,
+        resizePolicies: [['button wrapper', {
+          height: 'fixed',
+          width: 'fill'
+        }]],
+        spacing: 5
+      })
+    }), add({
+      name: 'button wrapper',
+      extent: pt(483.0000, 33.9000),
+      fill: Color.transparent,
+      layout: new TilingLayout({
+        align: 'center',
+        axisAlign: 'center',
+        justifySubmorphs: 'spaced',
+        spacing: 15
+      }),
+      submorphs: [
+        {
+          name: 'left buttons',
+          layout: new TilingLayout({
+            spacing: 5,
+            orderByIndex: true
+          }),
+          fill: Color.transparent,
+          submorphs: [
+            {
+              name: 'upload button',
+              borderColor: Color.rgb(112, 123, 124),
+              borderRadius: 5,
+              borderWidth: 1,
+              fill: new LinearGradient({ stops: [{ offset: 0, color: Color.rgb(149, 165, 166) }, { offset: 1, color: Color.rgb(127, 140, 141) }], vector: rect(0, 0, 0, 1) }),
+              layout: new TilingLayout({
+                align: 'center',
+                axisAlign: 'center'
+              }),
+              master: ButtonDarkDefault,
+              nativeCursor: 'pointer',
+              submorphs: [{
+                name: 'label',
+                type: Label,
+                fill: Color.transparent,
+                fontColor: Color.rgb(255, 255, 255),
+                textAndAttributes: ['', {
+                  fontColor: Color.rgb(178, 235, 242),
+                  fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
+                  fontWeight: '900',
+                  lineHeight: 1
+                }, ' Upload', {
+                  fontFamily: 'IBM Plex Sans'
+                }]
+              }]
+            },
+            {
+              name: 'delete button',
+              borderColor: Color.rgb(112, 123, 124),
+              borderRadius: 5,
+              borderWidth: 1,
+              visible: false,
+              fill: new LinearGradient({ stops: [{ offset: 0, color: Color.rgb(149, 165, 166) }, { offset: 1, color: Color.rgb(127, 140, 141) }], vector: rect(0, 0, 0, 1) }),
+              layout: new TilingLayout({
+                align: 'center',
+                axisAlign: 'center'
+              }),
+              master: ButtonDarkDefault,
+              nativeCursor: 'pointer',
+              submorphs: [{
+                name: 'label',
+                type: Label,
+                fill: Color.transparent,
+                fontColor: Color.rgb(255, 255, 255),
+                textAndAttributes: ['', {
+                  fontColor: Color.rgb(178, 235, 242),
+                  fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
+                  fontWeight: '900',
+                  lineHeight: 1
+                }, ' Delete', {
+                  fontFamily: 'IBM Plex Sans'
+                }]
+              }]
+            }
+          ]
+        }, {
+          name: 'selection button',
+          borderColor: Color.rgb(112, 123, 124),
+          borderRadius: 5,
+          borderWidth: 1,
+          fill: new LinearGradient({ stops: [{ offset: 0, color: Color.rgb(149, 165, 166) }, { offset: 1, color: Color.rgb(127, 140, 141) }], vector: rect(0, 0, 0, 1) }),
+          master: ButtonDarkDefault,
+          nativeCursor: 'pointer',
+          submorphs: [{
+            name: 'label',
+            type: Label,
+            fill: Color.transparent,
+            fontColor: Color.rgb(255, 255, 255),
+            textAndAttributes: ['', {
+              fontColor: Color.rgb(178, 235, 242),
+              fontFamily: '"Font Awesome 5 Free", "Font Awesome 5 Brands"',
+              fontWeight: '900',
+              lineHeight: 1
+            }, ' Use', {
+              fontFamily: 'IBM Plex Sans'
+            }]
+          }]
+        }]
+    }), add({
+      name: 'status prompt',
+      visible: false,
+      extent: pt(342.0000, 62.5000),
+      layout: new TilingLayout({
+        axisAlign: 'center',
+        hugContentsVertically: true,
+        justifySubmorphs: 'spaced',
+        padding: rect(5, 5, 0, 0),
+        spacing: 5,
+        wrapSubmorphs: true
+      }),
+      master: FileStatusWarning,
+      submorphs: [
+        {
+          type: Text,
+          name: 'status text',
+          padding: rect(5, 3, 0, 0),
+          fixedWidth: true,
+          fixedHeight: false,
+          textAndAttributes: ['I am a status text', null],
+          cursorWidth: 1.5,
+          dynamicCursorColoring: true,
+          extent: pt(195.3, 23),
+          lineWrapping: true
+        },
+        part(DarkButton, {
+          name: 'proceed button ',
+          extent: pt(80, 20),
+          opacity: 0.8,
+          submorphs: [{
+            name: 'label',
+            textAndAttributes: ['Proceed', null]
+
+          }]
+        }),
+        part(DarkButton, {
+          name: 'cancel button ',
+          opacity: .8,
+          extent: pt(79.9, 19.7),
+          submorphs: [{
+            name: 'label',
+            textAndAttributes: ['Cancel', null]
+
+          }]
+        })
+      ]
+    })]
+});

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -809,7 +809,7 @@ class AssetManagerPopupModel extends ViewModel {
   }
 
   get expose () {
-    return ['activate', 'isPrompt', 'isHaloItem', 'isEpiMorph'];
+    return ['activate', 'isPrompt', 'isHaloItem', 'isEpiMorph', 'close'];
   }
 
   get bindings () {
@@ -826,6 +826,7 @@ class AssetManagerPopupModel extends ViewModel {
   }
 
   close () {
+    $world._assetBrowserPopup = null;
     this.ui.assetManager.close();
     this.view.remove();
   }

--- a/lively.ide/studio/asset-manager.cp.js
+++ b/lively.ide/studio/asset-manager.cp.js
@@ -288,7 +288,8 @@ class AssetManagerModel extends ViewModel {
   }
 
   async listAssets (updateAtRuntime = false) {
-    if (this.needsListRefreshed) this.view.get('assets').submorphs = [];
+    const assetHolder = this.view.getSubmorphNamed('assets');
+    if (this.needsListRefreshed) assetHolder.submorphs = assetHolder.submorphs.filter(m => !m.isAssetPreview);
     this.needsListRefreshed = false;
     let fader, li;
     if (updateAtRuntime) {
@@ -311,8 +312,8 @@ class AssetManagerModel extends ViewModel {
 
     assets.forEach(a => {
       const assetName = a.nameWithoutExt();
-      if (!this.view.get(assetName)) {
-        this.view.get('assets').addMorph(part(AssetPreview, {
+      if (!this.view.getSubmorphNamed(assetName)) {
+        this.view.getSubmorphNamed('assets').addMorph(part(AssetPreview, {
           name: assetName,
           viewModel: {
             assetName,

--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -1880,6 +1880,8 @@ export {
   ComponentBrowserPopupDark,
   ComponentPreview,
   ComponentPreviewSelected,
+  ComponentPreviewDark,
+  ComponentPreviewSelectedDark,
   ProjectSection,
   ComponentError
 };

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -8,15 +8,10 @@ import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { obj } from 'lively.lang';
 import { noUpdate } from 'lively.bindings';
 
-const placeholderImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAfRJREFUaEPtmTFrFFEUhb+jIIKQgFZGi3QBU6SQCDaCXVJbqZCQpLW2E1OntRJCFEXxB2gdCxtFAxYh+QOJVYoU0c4THkxg3dmZnWXnTWbk3XLnzbvn3HPuXd4b0fFQx/GTCJy3gkmBVitg+wawAdwHrjcM9hewDTyVdFCUu9BCGfifwLWGgfenOwLmikiUEXgHPDpn8Gfp30t6PAhLGYEg21RLCBxKCnbORRkB966W1OjEsl0pfyIQy2JJgaoVSAoUVKBqAVMTJwslC41ZgWShMQuYptCoFrI9Kel42Hut/B+w/QBYB+5I+lNGonUEbM8A34AJYEvSWmsI2L4NXJQUAObC9hXgKzDb83BJ0tsiEo0pYPsq8AO4lFkjdwC3Peh4egLMS9orIB3/QGP7AvAJWMhAfAfu9frb9hPgRUGldzPSv/ufN6KA7dCQz/uSf5D0MPxm+y7wOVOnyC2vJK02TsD2IvARCCr0xzPgJbAD3Bw2MoFlSW9610VVwPZ05vvg/0HxF9gHblUAH5bk+iEaAduXgS9AmDx1xj/9EJPAJlA6w8dg9VrSStY/8afQGECHvhpNgaGZa1qQCFStQE0Fz21TNf9/fbnb+ev1cJ3d3Q8c2Szu7iemWM1Z976NfrSoG3zYLxGIUdVR9kwKjFKtGGtPAaQTYEDIYzesAAAAAElFTkSuQmCC';
-
 export class FillControlModel extends ViewModel {
   static get properties () {
     return {
       targetMorph: {},
-      placeholderImage: {
-        defaultValue: placeholderImage
-      },
       bindings: {
         get () {
           return [
@@ -60,7 +55,7 @@ export class FillControlModel extends ViewModel {
     this.ui.fillColorInput.setColor(fill);
     this.ui.imageControl.visible = isImage;
     if (isImage) {
-      this.ui.imageContainer.imageUrl = this.targetMorph.imageUrl || this.placeholderImage;
+      this.ui.imageContainer.imageUrl = this.targetMorph.imageUrl;
       // fixme: autofit the image preview
     }
   }
@@ -108,7 +103,6 @@ const FillControl = component(PropertySection, {
         name: 'image container',
         reactsToPointer: false,
         extent: pt(20, 20),
-        imageUrl: placeholderImage,
         naturalExtent: pt(48, 48),
         position: pt(1, 1)
       }]

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -67,7 +67,7 @@ export class FillControlModel extends ViewModel {
     const assetManager = part(AssetManagerPopup);
     $world._assetBrowserPopup = assetManager;
     once(assetManager, 'close', this, 'closeAssetManagerPopup');
-
+    if ($world._assetBrowser) $world._assetBrowser.block();
     const selectedImageUrl = await assetManager.activate();
     if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
   }

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -8,7 +8,7 @@ import { PropertySection } from './section.cp.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { obj } from 'lively.lang';
 import { noUpdate, once } from 'lively.bindings';
-import { AssetManagerPopup } from '../asset-manager.cp.js';
+import { AssetBrowserPopup } from '../asset-browser.cp.js';
 
 import { StatusMessageError } from 'lively.halos/components/messages.cp.js';
 import { LabeledCheckbox } from 'lively.components/checkbox.cp.js';
@@ -78,11 +78,11 @@ export class FillControlModel extends ViewModel {
         this.targetMorph.imageUrl = this.ui.sourceDescription.textString;
       });
     } else {
-      const assetManager = part(AssetManagerPopup);
-      $world._assetBrowserPopup = assetManager;
-      once(assetManager, 'close', this, 'closeAssetManagerPopup');
+      const assetBrowser = part(AssetBrowserPopup);
+      $world._assetBrowserPopup = assetBrowser;
+      once(assetBrowser, 'close', this, 'closeAssetBrowserPopup');
       if ($world._assetBrowser) $world._assetBrowser.block();
-      const selectedImageUrl = await assetManager.activate();
+      const selectedImageUrl = await assetBrowser.activate();
       if (selectedImageUrl) {
         this.targetMorph.withMetaDo({ reconcileChanges: true }, () => {
           this.targetMorph.imageUrl = selectedImageUrl;
@@ -92,7 +92,7 @@ export class FillControlModel extends ViewModel {
     this.update();
   }
 
-  closeAssetManagerPopup () {
+  closeAssetBrowserPopup () {
     if (!$world._assetBrowserPopup) return;
     $world._assetBrowserPopup.close();
     $world._assetBrowserPopup = null;
@@ -156,7 +156,7 @@ export class FillControlModel extends ViewModel {
   }
 
   deactivate () {
-    this.closeAssetManagerPopup();
+    this.closeAssetBrowserPopup();
     this.models.fillColorInput.closeColorPicker();
   }
 }

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -63,7 +63,7 @@ export class FillControlModel extends ViewModel {
 
   async openAssetManager () {
     const assetManager = part(AssetManagerPopup);
-    const selectedImageUrl = await assetManager.initialize();
+    const selectedImageUrl = await assetManager.activate();
     if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
   }
 

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -8,10 +8,12 @@ import { TextInput, AddButton } from '../shared.cp.js';
 import { PropertySection } from './section.cp.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { obj } from 'lively.lang';
-import { noUpdate } from 'lively.bindings';
+import { noUpdate, once } from 'lively.bindings';
 import { AssetManagerPopup } from '../asset-manager.cp.js';
-import { ModeSelectorDark } from 'lively.components/widgets/mode-selector.cp.js';
+
 import { StatusMessageError } from 'lively.halos/components/messages.cp.js';
+import { LabeledCheckbox } from 'lively.components/checkbox.cp.js';
+import { CheckboxUnchecked } from 'lively.components';
 
 export class FillControlModel extends ViewModel {
   static get properties () {
@@ -63,8 +65,17 @@ export class FillControlModel extends ViewModel {
 
   async openAssetManager () {
     const assetManager = part(AssetManagerPopup);
+    $world._assetBrowserPopup = assetManager;
+    once(assetManager, 'close', this, 'closeAssetManagerPopup');
+
     const selectedImageUrl = await assetManager.activate();
     if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
+  }
+
+  closeAssetManagerPopup () {
+    if (!$world._assetBrowserPopup) return;
+    $world._assetBrowserPopup.close();
+    $world._assetBrowserPopup = null;
   }
 
   focusOn (target) {
@@ -107,6 +118,7 @@ export class FillControlModel extends ViewModel {
   }
 
   deactivate () {
+    this.closeAssetManagerPopup();
     this.models.fillColorInput.closeColorPicker();
   }
 }

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -41,7 +41,9 @@ export class FillControlModel extends ViewModel {
       $world.setStatusMessage('Invalid URL', StatusMessageError);
       return;
     }
-    this.targetMorph.imageUrl = this.ui.sourceDescription.textString;
+    this.targetMorph.withMetaDo({ reconcileChanges: true }, () => {
+      this.targetMorph.imageUrl = this.ui.sourceDescription.textString;
+    });
   }
 
   showControlsForAssetType (type) {
@@ -69,7 +71,11 @@ export class FillControlModel extends ViewModel {
     once(assetManager, 'close', this, 'closeAssetManagerPopup');
     if ($world._assetBrowser) $world._assetBrowser.block();
     const selectedImageUrl = await assetManager.activate();
-    if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
+    if (selectedImageUrl) {
+      this.targetMorph.withMetaDo({ reconcileChanges: true }, () => {
+        this.targetMorph.imageUrl = selectedImageUrl;
+      });
+    }
   }
 
   closeAssetManagerPopup () {

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -1,12 +1,17 @@
+/* global URL */
+/* global URL */
 import { ViewModel, part, add, without, component } from 'lively.morphic';
 import { pt, rect, Color } from 'lively.graphics';
 import { ColorInput } from '../../styling/color-picker.cp.js';
 import { TilingLayout, Image } from 'lively.morphic';
-import { PropLabel } from '../shared.cp.js';
+import { TextInput, AddButton } from '../shared.cp.js';
 import { PropertySection } from './section.cp.js';
 import { DarkColorPicker } from '../dark-color-picker.cp.js';
 import { obj } from 'lively.lang';
 import { noUpdate } from 'lively.bindings';
+import { AssetManagerPopup } from '../asset-manager.cp.js';
+import { ModeSelectorDark } from 'lively.components/widgets/mode-selector.cp.js';
+import { StatusMessageError } from 'lively.halos/components/messages.cp.js';
 
 export class FillControlModel extends ViewModel {
   static get properties () {
@@ -17,19 +22,60 @@ export class FillControlModel extends ViewModel {
           return [
             { model: 'fill color input', signal: 'onPickerClosedWithClick', handler: 'ensureHalo' },
             { model: 'fill color input', signal: 'color', handler: 'confirm' },
-            { target: 'image cell', signal: 'onMouseDown', handler: 'changeImageUrl' },
-            { signal: 'onMouseDown', handler: 'onMouseDown' }
+            { target: 'open asset manager button', signal: 'onMouseDown', handler: 'openAssetManager' },
+            { target: 'confirm url', signal: 'onMouseDown', handler: 'changeRemoteURL' },
+            { signal: 'onMouseDown', handler: 'onMouseDown' },
+            { target: 'asset type selector', signal: 'selectionChanged', handler: 'showControlsForAssetType' }
           ];
         }
       }
     };
   }
 
-  onMouseDown () { this.deactivate(); }
+  changeRemoteURL () {
+    try {
+      new URL(this.ui.sourceDescription.textString);
+    } catch (e) {
+      $world.setStatusMessage('Invalid URL', StatusMessageError);
+      return;
+    }
+    this.targetMorph.imageUrl = this.ui.sourceDescription.textString;
+  }
+
+  showControlsForAssetType (type) {
+    if (type === 'local') {
+      this.ui.sourceDescription.readOnly = true;
+      this.ui.sourceDescription.selectable = false;
+      this.ui.confirmUrl.visible = this.ui.confirmUrl.isLayoutable = false;
+      this.ui.openAssetManagerButton.visible = this.ui.openAssetManagerButton.isLayoutable = true;
+    }
+    if (type === 'remote') {
+      this.ui.sourceDescription.readOnly = false;
+      this.ui.sourceDescription.selectable = true;
+      this.ui.confirmUrl.visible = this.ui.confirmUrl.isLayoutable = true;
+      this.ui.openAssetManagerButton.visible = this.ui.openAssetManagerButton.isLayoutable = false;
+    }
+  }
+
+  onMouseDown () {
+    this.deactivate();
+  }
+
+  async openAssetManager () {
+    const assetManager = part(AssetManagerPopup);
+    const selectedImageUrl = await assetManager.activate();
+    if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
+  }
 
   focusOn (target) {
     this.targetMorph = target;
     this.ui.imageControl.visible = !!target.isImage;
+    if (target.isImage) {
+      const imageUrl = target.imageUrl;
+      if (imageUrl.includes('local_projects')) this.ui.sourceDescription.textString = 'Project Asset';
+      else if (imageUrl.includes('http')) this.ui.sourceDescription.textString = target.imageUrl;
+      else this.ui.sourceDescription.textString = 'Other Image';
+    }
     this.models.fillColorInput.targetMorph = target;
   }
 
@@ -88,25 +134,74 @@ const FillControl = component(PropertySection, {
     extent: pt(235.1, 25),
     fill: Color.rgba(255, 255, 255, 0),
     layout: new TilingLayout({
+      axis: 'column',
       axisAlign: 'center',
+      justifySubmorphs: 'spaced',
       padding: rect(20, 1, -10, 1)
     }),
     height: 25,
-    submorphs: [{
-      name: 'image cell',
-      nativeCursor: 'pointer',
-      fill: Color.transparent,
-      clipMode: 'hidden',
-      extent: pt(22, 22),
-      submorphs: [{
-        type: Image,
-        name: 'image container',
-        reactsToPointer: false,
-        extent: pt(20, 20),
-        naturalExtent: pt(48, 48),
-        position: pt(1, 1)
+    submorphs: [
+      part(ModeSelectorDark, {
+        name: 'asset type selector',
+        viewModel: {
+          items: [
+            { text: 'Local Asset', name: 'local', tooltip: 'Use a local asset from within this project or add a new one.' },
+            { text: 'Remote URL', name: 'remote', tooltip: 'Enter an Asset URL to use a remote asset.' }]
+        }
+      }
+      ), {
+        name: 'bottom wrapper',
+        clipMode: 'hidden',
+        extent: pt(235.0000, 30.0000),
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          padding: rect(15, 10, 15, 0),
+          spacing: 5
+        }),
+        fill: Color.transparent,
+        submorphs: [
+          {
+            name: 'image cell',
+            fill: Color.transparent,
+            clipMode: 'hidden',
+            extent: pt(22.0000, 22.0000),
+            submorphs: [{
+              type: Image,
+              name: 'image container',
+              reactsToPointer: false,
+              extent: pt(20, 20),
+              naturalExtent: pt(48, 48),
+              position: pt(1, 1)
+            }]
+          },
+          part(TextInput, {
+            name: 'source description',
+            width: 130,
+            placeholder: null,
+            textAndAttributes: ['ddf', null]
+          }), part(AddButton, {
+            name: 'open asset manager button',
+            tooltip: 'Add an asset to this project',
+            textAndAttributes: ['', {
+              fontFamily: 'Tabler Icons',
+              fontSize: 18,
+              fontWeight: '900'
+            }]
+          }),
+          part(AddButton, {
+            name: 'confirm url',
+            visible: false,
+            isLayoutable: false,
+            tooltip: 'Load remote asset URL.',
+            textAndAttributes: ['', {
+              fontFamily: 'Tabler Icons',
+              fontSize: 18,
+              fontWeight: '900'
+            }]
+          })
+        ]
       }]
-    }, part(PropLabel, { name: 'image marker', textString: 'Image' })]
   })]
 });
 

--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -63,7 +63,7 @@ export class FillControlModel extends ViewModel {
 
   async openAssetManager () {
     const assetManager = part(AssetManagerPopup);
-    const selectedImageUrl = await assetManager.activate();
+    const selectedImageUrl = await assetManager.initialize();
     if (selectedImageUrl) this.targetMorph.imageUrl = selectedImageUrl;
   }
 

--- a/lively.ide/studio/controls/text.cp.js
+++ b/lively.ide/studio/controls/text.cp.js
@@ -372,8 +372,8 @@ const RichTextControl = component(PropertySection, {
     }, {
       name: 'add button',
       tooltip: 'Install a custom font',
-      textAndAttributes: ['', {
-        fontFamily: 'Material Icons',
+      textAndAttributes: ['', {
+        fontFamily: 'Tabler Icons',
         fontSize: 18,
         fontWeight: '900'
       }]

--- a/lively.ide/studio/properties-panel.cp.js
+++ b/lively.ide/studio/properties-panel.cp.js
@@ -194,6 +194,10 @@ export class PropertiesPanelModel extends ViewModel {
     this.models.borderControl.targetMorph = null;
     this.models.borderControl.deactivate();
     this.models.textControl.deactivate();
+
+    this.models.componentControl.closePopup();
+    this.models.componentStatesControl.closePopup();
+
     this.models.responsiveControl.clearHalo();
   }
 

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -20,6 +20,7 @@ import { notYetImplemented } from 'lively.lang/function.js';
 import { defaultDirectory } from '../shell/shell-interface.js';
 import { ProjectSettingsPrompt, RepoCreationPrompt } from 'lively.project/prompts.cp.js';
 import { isUserLoggedIn } from 'lively.user';
+import { AssetManagerLight } from './asset-manager.cp.js';
 
 class SelectionElement extends Morph {
   static get properties () {
@@ -219,6 +220,10 @@ export class TopBarModel extends ViewModel {
 
     if (evt.targetMorph.name === 'text mode button') {
       this.setEditMode('Text');
+    }
+
+    if (evt.targetMorph.name === 'open asset browser') {
+      this.browseAssets();
     }
 
     if (evt.targetMorph.name === 'open component browser') {
@@ -450,6 +455,22 @@ export class TopBarModel extends ViewModel {
       const miniMap = part(WorldMiniMap).openInWorld();
       miniMap.relayout();
       $world.getSubmorphNamed('world zoom indicator').relayout();
+    }
+  }
+
+  async browseAssets () {
+    if (!this._assetBrowser) {
+      this.colorTopbarButton(this.ui.openAssetBrowser, true);
+      const assetBrowser = part(AssetManagerLight);
+      await assetBrowser.initialize();
+      const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
+      assetBrowser.container = win;
+      this._assetBrowser = win;
+      once(win, 'close', () => this.colorTopbarButton(this.ui.openAssetBrowser, false));
+    } else {
+      this._assetBrowser.close();
+      this._assetBrowser = null;
+      this.colorTopbarButton(this.ui.openAssetBrowser, false);
     }
   }
 
@@ -983,6 +1004,11 @@ const TopBar = component({
             }
           }
         }
+      }),
+      part(TopBarButton, {
+        name: 'open asset browser',
+        textAndAttributes: Icon.textAttribute('heart-music-camera-bolt'),
+        tooltip: 'Browse Project Assets'
       }),
       part(TopBarButton, {
         name: 'open component browser',

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -454,6 +454,7 @@ export class TopBarModel extends ViewModel {
   }
 
   async interactivelyLoadComponent () {
+    if ($world._loadingComponentBrowser) return;
     let currComponentBrowser = this.world()._componentBrowser;
     if (currComponentBrowser && !!currComponentBrowser.world()) {
       return currComponentBrowser.getWindow().close(false);

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -459,17 +459,23 @@ export class TopBarModel extends ViewModel {
   }
 
   async browseAssets () {
-    if (!this._assetBrowser) {
+    if ($world._loadingAssetBrowser) return;
+    if (!$world._assetBrowser) {
+      $world._loadingAssetBrowser = true;
       this.colorTopbarButton(this.ui.openAssetBrowser, true);
       const assetBrowser = part(AssetManagerLight);
       await assetBrowser.initialize();
       const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
+      delete $world._loadingAssetBrowser;
       assetBrowser.container = win;
-      this._assetBrowser = win;
-      once(win, 'close', () => this.colorTopbarButton(this.ui.openAssetBrowser, false));
+      $world._assetBrowser = assetBrowser;
+      once(win, 'close', () => {
+        this.colorTopbarButton(this.ui.openAssetBrowser, false);
+        $world._assetBrowser = null;
+      });
     } else {
-      this._assetBrowser.close();
-      this._assetBrowser = null;
+      $world._assetBrowser.getWindow().close();
+      $world._assetBrowser = null;
       this.colorTopbarButton(this.ui.openAssetBrowser, false);
     }
   }

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -462,7 +462,7 @@ export class TopBarModel extends ViewModel {
     fun.guardNamed('loadingAssetBrowser', async () => {
       if (!$world._assetBrowser) {
         this.colorTopbarButton(this.ui.openAssetBrowser, true);
-        const assetBrowser = part(AssetBrowserLight);
+        const assetBrowser = part(AssetBrowserLight, { extent: pt(520, 600) });
         await assetBrowser.initialize();
         const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
         assetBrowser.container = win;

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -20,7 +20,7 @@ import { notYetImplemented } from 'lively.lang/function.js';
 import { defaultDirectory } from '../shell/shell-interface.js';
 import { ProjectSettingsPrompt, RepoCreationPrompt } from 'lively.project/prompts.cp.js';
 import { isUserLoggedIn } from 'lively.user';
-import { AssetManagerLight } from './asset-manager.cp.js';
+import { AssetBrowserLight } from './asset-browser.cp.js';
 
 class SelectionElement extends Morph {
   static get properties () {
@@ -463,7 +463,7 @@ export class TopBarModel extends ViewModel {
     if (!$world._assetBrowser) {
       $world._loadingAssetBrowser = true;
       this.colorTopbarButton(this.ui.openAssetBrowser, true);
-      const assetBrowser = part(AssetManagerLight);
+      const assetBrowser = part(AssetBrowserLight);
       await assetBrowser.initialize();
       const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
       delete $world._loadingAssetBrowser;

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -6,7 +6,7 @@ import {
   component, ViewModel, part
 } from 'lively.morphic';
 import { Canvas } from 'lively.components/canvas.js';
-import { Closure, obj } from 'lively.lang';
+import { Closure, fun, obj } from 'lively.lang';
 
 import { CommentBrowser } from 'lively.collab';
 import { once, connect, disconnect, signal } from 'lively.bindings';
@@ -459,25 +459,24 @@ export class TopBarModel extends ViewModel {
   }
 
   async browseAssets () {
-    if ($world._loadingAssetBrowser) return;
-    if (!$world._assetBrowser) {
-      $world._loadingAssetBrowser = true;
-      this.colorTopbarButton(this.ui.openAssetBrowser, true);
-      const assetBrowser = part(AssetBrowserLight);
-      await assetBrowser.initialize();
-      const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
-      delete $world._loadingAssetBrowser;
-      assetBrowser.container = win;
-      $world._assetBrowser = assetBrowser;
-      once(win, 'close', () => {
-        this.colorTopbarButton(this.ui.openAssetBrowser, false);
+    fun.guardNamed('loadingAssetBrowser', async () => {
+      if (!$world._assetBrowser) {
+        this.colorTopbarButton(this.ui.openAssetBrowser, true);
+        const assetBrowser = part(AssetBrowserLight);
+        await assetBrowser.initialize();
+        const win = assetBrowser.openInWindow({ title: 'Asset Browser' });
+        assetBrowser.container = win;
+        $world._assetBrowser = assetBrowser;
+        once(win, 'close', () => {
+          this.colorTopbarButton(this.ui.openAssetBrowser, false);
+          $world._assetBrowser = null;
+        });
+      } else {
+        $world._assetBrowser.getWindow().close();
         $world._assetBrowser = null;
-      });
-    } else {
-      $world._assetBrowser.getWindow().close();
-      $world._assetBrowser = null;
-      this.colorTopbarButton(this.ui.openAssetBrowser, false);
-    }
+        this.colorTopbarButton(this.ui.openAssetBrowser, false);
+      }
+    })();
   }
 
   async interactivelyLoadComponent () {

--- a/lively.ide/text/rich-text-editor-plugin.js
+++ b/lively.ide/text/rich-text-editor-plugin.js
@@ -42,7 +42,7 @@ export class RichTextPlugin extends EditorPlugin {
       name: 'insert icon button',
       tooltip: 'Insert Icon',
       fontSize: 14,
-      textAndAttributes: Icon.textAttribute('heart-music-camera-bolt')
+      textAndAttributes: Icon.textAttribute('ti-icons')
     });
     const iconButtonHolder = new Morph({
       fill: Color.rgb(30, 30, 30).withA(0.95),

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -1,6 +1,6 @@
 /* global System */
 import { Rectangle, rect, Color, pt } from 'lively.graphics';
-import { tree, date, arr, string, obj } from 'lively.lang';
+import { tree, fun, date, arr, string, obj } from 'lively.lang';
 import { inspect, morph, Text, config, part } from 'lively.morphic';
 import KeyHandler from 'lively.morphic/events/KeyHandler.js';
 import { interactivelySaveWorld } from 'lively.morphic/world-loading.js';
@@ -856,17 +856,17 @@ const commands = [
   {
     name: 'browse and load component',
     exec: async function (world) {
-      $world._loadingComponentBrowser = true;
-      const li = LoadingIndicator.open('loading component browser');
-      const p = $world.openedProject;
-      if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('partsbin', 'LivelyKernel', true);
-      const { ComponentBrowser } = await System.import('lively.ide/studio/component-browser.cp.js');
-      const componentBrowser = world._componentBrowser || (world._componentBrowser = part(ComponentBrowser, { name: 'lively component browser' }));
-      li.remove();
-      componentBrowser.openInWindow({ minimizable: false, title: 'Browse Components' });
-      delete $world._loadingComponentBrowser;
-      const loadedComponent = await componentBrowser.activate();
-      if (loadedComponent && !loadedComponent.world()) { loadedComponent.openInWorld(); }
+      fun.guardNamed('loadingComponentBrowser', async () => {
+        const li = LoadingIndicator.open('loading component browser');
+        const p = $world.openedProject;
+        if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('partsbin', 'LivelyKernel', true);
+        const { ComponentBrowser } = await System.import('lively.ide/studio/component-browser.cp.js');
+        const componentBrowser = world._componentBrowser || (world._componentBrowser = part(ComponentBrowser, { name: 'lively component browser' }));
+        li.remove();
+        componentBrowser.openInWindow({ minimizable: false, title: 'Browse Components' });
+        const loadedComponent = await componentBrowser.activate();
+        if (loadedComponent && !loadedComponent.world()) { loadedComponent.openInWorld(); }
+      })();
     }
   },
 

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -856,6 +856,7 @@ const commands = [
   {
     name: 'browse and load component',
     exec: async function (world) {
+      $world._loadingComponentBrowser = true;
       const li = LoadingIndicator.open('loading component browser');
       const p = $world.openedProject;
       if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('partsbin', 'LivelyKernel', true);
@@ -863,6 +864,7 @@ const commands = [
       const componentBrowser = world._componentBrowser || (world._componentBrowser = part(ComponentBrowser, { name: 'lively component browser' }));
       li.remove();
       componentBrowser.openInWindow({ minimizable: false, title: 'Browse Components' });
+      delete $world._loadingComponentBrowser;
       const loadedComponent = await componentBrowser.activate();
       if (loadedComponent && !loadedComponent.world()) { loadedComponent.openInWorld(); }
     }

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -44,6 +44,7 @@ import { localInterface } from 'lively-system-interface';
 import { ProjectCreationPrompt } from 'lively.project/prompts.cp.js';
 import { currentUsername, isUserLoggedIn, currentUser } from 'lively.user';
 import { subscribe } from 'lively.notifications/index.js';
+import { supportedImageFormats } from './assets.js';
 
 export class LivelyWorld extends World {
   static get properties () {
@@ -706,6 +707,15 @@ export class LivelyWorld extends World {
         }
       } else if (item.kind === 'string') {
         item.getAsString((s) => inspect(s));
+      }
+    }
+  }
+
+  async getAssets (type = 'image') {
+    switch (type) {
+      case 'image': {
+        const assetFolderResource = isUserLoggedIn() ? resource(System.baseURL + `/user/${currentUsername()}/uploads`) : await resource(System.baseURL + 'uploads');
+        return (await assetFolderResource.dirList()).filter(a => a.name().match(supportedImageFormats)).sort((a, b) => ('' + a).localeCompare(b));
       }
     }
   }

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -712,9 +712,12 @@ export class LivelyWorld extends World {
   }
 
   async getAssets (type = 'image') {
+    const assetFolderResource = isUserLoggedIn() ? resource(System.baseURL + `/user/${currentUsername()}/uploads`) : await resource(System.baseURL + 'uploads');
+    if (!(await assetFolderResource.exists()) || (await assetFolderResource.dirList()).length === 0) {
+      return false;
+    }
     switch (type) {
       case 'image': {
-        const assetFolderResource = isUserLoggedIn() ? resource(System.baseURL + `/user/${currentUsername()}/uploads`) : await resource(System.baseURL + 'uploads');
         return (await assetFolderResource.dirList()).filter(a => a.name().match(supportedImageFormats)).sort((a, b) => ('' + a).localeCompare(b));
       }
     }

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -387,6 +387,10 @@ export class StylePolicy {
     this.targetMorph?.requestMasterStyling();
   }
 
+  getState () {
+    return this._componentState;
+  }
+
   /**
    * Checks wether or not another policy is in the derivation chain of this
    * policy.

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1,4 +1,5 @@
 /* global System,Uint8Array,Blob */
+/* eslint-disable no-console, no-unused-vars */
 import { Color, Line, Point, pt, rect, Rectangle, Transform } from 'lively.graphics';
 import { string, obj, arr, num, promise, tree, Path as PropertyPath } from 'lively.lang';
 import { signal } from 'lively.bindings';
@@ -3549,14 +3550,14 @@ export class Path extends Morph {
     }
 
     return pathNode
-      ? findClosestPointOnPath(pathNode, fromPoint, nSamples, iterations)
+      ? findClosestPointOnPath(pathNode, fromPoint, nSamples, iterations) // eslint-disable-line no-use-before-define
       : { length: 0, point: fromPoint };
 
     function findClosestPointOnPath (
       pathNode, pos, nSamples = 10, iterations = 3,
       fromLength = 0, toLength = pathNode.getTotalLength(), iteration = 0
     ) {
-      const samples = samplePathPoints(pathNode, toLength, fromLength, nSamples);
+      const samples = samplePathPoints(pathNode, toLength, fromLength, nSamples); // eslint-disable-line no-use-before-define
       let minDist = Infinity; let minIndex = -1;
       for (const [point, _, i] of samples) {
         const dist = pos.dist(point);

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -22,6 +22,7 @@ import { pt } from 'lively.graphics';
 import { arr, obj } from 'lively.lang';
 import { addOrChangeCSSDeclaration } from 'lively.morphic';
 import { generateFontFaceString } from 'lively.morphic/rendering/fonts.js';
+import { supportedImageFormats } from 'lively.ide/assets.js';
 
 const repositoryOwnerAndNameRegex = /\.com\/(.+)\/(.*)/;
 const fontCSSWarningString = `/*\nDO NOT CHANGE THE CONTENTS OF THIS FILE!
@@ -494,7 +495,7 @@ export class Project {
     if (triggerOnPush) {
       definition = definition.replace('%ACTION_TRIGGER%', '\n  push:\n    branches:\n      - main');
     } else definition = definition.replace('%ACTION_TRIGGER%', '');
-    if (livelyConf.repositoryIsPrivate && livelyConf.canUsePages) definition = definition.replace('%TOKEN_PERMISSIONS%', '\n  contents: read')
+    if (livelyConf.repositoryIsPrivate && livelyConf.canUsePages) definition = definition.replace('%TOKEN_PERMISSIONS%', '\n  contents: read');
     else definition = definition.replace('%TOKEN_PERMISSIONS%', '');
     return definition.replaceAll('%PROJECT_NAME%', `${this.repoOwner}--${this.name}`);
   }
@@ -787,7 +788,7 @@ export class Project {
   async getAssets (type) {
     switch (type) {
       case 'image':
-        return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(/gif|jpeg|jpg|png|webp|jxl/)).sort((a, b) => ('' + a).localeCompare(b));
+        return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(supportedImageFormats)).sort((a, b) => ('' + a).localeCompare(b));
     }
   }
 }

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -786,6 +786,9 @@ export class Project {
    * @param {string} type - One of 'video', 'audio', 'image'
    */
   async getAssets (type) {
+    if (!(await resource(this.url + '/assets').exists()) || ((await resource(this.url + '/assets').dirList()).length === 0)) {
+      return false;
+    }
     switch (type) {
       case 'image':
         return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(supportedImageFormats)).sort((a, b) => ('' + a).localeCompare(b));

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -779,4 +779,15 @@ export class Project {
     unifiedFontItems.forEach(fontItem => fontItem.supportedWeights = arr.uniq(fontItem.supportedWeights.sort(), true));
     return unifiedFontItems;
   }
+
+  /**
+   * Returns an array of `resource` handles.
+   * @param {string} type - One of 'video', 'audio', 'image'
+   */
+  async getAssets (type) {
+    switch (type) {
+      case 'image':
+        return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(/gif|jpeg|jpg|png|webp|jxl/));
+    }
+  }
 }

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -787,7 +787,7 @@ export class Project {
   async getAssets (type) {
     switch (type) {
       case 'image':
-        return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(/gif|jpeg|jpg|png|webp|jxl/));
+        return (await resource(this.url + '/assets').dirList()).filter(a => a.name().match(/gif|jpeg|jpg|png|webp|jxl/)).sort((a, b) => ('' + a).localeCompare(b));
     }
   }
 }


### PR DESCRIPTION
Adds an "Asset Browser" which can be used to browse, instantiate and add assets inside of Projects or Playgrounds.
Currently, images are supported.
The browser can be opened via the top-bar or via the sidebar, when one has an image focused. Changing the imageUrl of an image via the sidebar does also reconcile into components, using `projectAsset` where applicable.

![image](https://github.com/LivelyKernel/lively.next/assets/14252419/7c7126d0-7436-43b2-acbe-025aa3ca3ded)

![image](https://github.com/LivelyKernel/lively.next/assets/14252419/327a3c7c-2078-4672-b0a0-e3d97e518b33)

This closes #537.