### PR TITLE
🎀: do not signal falsy objects

### DIFF
--- a/lively.bindings/index.js
+++ b/lively.bindings/index.js
@@ -568,6 +568,7 @@ function once (sourceObj, attrName, targetObj, targetMethodName, spec) {
 }
 
 function signal (sourceObj, attrName, newVal) {
+  if (!sourceObj) return;
   const connections = sourceObj.attributeConnections;
   if (!connections) return;
   const oldVal = sourceObj[attrName];


### PR DESCRIPTION
Currently the right hand side bar can not be opened any more, since some code tries to signal `null`.
I thought that instead of adding defensive checks for any instances of `signal(obj, ...)` we just make `signal()` itself resilient towards falsy objects getting passed to it.