### PR TITLE
Enhancement/project name collision

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -25,7 +25,7 @@ import { generateFontFaceString } from 'lively.morphic/rendering/fonts.js';
 import { supportedImageFormats } from 'lively.ide/assets.js';
 import { evalOnServer } from 'lively.freezer/src/util/helpers.js';
 
-const repositoryOwnerAndNameRegex = /\.com\/(.+)\/(.*)/;
+export const repositoryOwnerAndNameRegex = /\.com\/(.+)\/(.*)/;
 const fontCSSWarningString = `/*\nDO NOT CHANGE THE CONTENTS OF THIS FILE!
 Its content is managed automatically by lively.next. It will automatically be loaded/bundled together with this project!\n*/\n\n`;
 export class Project {
@@ -519,8 +519,8 @@ export class Project {
 
   async regeneratePipelines () {
     if (!lively.isInOfflineMode) {
-        await this.checkPagesSupport();
-        await this.gitResource.activateGitHubPages(currentUserToken(), this.name, this.repoOwner);
+      await this.checkPagesSupport();
+      await this.gitResource.activateGitHubPages(currentUserToken(), this.name, this.repoOwner);
     }
     let pipelineFile, content;
     const livelyConfig = this.config.lively;

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -186,6 +186,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
           const projectRepoOwner = urlString.match(repositoryOwnerAndNameRegex)[1];
           const projectNameToLoad = `${projectRepoOwner}--${projectName}`;
           if (availableProjects.includes(projectNameToLoad)) {
+            li = null;
             this.enableButtons();
             this.view.setStatusMessage('Project already exists locally.', StatusMessageError);
             return;

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -186,9 +186,10 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
           const projectRepoOwner = urlString.match(repositoryOwnerAndNameRegex)[1];
           const projectNameToLoad = `${projectRepoOwner}--${projectName}`;
           if (availableProjects.includes(projectNameToLoad)) {
-            li = null;
             this.enableButtons();
-            this.view.setStatusMessage('Project already exists locally.', StatusMessageError);
+            this.view.setStatusMessage('Project already exists locally. You can open it via the Dashboard or fetch another Project from GitHub.', StatusMessageError);
+            remoteUrl.textString = '';
+            remoteUrl.clearError(); // otherwise the validity check instantly fails
             return;
           }
           this.view.remove();
@@ -208,7 +209,9 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
           li.remove();
           li = null;
           this.enableButtons();
-          this.view.setStatusMessage('Project name already taken.', StatusMessageError);
+          this.view.setStatusMessage('Project with this name already exists locally.', StatusMessageError);
+          projectName.textString = '';
+          projectName.indicateError('project name needs to be unique');
           return;
         }
 
@@ -225,7 +228,9 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
             li.remove();
             li = null;
             this.enableButtons();
-            this.view.setStatusMessage('Project already exists on GitHub.', StatusMessageError);
+            this.view.setStatusMessage('A repository with this name already exists on GitHub.', StatusMessageError);
+            projectName.textString = '';
+            projectName.indicateError('project name needs to be unique');
             return;
           }
         }


### PR DESCRIPTION
When creating a new project, we now check for name collisions and already existing local projects.
In the case that we clone a project from a remote, we check that we have not yet cloned it. When creating a new project, we check for existing local project and, in case a remote repository is to be created, for existing github repositories. This check is also performed when one tries to create the repository later via the menu item.

Closes #1107.

**This was estimated by both of us with 3h. This PR took 2h.**

