### PR TITLE
Add support for forked `lively.project`s

### DIFF
--- a/flatn/package-map.js
+++ b/flatn/package-map.js
@@ -453,7 +453,12 @@ class PackageMap {
     packageDir,
     seen = { packageDirs: {}, collectionDirs: {} }
   ) {
-    let spec = fs_exists(packageDir) && PackageSpec.fromDir(packageDir);
+    let spec;
+    try {
+      spec = fs_exists(packageDir) && PackageSpec.fromDir(packageDir);
+    } catch (e) {
+      return [];
+    }
     if (!spec) return [];
 
     let found = [spec];

--- a/lively.freezer/src/loading-screen.cp.js
+++ b/lively.freezer/src/loading-screen.cp.js
@@ -35,7 +35,6 @@ export class WorldLoadingScreen extends Morph {
     if (lively.FreezerRuntime) {
       const cssLoadingScreen = this.get('css loading screen');
       const projectName = this.getProjectName();
-      const projectRepoOwner = this.getProjectRepoOwner();
       const worldName = this.getWorldName();
       const filePath = this.getFilePath();
       const snapshot = this.getSnapshot();
@@ -56,12 +55,12 @@ export class WorldLoadingScreen extends Morph {
           opacity: 1, duration: 300
         });
       }
-      await this.transitionToLivelyWorld({ worldName, filePath, snapshot, projectName, projectRepoOwner }, progressBar);
+      await this.transitionToLivelyWorld({ worldName, filePath, snapshot, projectName }, progressBar);
       progressBar?.stopStepping();
     }
   }
 
