### PR TITLE
Add Offline Mode

### DIFF
--- a/lively.components/toggle.cp.js
+++ b/lively.components/toggle.cp.js
@@ -1,0 +1,135 @@
+import { component, ViewModel, part } from 'lively.morphic/components/core.js';
+import { Color } from 'lively.graphics/color.js';
+import { pt, rect, Rectangle } from 'lively.graphics/geometry-2d.js';
+import { TilingLayout } from 'lively.morphic/layout.js';
+import { TopBarButton, TopBarButtonSelected, TopBarButtonUnselected } from 'lively.ide/studio/top-bar-buttons.cp.js';
+import { Icon } from 'lively.morphic';
+import { signal } from 'lively.bindings';
+
+class ToggleModel extends ViewModel {
+  static get properties () {
+    return {
+      active: {
+        defaultValue: false
+      },
+      iconInactive: {
+        defaultValue: 'skull'
+      },
+      iconActive: {
+        defaultValue: 'dragon'
+      },
+      labelActive: {
+        defaultValue: 'label active'
+      },
+      labelInactive: {
+        defaultValue: 'label inactive'
+      },
+      tooltip: { },
+      expose: {
+        get () {
+          return ['active', 'tooltip'];
+        }
+      },
+      bindings: {
+        get () {
+          return [
+            { signal: 'onMouseDown', handler: 'toggle' }
+          ];
+        }
+      }
+    };
+  }
+
+  toggle () {
+    this.active = !this.active;
+    signal(this.view, 'toggeled', this.active);
+  }
+
+  onRefresh () {
+    const { toggleIndicator, label, icon } = this.ui;
+    if (this.active) {
+      label.master.setState('selected');
+      icon.master.setState('selected');
+      toggleIndicator.master.setState('selected');
+    } else {
+      label.master.setState(null);
+      icon.master.setState(null);
+      toggleIndicator.master.setState(null);
+    }
+
+    toggleIndicator.textAndAttributes = Icon.textAttribute(this.active ? 'toggle-on' : 'toggle-off');
+    icon.textAndAttributes = Icon.textAttribute(this.active ? this.iconActive : this.iconInactive);
+    label.textString = this.active ? this.labelActive : this.labelInactive;
+    this.view.tooltip = this.tooltip;
+  }
+}
+
+export const Toggle = component({
+  defaultViewModel: ToggleModel,
+  name: 'fast load toggler',
+  borderColor: Color.rgb(23, 160, 251),
+  extent: pt(115.3, 41.1),
+  fill: Color.rgba(0, 0, 0, 0),
+  layout: new TilingLayout({
+    axisAlign: 'center',
+    align: 'center',
+    direction: 'rightToLeft',
+    hugContentsHorizontally: true,
+    orderByIndex: true,
+    padding: Rectangle.inset(5, 5, 0, 5),
+    reactToSubmorphAnimations: false,
+    renderViaCSS: true,
+    spacing: 5
+  }),
+  submorphs: [
+    part(TopBarButton, {
+      name: 'icon',
+      fontSize: 16,
+      padding: rect(0, 4, 0, -4),
+      textAndAttributes: Icon.textAttribute('dragon')
+    }), part(TopBarButton, {
+      name: 'label',
+      fontSize: 16,
+      textAndAttributes: ['Fast Load', null]
+    }), part(TopBarButton, {
+      name: 'toggle indicator',
+      fontSize: 23,
+      nativeCursor: 'pointer',
+      textAndAttributes: Icon.textAttribute('toggle-off')
+    })]
+});
+
+const TopBarButtonUnselectedLight = component(TopBarButtonUnselected, {
+  fontColor: Color.white
+});
+
+const TopBarButtonSelectedLight = component(TopBarButtonSelected, {
+  fontColor: Color.rgb(99, 207, 255)
+});
+
+const TopBarButtonLight = component(TopBarButtonUnselectedLight, {
+  master: {
+    states: {
+      selected: TopBarButtonSelectedLight
+    }
+  }
+});
+
+export const LightToggle = component(Toggle, {
+  submorphs: [
+    {
+      name: 'icon',
+      fontSize: 16,
+      master: TopBarButtonLight
+    },
+    {
+      name: 'label',
+      fontSize: 16,
+      master: TopBarButtonLight
+    },
+    {
+      name: 'toggle indicator',
+      master: TopBarButtonLight
+    }
+  ]
+});

