### PR TITLE
Revert "🎨: prevent cursor from moving text when moving over wrapped line edge"

### DIFF
--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1844,7 +1844,7 @@ export default class Renderer {
       if (!morph.renderingState.animationAdded) {
         scrollLayer.scrollTop = morph.scroll.y;
         scrollLayer.scrollLeft = morph.scroll.x;
-        scrollWrapper.style.transform = `translate(${-scrollLayer.scrollLeft}px, ${-scrollLayer.scrollTop}px)`;
+        scrollWrapper.style.transform = `translate(${-morph.scroll.x}px, ${-morph.scroll.y}px)`;
         morph.renderingState.scroll = morph.scroll;
         this.renderTextAndAttributes(node, morph);
       }


### PR DESCRIPTION
This reverts commit 5d1bcd7c5fce5e5122e6b6f30b879dcfec523c9e.

Somehow, the issue of left-to-right-wiggling text in wrapped lines could not be reproduced anymore. However, our change lead to the text not updating correctly the transform on the `scrollWrapper` when navigating a file via the muller columns of the system browser.