### PR TITLE
🧰: properly parametrize number widgets

### DIFF
--- a/lively.ide/studio/controls/border.cp.js
+++ b/lively.ide/studio/controls/border.cp.js
@@ -361,10 +361,10 @@ const BorderControlElements = component({
       spacing: 10
     }),
     submorphs: [part(DarkNumberIconWidget, {
-      tooltip: 'Border Width',
       name: 'border width input',
+      viewModel: { min: 0 },
+      tooltip: 'Border Width',
       extent: pt(90, 22),
-      min: 0,
       submorphs: [{
         name: 'interactive label',
         textAndAttributes: ['', {
@@ -518,7 +518,6 @@ const BorderControl = component(PropertySection, {
         submorphs: [{
           name: 'border width input',
           extent: pt(59.9, 22),
-          min: 0,
           tooltip: 'Border Width',
           submorphs: [{
             name: 'value',

--- a/lively.ide/studio/controls/layout.cp.js
+++ b/lively.ide/studio/controls/layout.cp.js
@@ -330,7 +330,6 @@ const PaddingInput = component(DarkNumberIconWidget, {
     without('interactive label'), {
       name: 'value',
       textAlign: 'center',
-      min: 0,
       padding: rect(0, 2, 0, -2)
     }]
 });
@@ -497,7 +496,7 @@ const LayoutControl = component(PropertySection, {
       part(DarkNumberIconWidget, {
         name: 'spacing input',
         width: 60,
-        min: 0,
+        viewModel: { min: 0 },
         tooltip: 'Spacing between Items',
         submorphs: [{
           name: 'interactive label',
@@ -509,7 +508,7 @@ const LayoutControl = component(PropertySection, {
       part(DarkNumberIconWidget, {
         name: 'total padding input',
         width: 60,
-        min: 0,
+        viewModel: { min: 0 },
         tooltip: 'Padding between Container and Items',
         submorphs: [{
           name: 'interactive label',

--- a/lively.ide/studio/controls/popups.cp.js
+++ b/lively.ide/studio/controls/popups.cp.js
@@ -540,7 +540,7 @@ const NumberWidgetLight = component(DefaultNumberWidget, {
   dropShadow: null,
   submorphs: [
     { name: 'value', fontColor: Color.black, cursorColor: Color.gray, fontSize: 14 },
-    { name: 'button holder', visible: false }
+    without('button holder')
   ]
 });
 
@@ -566,7 +566,7 @@ const NumberPopupLight = component(PopupWindow, {
     fill: Color.rgba(0, 0, 0, 0),
     submorphs: [part(NumberWidgetLight, {
       name: 'value input',
-      min: 0,
+      viewModel: { min: 0 },
       position: pt(11.3, 14),
       submorphs: [{
         name: 'interactive label',
@@ -783,8 +783,10 @@ export const PaddingControlsLight = component({
   submorphs: [
     part(NumberWidgetLight, {
       name: 'padding all',
-      min: 0,
-      number: 0,
+      viewModel: {
+        min: 0,
+        number: 0
+      },
       extent: pt(60, 22),
       position: pt(9.7, 6.6),
       tooltip: 'Padding',
@@ -843,7 +845,7 @@ export const PaddingControlsLight = component({
         },
         part(NumberWidgetLight, {
           name: 'padding left',
-          min: 0,
+          viewModel: { min: 0 },
           extent: pt(35, 22),
           tooltip: 'Leftside Padding',
           borderRadiusTopRight: 0,


### PR DESCRIPTION
Fixes the broken guarding of values in a lot of the number controls in the side bar.
This was due to a botched migration of the number widgets to a view model implementation, where we forgot to adjust the parametrization like this: `..., viewModel: {...} `