### PR TITLE
🚨: image control in properties panel is always visible

### DIFF
--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -172,7 +172,6 @@ export class FillControlModel extends ViewModel {
   async update () {
     const { isImage, fill } = this.targetMorph;
     this.ui.fillColorInput.setColor(fill);
-    this.ui.imageControl.visible = isImage;
     if (isImage) {
       this.ui.imageContainer.imageUrl = this.targetMorph.imageUrl;
       // fixme: autofit the image preview
@@ -205,6 +204,7 @@ const FillControl = component(PropertySection, {
     extent: pt(250, 27)
   })), add({
     name: 'image control',
+    visible: false,
     extent: pt(235.1, 25),
     fill: Color.rgba(255, 255, 255, 0),
     layout: new TilingLayout({

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -175,14 +175,14 @@ export class TopBarModel extends ViewModel {
   }
 
   async onMouseDown (evt) {
-    const shapeSelector = this.ui.shapeModeButton.get('dropdown');
-    const handHaloSelector = this.ui.handOrHaloModeButton.get('dropdown');
+    const shapeSelector = this.ui.shapeModeButton.getSubmorphNamed('dropdown');
+    const handHaloSelector = this.ui.handOrHaloModeButton.getSubmorphNamed('dropdown');
     const handOrHaloModeButton = this.ui.handOrHaloModeButton;
     const shapeModeButton = this.ui.shapeModeButton;
     const canvasModeButton = this.ui.canvasModeButton;
-    const canvasModeSelector = this.ui.canvasModeButton.get('dropdown');
+    const canvasModeSelector = this.ui.canvasModeButton.getSubmorphNamed('dropdown');
     const saveButton = this.ui.saveButton;
-    const saveMenu = this.ui.saveButton.get('dropdown');
+    const saveMenu = this.ui.saveButton.getSubmorphNamed('dropdown');
     const target = this.primaryTarget || this.world();
 
     if (evt.targetMorph === saveButton) $world.execCommand('save world or project');


### PR DESCRIPTION
This fixes a problem with the image controls from #1061, which are currently not correctly hidden when a non-image morph is selected.
Additionally, I fixed a problem in the top-bar, where usage of `get` instead of `getSubmorphNamed` led to incorrect results due to multiple morphs with the same name.