### PR TITLE
🧰: align world menus within visible bounds

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -763,12 +763,20 @@ export class LivelyWorld extends World {
     ];
   }
 
-  openWorldMenu (evt, items) {
+  moveIntoVisibleBounds (aMorph) {
+    const translatedBounds = this.visibleBoundsExcludingTopBar().translateForInclusion(aMorph.bounds());
+    aMorph.setBounds(translatedBounds);
+    return aMorph;
+  }
+
+  async openWorldMenu (evt, items) {
     const eventState = this.env.eventDispatcher.eventState;
     if (eventState.menu) eventState.menu.remove();
-    return eventState.menu = items && items.length
+    eventState.menu = items && items.length
       ? Menu.openAtHand(items, { hand: (evt && evt.hand) || this.firstHand })
       : null;
+    await eventState.menu.whenRendered();
+    return this.moveIntoVisibleBounds(eventState.menu);
   }
 
   async onPaste (evt) {


### PR DESCRIPTION
Something that was super annoying up till now, is that world menus would appear not necessarily within the visible bounds of the world, having them cut off often when working on smaller screens. This fixes that, by moving the menu into the visible bounds to the extent its possible. It relies on `whenRendered()` since layouts are updating their bounds in an asynchronous fashion. 