### PR TITLE
📂: fix unsave access causing errors deleting sidebar target with halo

### DIFF
--- a/lively.ide/studio/properties-panel.cp.js
+++ b/lively.ide/studio/properties-panel.cp.js
@@ -202,7 +202,7 @@ export class PropertiesPanelModel extends ViewModel {
   }
 
   clearFocusIfRemoved () {
-    if (this.targetMorph && !this.targetMorph.owner && this.targetMorph.undoInProgress.name !== 'grab-halo') { this.clearFocus(); }
+    if (this.targetMorph && !this.targetMorph.owner && this.targetMorph.undoInProgress?.name !== 'grab-halo') { this.clearFocus(); }
   }
 
   focusOn (aMorph) {


### PR DESCRIPTION
Closes #1123.