### PR TITLE
🛠️: circumvent buggy github action summary by building it manually

### DIFF
--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -41,24 +41,64 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
       - name: Run CI Test Script
         run:  ./scripts/test.sh
+      - name: Circumvent buggy behavior of GHA Job Summaries
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_output
+          path: test_output_clean.md
+          retention-days: 1
   docs-coverage:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Setup `node`
-      uses: actions/setup-node@v3
-      with:
-        node-version: '20.10'
-    - name: Install `eslint`
-      run: npm install eslint
-    - name: Install `jsdoc` plugin for `eslint`
-      run: npm install eslint-plugin-jsdoc
-    - name: Install `eslint` parser for `babel`
-      run: npm install @babel/eslint-parser
-    - name: Setup GitHub Action Summary
-      run: |
-        echo '# Status of Documentation <g-emoji class="g-emoji" alias="books" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f4da.png"><img class="emoji" alt="books" src="https://github.githubassets.com/images/icons/emoji/unicode/1f4da.png" width="20" height="20"></g-emoji>' >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-    - name: Lint Code and Summarize Number of Errors
-      run: npx eslint -c .eslintrc.js lively.*/*.js | grep '✖' >> $GITHUB_STEP_SUMMARY
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup `node`
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.10'
+      - name: Install `eslint`
+        run: npm install eslint
+      - name: Install `jsdoc` plugin for `eslint`
+        run: npm install eslint-plugin-jsdoc
+      - name: Install `eslint` parser for `babel`
+        run: npm install @babel/eslint-parser
+      - name: Setup GitHub Action Summary
+        run: |
+          echo '' >> docs_output.md
+          echo '---' >> docs_output.md
+          echo '# Status of Documentation <g-emoji class="g-emoji" alias="books" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f4da.png"><img class="emoji" alt="books" src="https://github.githubassets.com/images/icons/emoji/unicode/1f4da.png" width="20" height="20"></g-emoji>' >> docs_output.md
+      - name: Lint Code and Summarize Number of Errors
+        run: npx eslint -c .eslintrc.js lively.*/*.js | grep '✖' >> docs_output.md
+      - name: Circumvent buggy behavior of GHA Job Summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs_output
+          path: docs_output.md
+          retention-days: 1
+  summary:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [docs-coverage, tests]
+    steps:
+      - name: Download Test Output Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          name: test_output
+      - name: Download Docs Output Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          name: docs_output
+      - name: Assemble Summary
+        run: |
+          cat test_output_clean.md >> $GITHUB_STEP_SUMMARY
+          cat docs_output.md >> $GITHUB_STEP_SUMMARY
+      - name: Delete all Artifacts
+        uses: geekyeggo/delete-artifact@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: |
+            docs_output
+            test_output

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -4,9 +4,9 @@ The script assumes that a lively server is running locally on port 9011.
 This script gets used by `test.sh`. To invoke tests, run `test.sh`.
 You should rarely (never) want to invoke this script here directly.
 
-This script suppots two "modes" of running tests, running them locally or inside of a GitHub Action.
+This script supports two "modes" of running tests, running them locally or inside of a GitHub Action.
 In the latter case, we use some special formatting hints for actions in our output and provide a markdown summary of failing tests
-to be rendered by GitHub.
+to be rendered by GitHub in a file called `test_output.md`. Otherwise, information is logged only to the console.
 Since this script gets called by another shell script, that we need to run further, even if a test fails in here, we communicate some
 summary statistics and other information in the form of text files, that then get used in the outer shell script.
 */
