### PR TITLE
❄️: extract lively.collab in bootstrap

### DIFF
--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -148,6 +148,9 @@ async function fastLoadPackages (progress) {
   await System.import('lively.project');
   extractModules('lively.project');
 
+  await System.import('lively.collab');
+  extractModules('lively.collab');
+
   // lively.freezer
   await System.import('lively.freezer');
   extractModules('lively.freezer');


### PR DESCRIPTION
Previously, `lively.collab` would not get properly *extracted* during the bootstrap process, leading to broken reviving issues.