-  async transitionToLivelyWorld ({ worldName, filePath, snapshot, projectName, projectRepoOwner }, progress) {
+  async transitionToLivelyWorld ({ worldName, filePath, snapshot, projectName }, progress) {
     const serverURL = resource(window.SYSTEM_BASE_URL || document.location.origin).join('objectdb/').url;
     const { bootstrap } = await System.import('lively.freezer/src/util/bootstrap.js');
 
@@ -70,7 +69,7 @@ export class WorldLoadingScreen extends Morph {
 
     if (projectName) {
       const existingProjects = await Project.listAvailableProjects();
-      const foundProject = existingProjects.filter(p => p.name === projectName && p.projectRepoOwner === projectRepoOwner);
+      const foundProject = existingProjects.filter(p => p._name === projectName);
       if (projectName !== '__newProject__' && !foundProject.length > 0) return this.indicateMissing(true);
     }
 
@@ -81,25 +80,16 @@ export class WorldLoadingScreen extends Morph {
 
     if (filePath && !await resource(document.location.origin).join(filePath).exists()) { return this.indicateMissing(false); }
 
-    await bootstrap({ worldName, filePath, loadingIndicator: new Morph(), progress, snapshot, projectName, projectRepoOwner });
+    await bootstrap({ worldName, filePath, loadingIndicator: new Morph(), progress, snapshot, projectName });
   }
 
   getProjectName () {
     if (!document.location.href.includes('projects')) return false;
     const loc = document.location;
     const query = resource(loc.href).query();
-    const projectNameMatch = query.name || window.PROJECT_NAME;
+    const projectNameMatch = query.name;
     const projectName = projectNameMatch || false;
     return projectName;
-  }
-
-  getProjectRepoOwner () {
-    if (!document.location.href.includes('projects')) return false;
-    const loc = document.location;
-    const query = resource(loc.href).query();
-    const projectRepoOwnerMatch = query.owner || window.OWNER;
-    const projectRepoOwner = projectRepoOwnerMatch || false;
-    return projectRepoOwner;
   }
 
   getWorldName () {

--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -342,7 +342,7 @@ function fastPrepLivelySystem () {
 }
 
 export async function bootstrap ({
-  filePath, worldName, projectName, projectRepoOwner, snapshot, commit, progress,
+  filePath, worldName, projectName, snapshot, commit, progress,
   fastLoad = query.fastLoad !== false || window.FORCE_FAST_LOAD,
   logError = (err) => console.log(err)
 }) {
@@ -423,7 +423,7 @@ export async function bootstrap ({
           }
           if (worldName) await loadWorld(new LivelyWorld({ openNewWorldPrompt: true }), undefined, opts);
           else if (projectName === '__newProject__') await loadWorld(new LivelyWorld({ openNewProjectPrompt: true }), undefined, opts);
-          else await loadWorld(new LivelyWorld({ projectToBeOpened: projectName, projectRepoOwner }), undefined, opts);
+          else await loadWorld(new LivelyWorld({ projectToBeOpened: projectName }), undefined, opts)
         } else {
           await morphic.World.loadFromDB(worldName, undefined, undefined, {
             ...opts,

--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -260,7 +260,7 @@ class MasterComponentTreeData extends TreeData {
     });
     if (projectToLoad) {
       await $world.withLoadingIndicatorDo(async () => {
-        await Project.loadProject(projectToLoad.name, projectToLoad.projectRepoOwner, true);
+        await Project.loadProject(projectToLoad.name, true);
         this.root.subNodes = await this.listAllComponentCollections();
         this.columnView.refresh();
       }, win, 'Importing project...');

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -859,7 +859,7 @@ const commands = [
       fun.guardNamed('loadingComponentBrowser', async () => {
         const li = LoadingIndicator.open('loading component browser');
         const p = $world.openedProject;
-        if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('partsbin', 'LivelyKernel', true);
+        if ((p && (p.name !== 'partsbin' || p.repoOwner !== 'LivelyKernel')) || !p) await Project.loadProject('LivelyKernel--partsbin', true);
         const { ComponentBrowser } = await System.import('lively.ide/studio/component-browser.cp.js');
         const componentBrowser = world._componentBrowser || (world._componentBrowser = part(ComponentBrowser, { name: 'lively component browser' }));
         li.remove();

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -481,7 +481,7 @@ export class LivelyWorld extends World {
       } else if (openNewProjectPrompt) { // We open a **new** Project
         const project = await this.openPrompt(part(ProjectCreationPrompt, { hasFixedPosition: true }));
         $world.openedProject = project;
-        worldName = project.name;
+        worldName = project.fullName;
       } else if (projectToBeOpened) { // We open an existing Project
         worldName = projectToBeOpened;
         await Project.loadProject(projectToBeOpened, projectRepoOwner);

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -466,7 +466,7 @@ export class LivelyWorld extends World {
   }
 
   async initializeStudio () {
-    let { openNewProjectPrompt, openNewWorldPrompt, projectToBeOpened, projectRepoOwner } = this;
+    let { openNewProjectPrompt, openNewWorldPrompt, projectToBeOpened } = this;
 
     let anonymousMode;
     const { askForWorldName } = resource(document.location.href).query();
@@ -484,9 +484,8 @@ export class LivelyWorld extends World {
         worldName = project.fullName;
       } else if (projectToBeOpened) { // We open an existing Project
         worldName = projectToBeOpened;
-        await Project.loadProject(projectToBeOpened, projectRepoOwner);
+        await Project.loadProject(projectToBeOpened);
         this.projectToBeOpened = null;
-        this.projectRepoOwner = null;
       }
 
       this.name = worldName;
@@ -500,8 +499,7 @@ export class LivelyWorld extends World {
       }
 
       if (window.history) {
-        if (!projectRepoOwner && $world.openedProject) projectRepoOwner = $world.openedProject.repoOwner;
-        window.history.pushState({}, 'lively.next', pathForBrowserHistory(this.name, null, !!$world.openedProject, $world.openedProject ? projectRepoOwner : null));
+        window.history.pushState({}, 'lively.next', pathForBrowserHistory(this.name, null, !!$world.openedProject));
       }
     }
 

--- a/lively.modules/src/packages/package-registry.js
+++ b/lively.modules/src/packages/package-registry.js
@@ -454,6 +454,14 @@ export class PackageRegistry {
       let pkg = (existingPackageMap && existingPackageMap[url]) ||
               new Package(this.System, url);
       let config = await pkg.tryToLoadPackageConfig();
+      if (url.includes('local_projects')){
+        const forkInfoFile = resource(url).join('.livelyForkInformation');
+        if ((await forkInfoFile.exists())) {
+          const forkInfo = JSON.parse((await forkInfoFile.read()));
+          config.name = forkInfo.owner + '--' + forkInfo.name;
+          config.isFork = true;
+        }
+      }
       pkg.setConfig(config);
       discovered[url] = { pkg, config, covered };
       if (this.System.debug) {

--- a/lively.modules/src/packages/package.js
+++ b/lively.modules/src/packages/package.js
@@ -329,6 +329,7 @@ class Package {
 
     try {
       let config = System.get(packageConfigURL) || await System.import(packageConfigURL);
+      if (config.__useDefault) config = config.default;
       let packageConfigPaths = [...System.packageConfigPaths];
       arr.pushIfNotIncluded(packageConfigPaths, packageConfigURL); // to inform systemjs that there is a config
       System.config({ packageConfigPaths });

--- a/lively.modules/src/packages/package.js
+++ b/lively.modules/src/packages/package.js
@@ -145,6 +145,9 @@ class Package {
     this.main = config.main || 'index.js';
     this.systemjs = config.systemjs;
     this.lively = config.lively;
+    this.author = config.author;
+    this.description = config.description;
+    this.isFork = config.isFork;
   }
 
   toJSON () {
@@ -158,7 +161,10 @@ class Package {
       'devDependencies',
       'main',
       'systemjs',
-      'lively'
+      'lively',
+      'author',
+      'description',
+      'isFork'
     ]);
     if (jso.url.startsWith(System.baseURL)) { jso.url = jso.url.slice(System.baseURL.length).replace(/^\//, ''); }
     return jso;
@@ -174,6 +180,9 @@ class Package {
     this.dependencies = jso.dependencies || {};
     this.devDependencies = jso.devDependencies || {};
     this.systemjs = jso.systemjs;
+    this.description = jso.description;
+    this.author = jso.author;
+    this.isFork = jso.isFork;
     this.lively = jso.lively;
     if (!isURL(this.url)) { this.url = join(System.baseURL, this.url); }
     this.registerWithConfig();

--- a/lively.morphic/helpers.js
+++ b/lively.morphic/helpers.js
@@ -42,7 +42,7 @@ export function sanitizeFont (font) {
   }).join(',');
 }
 
-export function pathForBrowserHistory (worldName, queryString, project = false, projectOwner) {
+export function pathForBrowserHistory (worldName, queryString, project = false) {
   // how does the resource map to a URL shown in the browser URL bar? used for
   // browser history
   if (!queryString) { queryString = typeof document !== 'undefined' ? document.location.search : ''; }
@@ -59,11 +59,11 @@ export function pathForBrowserHistory (worldName, queryString, project = false, 
   } else {
     delete query.file;
     query.name = worldName;
-    if (project && projectOwner) query.owner = projectOwner;
   }
 
   if (!lively.isResurrectionBuild) query.fastLoad = false;
 
+  // ensure the name param in the query string matches worldName
   return `${basePath}?${stringifyQuery(query)}`;
 }
 


### PR DESCRIPTION
This PR adds support for forked `lively.project`s. This way, it is possible to collaboratively work on a lively project without the need to set up a shared repository. This will be valuable for e.g., the partsbin, as it allows for a fork -> change -> PR -> merge workflow.

To achieve this, the following changes were made:

As we cannot change the contents of the `package.json` in the fork without creating a change that would propagate into the upstream repository, we create a `.livelyforkinformation` file which is hidden and on the `.gitignore` of projects by default. In this file we store information about the owner of the forked repository at the time at which the fork is cloned. As a fork needs to be created on GitHub, we are guaranteed to have this information (along with information about a repository being a fork in the first place) available via the GitHub API.
We then use the `packageRegistry` to persist this information at runtime. We now use the `packageRegistry` in general when loading projects, i.e., when enumerating available projects, instead of just scanning the `local_projects` directory.

The most prominent change is that, when supporting forks, the owner needs to become a relevant part of the project name at all times. Thus, the `owner` parameter in a lot of places is gone, especially in the URL of running lively sessions. Instead, the name of a project needs to be specified with a fully qualified `<owner>--<name>` in these places. 

**Note, that although GitHub in theory allows forks that have a name different from the upstream repository, we do currently not allow this!**