### PR TITLE
Add option to delete remote when a local project is deleted on landing page

### DIFF
--- a/lively.freezer/src/landing-page.cp.js
+++ b/lively.freezer/src/landing-page.cp.js
@@ -11,6 +11,7 @@ import { connect } from 'lively.bindings';
 
 // this pulls in a bunch of code
 import { WorldBrowser } from 'lively.ide/studio/world-browser.cp.js';
+import { UserFlap, UserFlapModel } from 'lively.user/user-flap.cp.js';
 
 class LandingPageWorld extends LivelyWorld {
   showHaloFor () {
@@ -214,7 +215,6 @@ class Globe extends WebGLCanvas {
     });
   }
 
-
   beforePublish () {
     this.get('cover').opacity = 1;
   }
@@ -320,14 +320,53 @@ const LandingPage = component({
   ]
 });
 
+class WorldAligningUserFlap extends UserFlapModel {
+  get expose () {
+    return [...super.expose, 'relayout'];
+  }
+
+  async viewDidLoad () {
+    await super.viewDidLoad();
+    await this.relayout();
+  }
+
+  async relayout () {
+    await this.view.whenRendered();
+    this.view.topRight = $world.visibleBounds().insetBy(10).topRight();
+    return this.view;
+  }
+
+  async showUserData () {
+    super.showUserData();
+    await this.relayout();
+  }
+
+  async showGuestUser () {
+    super.showGuestUser();
+    await this.relayout();
+  }
+}
+
+const DarkUserFlap = component(UserFlap, {
+  defaultViewModel: WorldAligningUserFlap,
+  submorphs: [{
+    name: 'left user label',
+    fontColor: Color.rgb(255, 255, 255)
+  }, {
+    name: 'right user label',
+    fontColor: Color.rgb(255, 255, 255)
+  }, {
+    name: 'spinner',
+    viewModel: { color: 'white' }
+  }]
+});
+
 export async function main () {
   config.altClickDefinesThat = false;
   config.ide.studio.canvasModeEnabled = false;
 
-  const lp = part(LandingPage);
-  lp.respondsToVisibleWindow = true;
-  $world.addMorph(lp);
-  lp.relayout();
+  part(LandingPage, { respondsToVisibleWindow: true }).openInWorld().relayout();
+  const flap = part(DarkUserFlap, { respondsToVisibleWindow: true }).openInWorld();
 }
 
 export const TITLE = 'lively.next';

