### PR TITLE
🧰📂: sort projects by name and allow filtering by all meta data

### DIFF
--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -461,7 +461,7 @@ export class WorldBrowserModel extends ViewModel {
   }
 
   sortAndFilterPreviews (previews) {
-    return previews.filter(p => this.ui.searchField.matches(p._project?._projectName || (p._commit.name + p._commit.description)));
+    return previews.filter(p => this.ui.searchField.matches((p._project?._projectName + p._project?._projectOwner + p._project?.author?.name + p._project?.description) || (p._commit.name + p._commit.description)));
   }
 
   updateList () {

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -128,6 +128,8 @@ export class Project {
       p._projectName = p._name.replace(/.*--/, '');
       p._projectOwner = p._name.replace(/--.*/, '');
     });
+    // case-insensitive and unicode aware sorting
+    projectsCandidates.sort((a, b) => a._projectName.toLowerCase().localeCompare(b._projectName.toLowerCase()));
     return projectsCandidates;
   }
 


### PR DESCRIPTION
When I changed how the available projects are populated in #1072, this feature went under the rails: We will now sort the available projects alphabetically after their name again. I also included more keys than just the project name in the search: It is now possible to filter by projectname, projectauthor, projectowner, and description.