### PR TITLE
👤: display current user data when no updated user data is retrieved

### DIFF
--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -126,6 +126,7 @@ export class UserFlapModel extends ViewModel {
       }
     } else {
       if (!lively.isInOfflineMode) await this.update();
+      else this.showLoggedInUser();
       leftUserLabel.tooltip = '';
       rightUserLabel.tooltip = 'Logout';
       rightUserLabel.nativeCursor = 'pointer';


### PR DESCRIPTION
This was an oversight in #1095, resulting in the user flap not showing the correct user data, even though that existed.