### PR TITLE
🎨: ensure custom tween changes are recorded in animations

### DIFF
--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -432,7 +432,10 @@ export class PropertyAnimation {
           this.morph.withMetaDo({ metaInteraction: true }, () => {
             customTween(easingFn(p));
           }));
-        if (p >= 1) return this.finish('css');
+        if (p >= 1) {
+          customTween(easingFn(1));
+          return this.finish('css');
+        }
         requestAnimationFrame(draw);
       };
       requestAnimationFrame(draw);


### PR DESCRIPTION
Animations that would use a `customTween` (both internally and by explicit parametrization) would not cause their changes to be registered as overrides in the style policies. This lead to funky behavior such as buttons disappearing (as can be witnessed in the inspector right now).