### PR TITLE
❄️: expose `relayout` on landing page

### DIFF
--- a/lively.freezer/src/landing-page.cp.js
+++ b/lively.freezer/src/landing-page.cp.js
@@ -325,6 +325,10 @@ const LandingPage = component({
 });
 
 class WorldAligningLandigPageUIElements extends ViewModel {
+  get expose () {
+    return ['relayout'];
+  }
+
   get bindings () {
     return [
       {target: 'user flap', signal: 'extent', handler: 'relayout'}


### PR DESCRIPTION
This is not yet a really solid relayout routine, but this at least fixes an error that appeared when the size of the window was changed on the landing-page, as it has `reactsToVisibleWindow` set to true which warrants a `relayout` function.