@@ -21,8 +21,7 @@ let passed = 0; let failed = 0; let skipped = 0;
 let markdownListOfFailingTests = '';
 
 if (CI) {
-  console.log(`::notice:: Tests for ${targetPackage} 📦`);
-  fs.appendFileSync('summary.txt', `### Tests for ${targetPackage} 📦\n`);
+  console.log(`Running Tests for ${targetPackage} 📦`);
 } else {
   console.log(`ℹ️ Tests for ${targetPackage} 📦`);
   console.log('');
@@ -44,8 +43,7 @@ const req = http.request(options, res => {
       data = JSON.parse(data);
       if (!Object.keys(data).length) {
         if (CI) {
-          console.log(`::notice:: ${targetPackage} does not contain any tests\n`);
-          fs.appendFileSync('summary.txt', `ℹ️ ${targetPackage} does not contain any tests.\n`);
+          console.log(`ℹ️ ${targetPackage} does not contain any tests\n`);
         } else {
           console.log(`ℹ️ ${targetPackage} does not contain any tests`);
         }
@@ -101,7 +99,7 @@ const req = http.request(options, res => {
           } else {
             failed += 1;
             if (CI) {
-              console.log(`::error:: ${test.fullTitle} failed ❌`);
+              console.log(`${test.fullTitle} failed ❌`);
               markdownListOfFailingTests = markdownListOfFailingTests + `- ${test.fullTitle} failed ❌\n`;
             } else {
               console.log(`${test.fullTitle} failed ❌`);
@@ -112,20 +110,17 @@ const req = http.request(options, res => {
         else console.log('');
       });
         console.log(`SUMMARY-passed:${passed}`);
-        if (CI) fs.appendFileSync('summary.txt', `✅ ${passed} tests passed\n`);
         console.log(`SUMMARY-skipped:${skipped}`);
-        if (CI) fs.appendFileSync('summary.txt', `⏩ ${skipped} tests skipped\n`);
         console.log(`SUMMARY-failed:${failed}`);
-        if (CI) fs.appendFileSync('summary.txt', `❌ ${failed} tests failed\n`);
         if (CI && markdownListOfFailingTests !== '') {
-          const firstLineOfSummary = `While running the tests for ${targetPackage}, the following ${failed} test(s) failed:\n`;
+          const firstLineOfSummary = `\n---\nWhile running the tests for **${targetPackage}**, the following ${failed} test(s) failed:\n`;
           fs.appendFileSync('failing.txt', firstLineOfSummary);
           fs.appendFileSync('failing.txt', markdownListOfFailingTests);
         }
     } catch (err) {
       if (CI) {
         console.log(`::error:: Running the tests produced the following error:\n"${err}"`);
-        fs.appendFileSync('summary.txt', `❌ Running the tests produced the following error:\n"${err}"\n`);
+        fs.appendFileSync('test_output.md', `\n---\n❌ Running the tests for **${targetPackage}** produced the following error:\n"${err}"\n`);
       } else {
         console.log(`❌ Running the tests produced the following error:\n"${err}"`);
       }
@@ -137,7 +132,7 @@ const req = http.request(options, res => {
 req.on('error', err => {
   if (CI) {
     console.log(`::error:: Error while trying to get the results of tests for ${targetPackage}`);
-    fs.appendFileSync('summary.txt', `❌ Error while trying to get the results of tests for ${targetPackage}\n`);
+    fs.appendFileSync('test_output.md', `❌ Error while trying to get the results of tests for ${targetPackage}\n`);
   }
   else console.log(`❌ Error while trying to get the results of tests for ${targetPackage}`);
   console.log(err);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,9 +5,8 @@
 # It is not possible to run multiple explicitly specified packages (except when modifying the below array).
 # As this script supports either running locally or inside of a GitHub Action environment, this leaves us with four cases:
 # (1) Testing the lively core a) in CI b) locally or (1) Testing one specific package a) in CI or b) locally.
-# In case (1), we provicde some summary statistics at the end of our test run.
+# In case (1), we provicde some summary statistics at the end of our test run and put them, as well as further information in markdown format, in a file called `test_output_clean.md` for later consumption.
 # In the cases a) we add some GitHub Actions output formatting hints as well as providing markdown to be rendered in the summary section of the action run.
-# See https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/ for further information.
 # In cases b), we provide more lean, human readable output meant for reading consumtion in a shell. 
 # For Linux systems, this script requires `ss` to run. On Mac, netstat is required instead.
 # On mac, make sure to have `gsed` installed.
@@ -56,7 +55,7 @@ then
 else
   if [ "$CI" ];
   then
-    echo '# Tests for `lively.next` 🧪' >> "$GITHUB_STEP_SUMMARY"
+    echo '# Tests for `lively.next` 🧪' >>  test_output.md
   fi
 fi
 
@@ -146,8 +145,7 @@ then
       echo "- ✅ $GREEN_TESTS (≈$GREEN_PERCENTAGES %) passed.";
       echo "- ❌ $RED_TESTS (≈$RED_PERCENTAGES %) failed.";
       echo "- ⏩ $SKIPPED_TESTS (≈$SKIPPED_PERCENTAGES %) skipped."
-    } >> "$GITHUB_STEP_SUMMARY"
-    cat summary.txt >> "$GITHUB_STEP_SUMMARY"
+    } >> test_output.md
   else
     echo ''
     echo 'Summary Statistics'
@@ -157,21 +155,19 @@ then
     echo "- ❌ $RED_TESTS (≈$RED_PERCENTAGES %) failed."
     echo "- ⏩ $SKIPPED_TESTS (≈$SKIPPED_PERCENTAGES %) skipped."
   fi
-elif [ "$CI" ];
-  then
-  if [ -f "failing.txt" ]; then
-    cat failing.txt >> "$GITHUB_STEP_SUMMARY"
-  fi
+fi
+if [ -f "failing.txt" ]; then
+    cat failing.txt >> test_output.md
 fi
 
 if [ "$CI" ];
 then
-  sed 's/✅/<g-emoji class="g-emoji" alias="white_check_mark" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png"><img class="emoji" alt="white_check_mark" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png" width="20" height="20"><\/g-emoji>/g' "$GITHUB_STEP_SUMMARY" |
+  sed 's/✅/<g-emoji class="g-emoji" alias="white_check_mark" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png"><img class="emoji" alt="white_check_mark" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2705.png" width="20" height="20"><\/g-emoji>/g' test_output.md |
   sed 's/🧪/<g-emoji class="g-emoji" alias="test_tube" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f9ea.png"><img class="emoji" alt="test_tube" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f9ea.png" width="20" height="20"><\/g-emoji>/g' |
   sed 's/⏩/<g-emoji class="g-emoji" alias="fast_forward" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/23e9.png"><img class="emoji" alt="fast_forward" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/23e9.png" width="20" height="20"><\/g-emoji>/g' |
   sed 's/❌/<g-emoji class="g-emoji" alias="x" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/274c.png"><img class="emoji" alt="x" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/274c.png" width="20" height="20"><\/g-emoji>/g' |
   sed 's/ℹ️/<g-emoji class="g-emoji" alias="information_source" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2139.png"><img class="emoji" alt="information_source" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/2139.png" width="20" height="20"><\/g-emoji>/g' |
-  sed 's/📦/<g-emoji class="g-emoji" alias="package" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png"><img class="emoji" alt="package" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png" width="20" height="20"><\/g-emoji>/g' > "$GITHUB_STEP_SUMMARY"
+  sed 's/📦/<g-emoji class="g-emoji" alias="package" fallback-src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png"><img class="emoji" alt="package" src="https:\/\/github.githubassets.com\/images\/icons\/emoji\/unicode\/1f4e6.png" width="20" height="20"><\/g-emoji>/g' > test_output_clean.md
 fi
 
 if ((RED_TESTS > 0 || ALL_TESTS == 0)); 


### PR DESCRIPTION
This fixes #1125.

This makes it so that we construct the summary manually in a separate step, which should always work. I still believe that the previous state did not work as intended is a bug, as multiple summaries per step and job are in theory possible and should be output in order, as per the GitHub documentation.

However, while at it I discovered some half-implemented features in the scripts and cleaned that up. When running the script locally, nothing should have changed. Running the script in CI it will now output the overall stats for all tests but also a list of all failing tests. The result can be seen here: https://github.com/LivelyKernel/lively.next/actions/runs/7424378787.

---

**This was estimated with 2 hours by both of us. This PR took 4.5 hours.**