### PR TITLE
🛠️: increase default memory of `v8` to ensure build process can run

### DIFF
--- a/scripts/lively-next-flatn-env.sh
+++ b/scripts/lively-next-flatn-env.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 function lively_next_flatn_env {
+    echo "Setting V8 memory size limit to allow space for builds"
+    export NODE_OPTIONS=--max_old_space_size=4096
     lv_next_dir=$1
     echo "Setting env vars for FLATN_PACKAGE_DIRS, FLATN_PACKAGE_COLLECTION_DIRS, FLATN_DEV_PACKAGE_DIRS for lively.next"
     export PATH=$lv_next_dir/flatn/bin:$PATH


### PR DESCRIPTION
Not setting this could lead to build failures when running `make artifacts` and friends due to a heap overflow, especially on machines with little RAM.