### PR TITLE
📂: clear project creation prompt after clone has been successful

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -133,7 +133,7 @@ export class Project {
 
   /**
    * Takes the URL for a GitHub Repository at which a lively project resides and clones the repository in the projects folder of the local lively installation.
-   * Afterwards, the cloned project gets loaded.
+   * Note, that the cloned project needs to be loaded separately.
    * @param {string} remote - The URL of the GitHub Repository.
    */
   static async fromRemote (remote) {
@@ -172,8 +172,7 @@ export class Project {
     await System.get('@lively-env').packageRegistry.addPackageAt(projectDir);
 
     li.remove();
-    const loadedProject = await Project.loadProject(`${projectRepoOwner}--${projectName}`);
-    return loadedProject;
+    return `${projectRepoOwner}--${projectName}`;
   }
 
   static async setupForkInformation (forkOwner, forkName) {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -176,8 +176,10 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
         try {
           urlString = remoteUrl.textString;
           if (urlString.endsWith('.git')) urlString = urlString.replace('.git', '');
-          createdProject = await Project.fromRemote(urlString);
-          super.resolve(createdProject);
+          const projectNameToLoad = await Project.fromRemote(urlString);
+          this.view.remove();
+          const loadedProject = await Project.loadProject(projectNameToLoad);
+          super.resolve(loadedProject)
         } catch (err) {
           this.enableButtons();
           this.view.setStatusMessage('Error fetching Project from remote.', StatusMessageError);


### PR DESCRIPTION
Previously, the `ProjectCreationPrompt` was visible for a very long time when initializing a project from a remote, resulting in a confusing user experience. Now, the prompt disappears once the clone was successful and the loading indicator for the loading of the project takes over. This is more consistent with the way it happens when creating a local project as well. 