### PR TITLE
Update Tokens in remoteURLs upon loading of Project

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -223,11 +223,15 @@ export class Project {
       loadedProject.gitResource = await resource('git/' + await defaultDirectory()).join('..').join('local_projects').join(fullName).withRelativePartsResolved().asDirectory();
       if (await loadedProject.gitResource.hasRemote()) {
           const remoteURL = await loadedProject.gitResource.getRemote();
-          const userTokenInRemoteURL = remoteURL.match(/(gho_.*)@/)[1];
-          if (userTokenInRemoteURL !== currentUserToken()) {
+          let remoteURLUserTokenMatch = remoteURL.match(/(gho_.*)@/);
+          let userTokenInRemoteURL;
+          const currUserToken = currentUserToken();
+          // This should always be the case, just be defensive here to minimize the potential for crashes.
+          if (remoteURLUserTokenMatch) userTokenInRemoteURL = remoteURLUserTokenMatch[1];
+          if (currUserToken && userTokenInRemoteURL && (userTokenInRemoteURL !== currUserToken)) {
             const repoOwner = fullName.replace(/--.*/, '');
             const name = fullName.replace(/.*--/, '');
-            await loadedProject.gitResource.changeRemoteURLToUseCurrentToken(currentUserToken(), repoOwner, name);
+            await loadedProject.gitResource.changeRemoteURLToUseCurrentToken(currUserToken, repoOwner, name);
           }
       }
       // Ensure that we do not run into conflicts regarding the bound lively version.


### PR DESCRIPTION
GitHub does only grant 10 tokens per oAuth-App/User combination. One gets a new token every time one logs in. This means, that after 10 login-logouts in lively, projects that still have an old token baked into their URL wont work anymore, as the token is revoked.
To mitigate this problem, we just always bake the currently logged in token into all remote urls once a project gets loaded. **Note, that this effectively makes a local lively install/locally running lively server a single user application at the moment, and logging in with multiple accounts could have unexpected consequences.**