### PR TITLE
🧰: always respect flag to show or hide edit button in component browser

### DIFF
--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -887,7 +887,7 @@ export class ComponentBrowserModel extends ViewModel {
     super.onRefresh(change);
     this.ui.behaviorToggle.checked = this.importAlive;
     this.handleColumnViewVisibility();
-    this.ui.editButton.visible = !this.selectionMode;
+    this.ui.editButton.visible = !this.selectionMode && config.ide.studio.componentEditViaComponentBrowser;
     this.ui.behaviorToggle.visible = !this.selectionMode;
     this.ui.importButton.visible = !this.selectionMode;
     this.ui.selectionButton.visible = this.selectionMode;


### PR DESCRIPTION
Previously, the flag was only considered when initially opening the Component Browser, but it became visible, for example when checking/unchecking the checkbox that controls the behavior of the opened components.