### PR TITLE
🐚: do not accidentally pop custom stash when updating a project

### DIFF
--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -856,6 +856,7 @@ export class ComponentBrowserModel extends ViewModel {
       const li = $world.showLoadingIndicatorFor(null, 'Updating `partsbin`');
       // This relies on the assumption, that the default directory the shell command gets dropped in is `lively.server`.
       // `install.sh` ensures that the partsbin repository exists.
+      // As users should fork the partsbin to contribute, no special precaution is taken here when stashing.
       const cmd = runCommand('cd ../local_projects/LivelyKernel--partsbin && git stash && git checkout main && git pull', { l2lClient: ShellClientResource.defaultL2lClient });
       await cmd.whenDone();
       if (cmd.exitCode !== 0) {


### PR DESCRIPTION
When one had a created a custom stash inside of a project (by using git via the command line as a programmer), that stash would be automatically popped once one pulled the latest version of the project. Now, the stash will be preserved and we only pop what we stashed ourselves.