### PR TITLE
🚨 Fix crash at initial population of esm_cache

### DIFF
--- a/.github/workflows/check-deploy-docs.yml
+++ b/.github/workflows/check-deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup `node`
       uses: actions/setup-node@v3
       with:
-        node-version: '18.12.1'
+        node-version: '20.10'
     - name: Install `jsdoc`
       run: npm install -g jsdoc@3.6.7
     - name: Install `jsdoc` theme

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Cache `lively.next` dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Install `sultan`
         run: pip3 install sultan 
       - name: Checkout repository

--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup `node`
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Cache `lively.next` dependencies
@@ -49,7 +49,7 @@ jobs:
     - name: Setup `node`
       uses: actions/setup-node@v3
       with:
-        node-version: '18.12.1'
+        node-version: '20.10'
     - name: Install `eslint`
       run: npm install eslint
     - name: Install `jsdoc` plugin for `eslint`

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup `node`
       uses: actions/setup-node@v3
       with:
-        node-version: '18.12.1'
+        node-version: '20.10'
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install `octokit`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Please note, that these instructions currently are not recommended for openly de
 Currently, MacOS, Linux, and the Linux Subsystem for Windows are supported.
 Make sure you have the following software installed:
 
-1. `node.js v18.12.1` or higher.
+1. `node.js v20.10`
 2. `git`.
+
+We try to require/support the current LTS version of `node`.
 
 > **Warning**
 > To use all features of `lively.next`, please note the following:

--- a/lively.ast/package.json
+++ b/lively.ast/package.json
@@ -58,13 +58,21 @@
   "systemjs": {
     "main": "index.js",
     "map": {
-      "escodegen": "esm://cache/escodegen@2.0.0",
-      "acorn-walk": "esm://cache/acorn-walk@8.2.0",
-      "acorn-loose": "esm://cache/acorn-loose@8.3.0",
+      "escodegen": {
+        "~node": "esm://cache/escodegen@2.0.0"
+      },
+      "acorn-walk": {
+        "~node": "esm://cache/acorn-walk@8.2.0"
+      },
+      "acorn-loose": {
+        "~node": "esm://cache/acorn-loose@8.3.0"
+      },
       "acorn": {
         "~node": "esm://cache/acorn@8.0.4"
       },
-      "esutils": "esm://cache/esutils@2.0.3",
+      "esutils": {
+        "~node": "esm://cache/esutils@2.0.3"
+      },
       "astq": {
         "~node": "esm://cache/astq@2.7.5",
         "node": "@empty"

--- a/lively.modules/src/cache.js
+++ b/lively.modules/src/cache.js
@@ -68,6 +68,7 @@ export class NodeModuleTranslationCache extends ModuleTranslationCache {
   }
 
   async fetchStoredModuleSource (moduleId) {
+    if (moduleId.endsWith('package.json')) return null;
     moduleId = moduleId.replace('file://', '');
     const fname = this.getFileName(moduleId);
     const fpath = moduleId.replace(fname, '');
@@ -80,6 +81,7 @@ export class NodeModuleTranslationCache extends ModuleTranslationCache {
   }
 
   async cacheModuleSource (moduleId, hash, source) {
+    if (moduleId.endsWith('package.json')) return;
     moduleId = moduleId.replace('file://', '');
     const fname = this.getFileName(moduleId);
     const fpath = moduleId.replace(fname, '');

--- a/lively.modules/systemjs-init.js
+++ b/lively.modules/systemjs-init.js
@@ -35,6 +35,7 @@
       const isCoreModule = !!System.loads['@node/' + args[0]];
       if (isCoreModule && !args[1].loaded && !exports.prototype) {
         exports = Object.assign(Object.create(exports.prototype || {}), exports)
+        if (!exports.default) exports.default = exports;
         exports.__esModule = true; 
       };
       return exports;

--- a/lively.project/templates/build-upload-action.js
+++ b/lively.project/templates/build-upload-action.js
@@ -14,7 +14,7 @@ jobs:
       - name: Setup \`node\`
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Restore \`lively.next\` installation
         id: cache-lively
         uses: actions/cache/restore@v3

--- a/lively.project/templates/deploy-pages-action.js
+++ b/lively.project/templates/deploy-pages-action.js
@@ -18,7 +18,7 @@ jobs:
       - name: Setup \`node\`
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Restore \`lively.next\` repo
         id: cache-lively
         uses: actions/cache/restore@v3

--- a/lively.project/templates/test-action.js
+++ b/lively.project/templates/test-action.js
@@ -14,7 +14,7 @@ jobs:
       - name: Setup \`node\`
         uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: '20.10'
       - name: Restore \`lively.next\` installation
         id: cache-lively-with-build
         uses: actions/cache/restore@v3


### PR DESCRIPTION
Fixes: #1116.
It appears the fact that we kept importing `jspm.dev` shipped version of `acorn-loose` and `acorn-walk` from the node.js context, finally took its toll and a recent change to the code that ships from `jspm.dev` wrecked havoc in the node.js runtime (namely: deleting the global Buffer object).
Whats interesting to note here, is that this error only occurs if the esm_cache does not carry a version of `acorn-loose` which makes me wonder why this error was not caught by the daily lively.next github action. I tried re-running it with a cleared cache and even that did not seem to raise the error reported in #1116. Any ideas @linusha ?