--- a/lively.freezer/src/landing-page.cp.js
+++ b/lively.freezer/src/landing-page.cp.js
@@ -1,4 +1,4 @@
-import { Morph, component, part, easings } from 'lively.morphic';
+import { Morph, component, config, part, easings } from 'lively.morphic';
 import { promise } from 'lively.lang';
 import { Color, pt } from 'lively.graphics';
 import {
@@ -6,11 +6,21 @@ import {
   TextureLoader, BackSide, MeshBasicMaterial, MeshPhongMaterial, SphereGeometry, Mesh
 } from 'esm://cache/three';
 import { Canvas } from 'lively.components/canvas.js';
-import { World } from 'lively.morphic/world.js';
+import { LivelyWorld } from 'lively.ide/world.js';
 import { connect } from 'lively.bindings';
 
 // this pulls in a bunch of code
 import { WorldBrowser } from 'lively.ide/studio/world-browser.cp.js';
+
+class LandingPageWorld extends LivelyWorld {
+  showHaloFor () {
+    // noop
+  }
+
+  onLoad () {
+    // noop
+  }
+}
 
 class WebGLCanvas extends Canvas {
   static get properties () {
@@ -204,6 +214,7 @@ class Globe extends WebGLCanvas {
     });
   }
 
+
   beforePublish () {
     this.get('cover').opacity = 1;
   }
@@ -255,7 +266,6 @@ class WorldLandingPage extends Morph {
     const worldList = this.getSubmorphNamed('a project browser');
     if (worldList) worldList.center = this.extent.scaleBy(0.5);
   }
-
 
   beforePublish () {
     const worldList = this.getSubmorphNamed('a project browser');
@@ -311,6 +321,9 @@ const LandingPage = component({
 });
 
 export async function main () {
+  config.altClickDefinesThat = false;
+  config.ide.studio.canvasModeEnabled = false;
+
   const lp = part(LandingPage);
   lp.respondsToVisibleWindow = true;
   $world.addMorph(lp);
@@ -319,7 +332,7 @@ export async function main () {
 
 export const TITLE = 'lively.next';
 
-export const WORLD_CLASS = World;
+export const WORLD_CLASS = LandingPageWorld;
 
 export const EXCLUDED_MODULES = [
   'lively.collab',

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -1221,9 +1221,6 @@ const WorldBrowser = component({
     }], ['fader top', {
       x: 'resize',
       y: 'fixed'
-    }], ['search field', {
-      x: 'move',
-      y: 'fixed'
     }], ['fader bottom', {
       x: 'resize',
       y: 'move'
@@ -1278,79 +1275,101 @@ const WorldBrowser = component({
     }]
   }, {
     name: 'fader top',
-    extent: pt(871.9, 63.9),
+    layout: new TilingLayout({
+      align: 'center',
+      axisAlign: 'center',
+      justifySubmorphs: 'spaced',
+      padding: rect(20, 0, 0, 0)
+    }),
+    extent: pt(870.0000, 60.0000),
     fill: new LinearGradient({
       stops: [{ offset: 0, color: Color.rgb(112, 123, 124) }, { offset: 1, color: Color.rgba(112, 123, 124, 0) }],
       vector: rect(0, 0, 0, 1)
     }),
-    submorphs: [part(GreenButton, {
-      name: 'new project button',
-      extent: pt(163, 30),
-      position: pt(19.8, 17),
-      submorphs: [{
-        name: 'label',
-        fontWeight: 600,
-        textAndAttributes: [...Icon.textAttribute('plus-circle', { paddingTop: '2px', paddingRight: '5px' }), ' NEW PROJECT']
-      }]
-    }), part(ModeSelector, {
-      name: 'mode selector',
-      extent: pt(150, 30),
-      position: pt(195, 17.5),
-      borderColor: Color.white,
-      fill: Color.rgba(114, 123, 124, 0),
-      borderRadius: 5,
-      viewModel: {
-        items: [
-          { text: 'Projects', name: 'Projects', tooltip: 'Create or Open a Project' },
-          { text: 'Playgrounds', name: 'Playgrounds', tooltip: 'Create or Open a Playground (Legacy/Prototyping Mode)' }
-        ]
-      }
-    })]
-  },
-  part(SearchField, {
-    name: 'search field',
-    borderStyle: 'hidden',
-    layout: new TilingLayout({
-      align: 'center',
-      axisAlign: 'center',
-      orderByIndex: true,
-      padding: rect(6, 0, 4, 0),
-      resizePolicies: [['search input', {
-        height: 'fill',
-        width: 'fill'
-      }]]
-    }),
-    borderRadius: 30,
-    viewModel: { fuzzy: true },
-    extent: pt(285.1, 34),
-    fill: Color.rgb(234, 237, 237),
-    position: pt(574.3, 13.6),
-    submorphs: [
-      {
-        name: 'search input',
-        layout: new ConstraintLayout({
-          lastExtent: {
-            x: 271,
-            y: 36
-          },
-          reactToSubmorphAnimations: false,
-          submorphSettings: []
+    submorphs: [{
+      name: 'left',
+      fill: Color.transparent,
+      layout: new TilingLayout({
+        axisAlign: 'center',
+        spacing: 10
+      }),
+      submorphs: [part(GreenButton, {
+        name: 'new project button',
+        extent: pt(163, 30),
+        submorphs: [{
+          name: 'label',
+          fontWeight: 600,
+          textAndAttributes: [...Icon.textAttribute('plus-circle', { paddingTop: '2px', paddingRight: '5px' }), ' NEW PROJECT']
+        }]
+      }), part(ModeSelector, {
+        name: 'mode selector',
+        extent: pt(150, 30),
+        borderColor: Color.white,
+        fill: Color.rgba(114, 123, 124, 0),
+        borderRadius: 5,
+        viewModel: {
+          items: [
+            { text: 'Projects', name: 'Projects', tooltip: 'Create or Open a Project' },
+            { text: 'Playgrounds', name: 'Playgrounds', tooltip: 'Create or Open a Playground (Legacy/Prototyping Mode)' }
+          ]
+        }
+      })]
+    }, {
+      name: 'right',
+      fill: Color.transparent,
+      layout: new TilingLayout({
+        align: 'right',
+        axisAlign: 'center',
+        hugContentsHorizontally: true,
+        hugContentsVertically: true,
+        spacing: 10
+      }),
+      submorphs: [part(SearchField, {
+        name: 'search field',
+        borderStyle: 'hidden',
+        layout: new TilingLayout({
+          align: 'center',
+          axisAlign: 'center',
+          orderByIndex: true,
+          padding: rect(6, 0, 4, 0),
+          resizePolicies: [['search input', {
+            height: 'fill',
+            width: 'fill'
+          }]]
         }),
-        selectionColor: Color.rgba(64, 196, 255, .4),
-        fontSize: 20,
+        borderRadius: 30,
+        viewModel: { fuzzy: true },
+        extent: pt(285.1, 34),
+        fill: Color.rgb(234, 237, 237),
         submorphs: [
           {
-            name: 'placeholder',
-            textAndAttributes: ['Search Projects', { fontSize: 22 }]
+            name: 'search input',
+            layout: new ConstraintLayout({
+              lastExtent: {
+                x: 271,
+                y: 36
+              },
+              reactToSubmorphAnimations: false,
+              submorphSettings: []
+            }),
+            selectionColor: Color.rgba(64, 196, 255, .4),
+            fontSize: 20,
+            submorphs: [
+              {
+                name: 'placeholder',
+                textAndAttributes: ['Search Projects', { fontSize: 22 }]
+              }
+            ]
+          }, {
+            name: 'placeholder icon',
+            padding: rect(2, 2, -2, -2),
+            fontSize: 18
           }
         ]
-      }, {
-        name: 'placeholder icon',
-        padding: rect(2, 2, -2, -2),
-        fontSize: 18
-      }
-    ]
-  }), {
+      }),
+      ]
+    }]
+  }, {
     name: 'fader bottom',
     extent: pt(871.9, 63.9),
     fill: new LinearGradient({

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -15,6 +15,7 @@ import { LivelyWorld } from '../world.js';
 import { without, add } from 'lively.morphic/components/core.js';
 import { Text } from 'lively.morphic/text/morph.js';
 import { Path } from 'lively.morphic/morph.js';
+import { UserFlap } from 'lively.user/user-flap.cp.js';
 
 export const missingSVG = `data:image/svg+xml;utf8,
 <svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="question-circle" class="svg-inline--fa fa-question-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="lightgray" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"></path></svg>
@@ -1367,6 +1368,11 @@ const WorldBrowser = component({
           }
         ]
       }),
+      part(UserFlap, {
+        name: 'user flap',
+        extent: pt(141.0000, 36),
+        fill: Color.rgba(255, 255, 255, 0.2341)
+      })
       ]
     }]
   }, {

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-use-before-define */
 import { easings, ViewModel, touchInputDevice, morph, World, MorphicDB, Image, HTMLMorph, Morph, Icon, TilingLayout, Label, ConstraintLayout, ShadowObject, component, part } from 'lively.morphic';
-import * as moduleManager from 'lively.modules';
 import { Color, LinearGradient, rect, pt } from 'lively.graphics/index.js';
 import { arr, promise, fun, graph, date, string } from 'lively.lang/index.js';
 import { GreenButton, ConfirmPrompt, RedButton, PlainButton } from 'lively.components/prompts.cp.js';
@@ -11,13 +10,13 @@ import { SystemList } from '../styling/shared.cp.js';
 import { ModeSelector } from 'lively.components/widgets/mode-selector.cp.js';
 import { SearchField } from 'lively.components/inputs.cp.js';
 import { Project } from 'lively.project';
-import { LivelyWorld } from '../world.js';
 import { without, add } from 'lively.morphic/components/core.js';
 import { Text } from 'lively.morphic/text/morph.js';
 import { Path } from 'lively.morphic/morph.js';
 import { UserFlap } from 'lively.user/user-flap.cp.js';
 import { currentUserToken, isUserLoggedIn } from 'lively.user';
 import { resource } from 'lively.resources';
+import { defaultDirectory } from 'lively.ide/shell/shell-interface.js';
 
 export const missingSVG = `data:image/svg+xml;utf8,
 <svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="question-circle" class="svg-inline--fa fa-question-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="lightgray" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"></path></svg>
@@ -845,8 +844,11 @@ class ProjectPreviewModel extends WorldPreviewModel {
   async tryToDelete () {
     const proceed = await this._worldBrowser.confirm(['Delete Project\n', {}, 'Do you really want to remove this project from this system? This step can not be undone.', { fontWeight: 'normal', fontSize: 16 }]);
     if (proceed) {
-      let deleteRepo = false;
-      if (isUserLoggedIn() && this._project.lively.hasRemote) {
+      const { _projectOwner, _projectName} = this._project;
+      const gitResource = await resource('git/' + await defaultDirectory()).join('..').join('local_projects').join(`${_projectOwner}--${_projectName}`).withRelativePartsResolved().asDirectory();
+      const hasRemote = await gitResource.hasRemote();
+      let deleteRepo;
+      if (isUserLoggedIn() && hasRemote) {
         deleteRepo = await this._worldBrowser.confirm(['Delete Remote Repository\n', {}, 'Should the remote repository be deleted as well?', { fontWeight: 'normal', fontSize: 16 }]);
       }
       await this.confirmDelete(deleteRepo);

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -13,7 +13,7 @@ import { Project } from 'lively.project';
 import { without, add } from 'lively.morphic/components/core.js';
 import { Text } from 'lively.morphic/text/morph.js';
 import { Path } from 'lively.morphic/morph.js';
-import { UserFlap } from 'lively.user/user-flap.cp.js';
+
 import { currentUserToken, isUserLoggedIn } from 'lively.user';
 import { resource } from 'lively.resources';
 import { defaultDirectory } from 'lively.ide/shell/shell-interface.js';
@@ -736,8 +736,8 @@ export class WorldPreviewModel extends ViewModel {
     this.loadEntity();
   }
 
-  async loadEntity () {  
-      this.transitionToLivelyWorld(this._commit);
+  async loadEntity () {
+    this.transitionToLivelyWorld(this._commit);
   }
 
   async transitionToLivelyWorld (commit, projectName) {
@@ -838,13 +838,13 @@ class ProjectPreviewModel extends WorldPreviewModel {
 
   async loadEntity () {
     const { _name } = this._project;
-      this.transitionToLivelyWorld(null, _name);
+    this.transitionToLivelyWorld(null, _name);
   }
 
   async tryToDelete () {
     const proceed = await this._worldBrowser.confirm(['Delete Project\n', {}, 'Do you really want to remove this project from this system? This step can not be undone.', { fontWeight: 'normal', fontSize: 16 }]);
     if (proceed) {
-      const { _projectOwner, _projectName} = this._project;
+      const { _projectOwner, _projectName } = this._project;
       const gitResource = await resource('git/' + await defaultDirectory()).join('..').join('local_projects').join(`${_projectOwner}--${_projectName}`).withRelativePartsResolved().asDirectory();
       const hasRemote = await gitResource.hasRemote();
       let deleteRepo;
@@ -1377,11 +1377,6 @@ const WorldBrowser = component({
             fontSize: 18
           }
         ]
-      }),
-      part(UserFlap, {
-        name: 'user flap',
-        extent: pt(141.0000, 36),
-        fill: Color.rgba(255, 255, 255, 0.2341)
       })
       ]
     }]

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -16,6 +16,8 @@ import { without, add } from 'lively.morphic/components/core.js';
 import { Text } from 'lively.morphic/text/morph.js';
 import { Path } from 'lively.morphic/morph.js';
 import { UserFlap } from 'lively.user/user-flap.cp.js';
+import { currentUserToken, isUserLoggedIn } from 'lively.user';
+import { resource } from 'lively.resources';
 
 export const missingSVG = `data:image/svg+xml;utf8,
 <svg aria-hidden="true" focusable="false" data-prefix="far" data-icon="question-circle" class="svg-inline--fa fa-question-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="lightgray" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"></path></svg>
@@ -368,7 +370,7 @@ export class WorldBrowserModel extends ViewModel {
   }
 
   async onRefresh (prop) {
-    if (prop == 'showCloseButton' && this.ui.closeButton) {
+    if (prop === 'showCloseButton' && this.ui.closeButton) {
       this.updateCloseButtonVisibility();
     }
   }
@@ -594,8 +596,8 @@ export class GrowingWorldList extends Morph {
     }
   }
 
-  onHoverIn (evt) { this.clipMode = 'auto'; }
-  onHoverOut (evt) { if (!touchInputDevice) this.clipMode = 'hidden'; }
+  onHoverIn () { this.clipMode = 'auto'; }
+  onHoverOut () { if (!touchInputDevice) this.clipMode = 'hidden'; }
 
   // add top and bottom buffer
 
@@ -842,12 +844,18 @@ class ProjectPreviewModel extends WorldPreviewModel {
 
   async tryToDelete () {
     const proceed = await this._worldBrowser.confirm(['Delete Project\n', {}, 'Do you really want to remove this project from this system? This step can not be undone.', { fontWeight: 'normal', fontSize: 16 }]);
-    if (proceed) await this.confirmDelete();
+    if (proceed) {
+      let deleteRepo = false;
+      if (isUserLoggedIn() && this._project.lively.hasRemote) {
+        deleteRepo = await this._worldBrowser.confirm(['Delete Remote Repository\n', {}, 'Should the remote repository be deleted as well?', { fontWeight: 'normal', fontSize: 16 }]);
+      }
+      await this.confirmDelete(deleteRepo);
+    }
   }
 
-  async confirmDelete () {
+  async confirmDelete (deleteRepo) {
     const { _projectName, _projectOwner } = this._project;
-    await Project.deleteProject(_projectName, _projectOwner);
+    await Project.deleteProject(_projectName, _projectOwner, currentUserToken(), deleteRepo);
     this._worldBrowser.displayItems();
   }
 }

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -412,9 +412,11 @@ export class Project {
   async create (withRemote = false, gitHubUser, priv) {
     this.gitResource = null;
     const system = Project.systemInterface;
+    
     const projectsDir = await Project.projectDirectory();
-    const projectDir = projectsDir.join(this.fullName);
+    const projectDir = projectsDir.join(`${gitHubUser}--${this.name}`);
     this.url = projectDir.url;
+
     const createForOrg = gitHubUser !== currentUsername();
 
     try {

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -1,3 +1,4 @@
+/* global fetch */
 /* eslint-disable no-console */
 import ShellClientResource from './client-resource.js';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
@@ -73,6 +74,21 @@ export default class GitShellResource extends ShellClientResource {
     cmd = this.runCommand(addingRemoteCommand);
     await cmd.whenDone();
     if (cmd.exitCode !== 0) throw Error('Error adding the remote to local repository');
+  }
+
+  async deleteRemoteRepository (token, repoName, repoUser) {
+    const deleteRes = await fetch(`https://api.github.com/repos/${repoUser}/${repoName}`,{
+      method: 'DELETE',  
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": '2022-11-28'
+      }
+    }); 
+
+    if (deleteRes.status === 404) throw Error('Unexpected problem delete remote repository.');
+    if (deleteRes.status === 403) return false;
+    if (deleteRes.status === 204) return true;
   }
 
   async changeRemoteVisibility (token, repoName, repoUser, visibility) {

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -2,12 +2,17 @@
 /* eslint-disable no-console */
 import ShellClientResource from './client-resource.js';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
+import L2LClient from 'lively.2lively/client.js';
 
 export default class GitShellResource extends ShellClientResource {
   constructor (url) {
     url = url.replace('git\/', '');
     super(url);
     this.options.cwd = this.url;
+    if (!this.options.l2lClient) {
+      const defaultConnection = { url: `${document.location.origin}/lively-socket.io`, namespace: 'l2l' };
+      this.options.l2lClient = L2LClient.ensure(defaultConnection);
+    }
   }
 
   runCommand (cmd) {

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -1,3 +1,4 @@
+/* global fetch */
 import { ViewModel, ShadowObject, Image, Icon, Label, TilingLayout, component } from 'lively.morphic';
 import { pt, Color } from 'lively.graphics';
 import { currentUser, isUserLoggedIn, clearUserData, clearAllUserData, storeCurrentUser, storeCurrentUsersOrganizations, currentUserToken, storeCurrentUserToken } from 'lively.user';
@@ -96,7 +97,6 @@ class UserFlapModel extends ViewModel {
       }
     } else {
       await this.update();
-      this.showUserData();
       leftUserLabel.tooltip = '';
       rightUserLabel.tooltip = 'Logout';
       rightUserLabel.nativeCursor = 'pointer';

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -200,26 +200,27 @@ class UserFlapModel extends ViewModel {
   async retrieveGithubUserData () {
     const token = currentUserToken();
     // retrieve general data about the authenticated user
-    const cmdString = `curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${token}" https://api.github.com/user`;
-    let { stdout: userRes } = await runCommand(cmdString).whenDone();
-    if (!userRes || userRes === '') {
-      $world.setStatusMessage('An unexpected error occured. Please check your connection.', StatusMessageError);
-      return;
-    }
+    const userRes = await fetch('https://api.github.com/user', {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    const userData = await userRes.json();
     // retrieve the organizations in which the authenticated user is a member
-    const organizationCmdString = `curl -L \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer ${token}"\
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      https://api.github.com/user/orgs`;
-    let { stdout: orgsResForUser } = await runCommand(organizationCmdString).whenDone();
-    if (!userRes || userRes === '') {
-      $world.setStatusMessage('An unexpected error occured. Please check your connection.', StatusMessageError);
-      return;
-    }
-    const orgNames = JSON.parse(orgsResForUser).map(org => org.login);
+    const orgsForUserRes = await fetch('https://api.github.com/user/orgs', {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+
+      }
+    });
+    const orgsForUser = await orgsForUserRes.json();
+    const orgNames = orgsForUser.map(org => org.login);
     storeCurrentUsersOrganizations(orgNames);
-    storeCurrentUser(userRes);
+    storeCurrentUser(JSON.stringify(userData));
   }
 
   logout () {

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -106,7 +106,7 @@ class UserFlapModel extends ViewModel {
 
   async login () {
     if ($world.get('github login prompt')) return;
-    let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,workflow' https://github.com/login/device/code`;
+    let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,delete_repo,workflow' https://github.com/login/device/code`;
     const { stdout: resOne } = await runCommand(cmdString).whenDone();
     if (resOne === '') {
       $world.setStatusMessage('You seem to be offline.', StatusMessageError);

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -11,6 +11,7 @@ import { rect } from 'lively.graphics/geometry-2d.js';
 import { waitFor, delay, timeToRun } from 'lively.lang/promise.js';
 import { DarkPrompt, ConfirmPrompt } from 'lively.components/prompts.cp.js';
 import { SystemButton } from 'lively.components/buttons.cp.js';
+import { promise } from 'lively.lang';
 
 const livelyAuthGithubAppId = 'd523a69022b9ef6be515';
 
@@ -41,7 +42,7 @@ const CompactConfirmPrompt = component(ConfirmPrompt, {
   }]
 });
 
-class UserFlapModel extends ViewModel {
+export class UserFlapModel extends ViewModel {
   static get properties () {
     return {
       withLoginButton: {
@@ -85,7 +86,10 @@ class UserFlapModel extends ViewModel {
   }
 
   async viewDidLoad () {
+    this.view.opacity = 0;
     const { loginButton, leftUserLabel, rightUserLabel, avatar } = this.ui;
+    await leftUserLabel.whenFontLoaded();
+    await rightUserLabel.whenFontLoaded();
     if (!isUserLoggedIn()) {
       if (this.withLoginButton) {
         avatar.visible = false;
@@ -102,6 +106,7 @@ class UserFlapModel extends ViewModel {
       rightUserLabel.nativeCursor = 'pointer';
       leftUserLabel.nativeCursor = 'auto';
     }
+    promise.delay(100).then(() => this.view.animate({ opacity: 1, duration: 300 }));
   }
 
   async login () {


### PR DESCRIPTION
This adds the possibility to delete the remote of a lively project as well, once the project gets deleted.
As currently the only place to delete projects is on the landing page and one needs to authenticate with GitHub to delete a repository, this meant including the user flap on the landing page once more. In order to use `$world.inform` as part of the login process, we needed to adjust the `WORLD_CLASS` of the landing page.