--- a/lively.components/toggle.cp.js
+++ b/lively.components/toggle.cp.js
@@ -6,7 +6,7 @@ import { TopBarButton, TopBarButtonSelected, TopBarButtonUnselected } from 'live
 import { Icon } from 'lively.morphic';
 import { signal } from 'lively.bindings';
 
-class ToggleModel extends ViewModel {
+export class ToggleModel extends ViewModel {
   static get properties () {
     return {
       active: {

--- a/lively.freezer/src/landing-page.cp.js
+++ b/lively.freezer/src/landing-page.cp.js
@@ -11,7 +11,11 @@ import { connect } from 'lively.bindings';
 
 // this pulls in a bunch of code
 import { WorldBrowser } from 'lively.ide/studio/world-browser.cp.js';
-import { UserFlap, UserFlapModel } from 'lively.user/user-flap.cp.js';
+import { UserFlap } from 'lively.user/user-flap.cp.js';
+import { ViewModel } from 'lively.morphic/components/core.js';
+
+import { TilingLayout } from 'lively.morphic/layout.js';
+import { OfflineToggleLight } from 'lively.ide/offline-mode-toggle.cp.js';
 
 class LandingPageWorld extends LivelyWorld {
   showHaloFor () {
@@ -320,14 +324,11 @@ const LandingPage = component({
   ]
 });
 
-class WorldAligningUserFlap extends UserFlapModel {
-  get expose () {
-    return [...super.expose, 'relayout'];
-  }
-
-  async viewDidLoad () {
-    await super.viewDidLoad();
-    await this.relayout();
+class WorldAligningLandigPageUIElements extends ViewModel {
+  get bindings () {
+    return [
+      {target: 'user flap', signal: 'extent', handler: 'relayout'}
+    ]
   }
 
   async relayout () {
@@ -335,38 +336,43 @@ class WorldAligningUserFlap extends UserFlapModel {
     this.view.topRight = $world.visibleBounds().insetBy(10).topRight();
     return this.view;
   }
-
-  async showUserData () {
-    super.showUserData();
-    await this.relayout();
-  }
-
-  async showGuestUser () {
-    super.showGuestUser();
-    await this.relayout();
-  }
 }
 
-const DarkUserFlap = component(UserFlap, {
-  defaultViewModel: WorldAligningUserFlap,
-  submorphs: [{
-    name: 'left user label',
-    fontColor: Color.rgb(255, 255, 255)
-  }, {
-    name: 'right user label',
-    fontColor: Color.rgb(255, 255, 255)
-  }, {
-    name: 'spinner',
-    viewModel: { color: 'white' }
-  }]
-});
+const LandingPageUI = component(
+  {
+    name: 'landing page ui elements',
+    defaultViewModel: WorldAligningLandigPageUIElements,
+    fill: Color.transparent,
+    layout: new TilingLayout({
+      hugContentsHorizontally: true,
+      padding: 5,
+      spacing: 5,
+      axisAlign: 'center'
+    }),
+    submorphs:
+ [
+   part(OfflineToggleLight),
+   part(UserFlap, {
+     name: 'user flap',
+     submorphs: [{
+       name: 'left user label',
+       fontColor: Color.rgb(255, 255, 255)
+     }, {
+       name: 'right user label',
+       fontColor: Color.rgb(255, 255, 255)
+     }, {
+       name: 'spinner',
+       viewModel: { color: 'white' }
+     }]
+   })]
+  });
 
 export async function main () {
   config.altClickDefinesThat = false;
   config.ide.studio.canvasModeEnabled = false;
 
   part(LandingPage, { respondsToVisibleWindow: true }).openInWorld().relayout();
-  const flap = part(DarkUserFlap, { respondsToVisibleWindow: true }).openInWorld();
+  part(LandingPageUI, { respondsToVisibleWindow: true }).openInWorld();
 }
 
 export const TITLE = 'lively.next';

--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -8,6 +8,14 @@ import { Color } from 'lively.graphics/color.js';
 
 lively.modules = modulePackage; // temporary modules package used for bootstrapping
 
+Object.defineProperty(lively, 'isInOfflineMode', {
+  configurable: true,
+  get () {
+    const item = localStorage.getItem('LIVELY_OFFLINE_MODE');
+    return item == true;
+  }
+});
+
 const doBootstrap = true;
 const askBeforeQuit = true;
 const loc = document.location;
@@ -423,7 +431,7 @@ export async function bootstrap ({
           }
           if (worldName) await loadWorld(new LivelyWorld({ openNewWorldPrompt: true }), undefined, opts);
           else if (projectName === '__newProject__') await loadWorld(new LivelyWorld({ openNewProjectPrompt: true }), undefined, opts);
-          else await loadWorld(new LivelyWorld({ projectToBeOpened: projectName }), undefined, opts)
+          else await loadWorld(new LivelyWorld({ projectToBeOpened: projectName }), undefined, opts);
         } else {
           await morphic.World.loadFromDB(worldName, undefined, undefined, {
             ...opts,

--- a/lively.ide/offline-mode-toggle.cp.js
+++ b/lively.ide/offline-mode-toggle.cp.js
@@ -1,0 +1,31 @@
+import { ToggleModel, LightToggle, Toggle } from 'lively.components/toggle.cp.js';
+import { component } from 'lively.morphic/components/core.js';
+
+class OfflineToggleModel extends ToggleModel {
+  viewDidLoad () {
+    if (lively.isInOfflineMode || (localStorage.getItem('LIVELY_OFFLINE_MODE') == true)) this.active = true;
+    else this.active = false;
+  }
+
+  toggle () {
+    super.toggle();
+    localStorage.setItem('LIVELY_OFFLINE_MODE', this.active ? 1 : 0);
+    if (this.active) $world.inform('You are entering offline mode.\n Interactions with GitHub repositories are not available. You will not be able to update or upload projects.');
+  }
+}
+
+export const OfflineToggleDark = component(Toggle, {
+  name: 'offline mode toggle',
+  defaultViewModel: OfflineToggleModel,
+  viewModel: {
+    iconActive: 'mi-wifi_off',
+    iconInactive: 'mi-wifi',
+    labelActive: 'offline mode',
+    labelInactive: 'online mode',
+    tooltip: 'Toggle Offline Mode'
+  }
+});
+
+export const OfflineToggleLight = component(OfflineToggleDark, {
+  master: LightToggle
+});

--- a/lively.ide/studio/top-bar-buttons.cp.js
+++ b/lively.ide/studio/top-bar-buttons.cp.js
@@ -42,7 +42,7 @@ export const TopBarButtonUnselected = component({
   padding: rect(0, 1, 0, -1)
 });
 
-const TopBarButtonSelected = component(TopBarButtonUnselected, {
+export const TopBarButtonSelected = component(TopBarButtonUnselected, {
   dropShadow: new ShadowObject({ color: Color.rgba(64, 196, 255, 0.4), fast: false }),
   fontColor: Color.rgb(0, 176, 255)
 });

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -22,6 +22,8 @@ import { ProjectSettingsPrompt, RepoCreationPrompt } from 'lively.project/prompt
 import { isUserLoggedIn } from 'lively.user';
 import { AssetBrowserLight } from './asset-browser.cp.js';
 
+import { OfflineToggleDark } from '../offline-mode-toggle.cp.js';
+
 class SelectionElement extends Morph {
   static get properties () {
     return {
@@ -1011,10 +1013,20 @@ const TopBar = component({
     fill: Color.rgb(0, 0, 0),
     position: pt(0, -26)
   },
-  part(UserFlap, {
-    name: 'user flap',
-    fill: Color.transparent
-  })]
+  {
+    name: 'right UI wrapper',
+    layout: new TilingLayout({
+      axisAlign: 'center',
+      spacing: 10
+    }),
+    fill: Color.transparent,
+    submorphs: [
+      part(OfflineToggleDark),
+      part(UserFlap, {
+        name: 'user flap',
+        fill: Color.transparent
+      })]
+  }]
 });
 
 export { TopBar };

--- a/lively.ide/studio/top-bar.cp.js
+++ b/lively.ide/studio/top-bar.cp.js
@@ -287,14 +287,18 @@ export class TopBarModel extends ViewModel {
         ? [['⚙️', { fontFamily: 'Noto Emoji' }, ' Change Project Settings', null], () => {
             $world.openPrompt(part(ProjectSettingsPrompt, { viewModel: { project: $world.openedProject }, hasFixedPosition: true }));
           }]
-        : [['🌏', { fontFamily: 'Noto Emoji' }, ' Create Remote Repository', null], async () => {
+        : ([['🌏', { fontFamily: 'Noto Emoji' }, ' Create Remote Repository', null], async () => {
+            if (lively.isInOfflineMode) {
+              $world.setStatusMessage('Operation not available, as you are in offline mode!');
+              return;
+            }
             if (!isUserLoggedIn()) {
               $world.setStatusMessage('You need to log in using github.');
               $world.get('user flap').show();
               return;
             }
             $world.openPrompt(part(RepoCreationPrompt, { viewModel: { project: $world.openedProject }, hasFixedPosition: true }));
-          }],
+          }]),
       [['🧑‍💻', { fontFamily: 'Noto Emoji' }, ' Open a Terminal (advanced operation)', null], async () => {
         // This relies on the assumption, that the default directory the shell command gets dropped in is `lively.server`.
         const serverDir = await defaultDirectory();

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -85,6 +85,9 @@ class ProjectSettingsPromptModel extends AbstractPromptModel {
 
   viewDidLoad () {
     const { testCheck, buildCheck, deployCheck, testModeSelector, buildModeSelector, deployModeSelector, visibilitySelector } = this.ui;
+
+    if (lively.isInOfflineMode) visibilitySelector.enabled = false;
+
     const conf = this.project.config.lively;
 
     if (conf.repositoryIsPrivate) {
@@ -207,8 +210,10 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
   }
 
   async viewDidLoad () {
-    const { promptTitle, cancelButton, okButton, privateCheckbox } = this.ui;
+    const { promptTitle, cancelButton, okButton, privateCheckbox, createRemoteCheckbox, fromRemoteCheckbox } = this.ui;
     okButton.disable();
+    createRemoteCheckbox.disable();
+    if (lively.isInOfflineMode) fromRemoteCheckbox.disable();
     privateCheckbox.disable();
     cancelButton.disable();
     if (!currentUserToken()) {
@@ -245,8 +250,11 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
   }
 
   onLogin () {
+    const { fromRemoteCheckbox } = this.ui;
     $world.get('user flap').showLoggedInUser();
-    this.withoutBindingsDo(() => this.ui.fromRemoteCheckbox.enable());
+    this.withoutBindingsDo(() => {
+      if (!lively.isInOfflineMode) fromRemoteCheckbox.enable()
+    });
     this.projectNameMode();
   }
 
@@ -266,7 +274,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     projectName.activate();
     userSelector.enable();
     description.activate();
-    createRemoteCheckbox.enable();
+    if (!lively.isInOfflineMode) createRemoteCheckbox.enable();
     remoteUrl.deactivate();
     projectName.indicateError('required', 'only - and letters are allowed');
     // we do this here since we are sure that we are logged in when we reach this method!


### PR DESCRIPTION
This PR makes it possible to work with projects without an active internet connection. Right now, this needs to be actively enabled by the use, by toggling the offline mode either on the landing-page or in the top-bar.
Doing so will give the user some information about the restrictions in offline mode.

In offline mode, the following happens:

- When creating a new project, no github repo can be created.
- No projects can be created from a remote URL.
- Loading a project will not pull the corresponding repository.
- It is not possible to add a remote to an existing project.
- Saving a project will not push the project.
- Updated user data will not be available, but a logged in user stays logged in when toggling offline mode.
- Logging out the user while being in offline mode requires an additional confirmation, as a new login is not possible.