### PR TITLE
🛠️: fix inconsistencies in `update.sh` between different platforms

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -30,6 +30,6 @@ echo "🔁 Restart lively.next server."
 # 2. Clean up the output (spaces instead of tabs).
 # 3. `grep` for `start.sh` and discard unecessary lines.
 # 4. Extract the PGID from the remaining information. Since macOS output and linux output differ in whitespace, 🫓 that shit with xargs.
-kill -TERM "-$(ps -ax -o pgid,command | tr -s " " | grep -E "PGID|start.sh" | sed -n 2p | xargs | cut -d " " -f 1)"
+kill -TERM "-$(ps -ax -o pgid,command | tr -s " " | grep -E "PGID|start.sh" | grep -v "grep" | sed -n 2p | xargs | cut -d " " -f 1)"
 
 echo "✅ lively.next has been updated!"


### PR DESCRIPTION
@merryman recently reported that the updating script did not work on his macOS system and there seemed to be a problem for some windows (WSL) users as well.

The problem was that the previous version of this script implicitly assumed a specific ordering of the output lines, which were not guaranteed. This was necessary in the first place, as at runtime of the command, the `grep` process itself as well as the shell process executing the whole command will show up in the output of the initial command.

By filtering those out, we guarantee the output at this point to only have two lines, which will make us resilient against any differences in ordering behavior between different platforms/implementations. 