### PR TITLE
Fix/object editor fast load

### DIFF
--- a/lively.classes/source-descriptors.js
+++ b/lively.classes/source-descriptors.js
@@ -160,7 +160,7 @@ export class RuntimeSourceDescriptor {
     if (!obj[moduleSym]) { throw new Error('runtime object of source descriptor has no module data'); }
 
     let { package: { name: pName }, pathInPackage: mName } = obj[moduleSym];
-    let mId = mName.includes('://') ? mName : pName + '/' + mName;
+    let mId = mName.includes('://') ? mName : string.joinPath(pName, mName);
     let m = this.System._scripting.module(System, mId);
 
     if (!m._frozenModule && !m._source && this.moduleSource) {
@@ -271,6 +271,7 @@ export class RuntimeSourceDescriptor {
 
   async changeSource (newSource) {
     let { module } = this;
+    if (module._frozenModule) await module.revive();
     await module.changeSourceAction(oldSource => {
       if (oldSource !== this.moduleSource) {
         throw new Error(`source of module ${module.id} and source of ${this} don't match`);

--- a/lively.freezer/src/plugins/rollup.js
+++ b/lively.freezer/src/plugins/rollup.js
@@ -82,13 +82,14 @@ export function lively (args) {
         opts.shimMissingExports = true; // since we are asked to exclude some of the lively modules, we set this flag to true. Can we isolate this??
       }
       if (!opts.onwarn) opts.onwarn = (warning, warn) => { return customWarn(warning, warn, bundler); };
+      const self = opts.plugins.find(plugin => plugin.name === 'rollup-plugin-lively');
       opts.plugins = [
-        ...bundler.resolver.supportingPlugins(bundler.asBrowserModule ? 'browser' : 'node'),
-        ...opts.plugins
+        ...bundler.resolver.supportingPlugins(bundler.asBrowserModule ? 'browser' : 'node', self),
+        ...arr.without(opts.plugins, self)
       ];
       // we still need to make sure that the options are invoked
       for (let plugin of opts.plugins) {
-        if (plugin.name === 'rollup-plugin-lively') continue;
+        if (plugin === self) continue;
         if (plugin.options) opts = plugin.options.bind(this)(opts) || opts;
       }
       return opts;

--- a/lively.freezer/src/resolvers/browser.js
+++ b/lively.freezer/src/resolvers/browser.js
@@ -95,8 +95,9 @@ async function load (url) {
   return await fetchFile(url);
 }
 
-function supportingPlugins () {
+function supportingPlugins (self) {
   return [
+    self,
     commonjs({
       sourceMap: false,
       defaultIsModuleExports: true,

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -162,18 +162,7 @@ async function fetchFile (url) {
 
 async function load(url) {
   if (url === '@empty') return '';
-  // also transpile the source code if this is a js file...
-  // in the future we should restrict it to cp.js or some
-  // more general lv.js files...
-  const code = await fetchFile(url); 
-  if (url.endsWith('.js') || url.endsWith('.cjs'))
-    return babel.transform(code, {
-      plugins: [
-        require('@babel/plugin-proposal-class-properties')
-      ]
-      // systemjs transform is not really needed
-    }).code;
-  return code;
+  return  await fetchFile(url); 
 }
 
 function supportingPlugins(context = 'node') {

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -165,7 +165,7 @@ async function load(url) {
   return  await fetchFile(url); 
 }
 
-function supportingPlugins(context = 'node') {
+function supportingPlugins(context = 'node', self) {
   return [
     context == 'node' && {
       name: 'system-require-handler',
@@ -215,17 +215,18 @@ function supportingPlugins(context = 'node') {
         }
       }
     },
-    context == 'browser' && nodePolyfills(), // only if we bundle for the browser  
+    context == 'browser' && nodePolyfills(), // only if we bundle for the browser
     commonjs({
       sourceMap: false,
       defaultIsModuleExports: true,
       transformMixedEsModules: true,
       dynamicRequireRoot: process.env.lv_next_dir,
-      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js'],
+      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /lively./],
       dynamicRequireTargets: [
          resolveModuleId('babel-plugin-transform-es2015-modules-systemjs')
       ]
-    })
+    }),
+    self,
   ].filter(Boolean);
 }
 

--- a/lively.ide/js/objecteditor/index.js
+++ b/lively.ide/js/objecteditor/index.js
@@ -1025,8 +1025,6 @@ export class ObjectEditorModel extends ViewModel {
     const { ui: { sourceEditor } } = this;
     if (await this.withContextDo((ctx) => !ctx.selectedClass)) { return { success: false, reason: 'No class selected' }; }
 
-    if (await this.withContextDo((ctx) => ctx.selectedModule._frozenModule)) { return { success: false, reason: 'Frozen modules can not be altered' }; }
-
     // Ask user what to do with undeclared variables. If this gets canceled we
     // abort the save
     if (config.objectEditor.fixUndeclaredVarsOnSave) {


### PR DESCRIPTION
Fixes two things:
 - [x] Make object editor work again in fast loaded environments: Closes #1115.
 - [x] Fixes reviving of modules that are deferred loaded: e.g. part of the bundle is loaded after the initial reviving causing left over modules not to be revived on time.