### PR TITLE
🧰: stop open widget from being removed prematurely

### DIFF
--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -385,9 +385,9 @@ export class PropertyControl extends DraggableTreeLabel {
     const inspector = tree.owner;
     const handler = async (evt) => {
       const editor = part(PaddingPopup, { hasFixedPosition: true });
-      inspector.openWidget = editor;
       editor.startPadding(target[keyString]);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
+      inspector.openWidget = editor;
       connect(editor, 'paddingChanged', (padding) => {
         target[keyString] = padding;
         node.rerender();
@@ -441,8 +441,8 @@ export class PropertyControl extends DraggableTreeLabel {
         baseFactor: widgetState.baseFactor,
         floatingPoint: widgetState.floatingPoint
       }));
-      inspector.openWidget = editor;
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
+      inspector.openWidget = editor;
       connect(editor, 'value', (num) => {
         target[keyString] = num;
         node.rerender();
@@ -465,9 +465,9 @@ export class PropertyControl extends DraggableTreeLabel {
     const handler = async (evt) => {
       // if already open, return
       const editor = part(ShadowPopup, { hasFixedPosition: true });
-      inspector.openWidget = editor;
       editor.shadowValue = target[keyString];
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
+      inspector.openWidget = editor;
       connect(editor, 'value', (shadowValue) => {
         target[keyString] = shadowValue;
         node.rerender();
@@ -484,9 +484,9 @@ export class PropertyControl extends DraggableTreeLabel {
     const inspector = tree.owner;
     const handler = async (evt) => {
       const editor = part(PositionPopupLight, { hasFixedPosition: true });
-      inspector.openWidget = editor;
       editor.setPoint(target[keyString]);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
+      inspector.openWidget = editor;
       connect(editor, 'value', (pointValue) => {
         target[keyString] = pointValue;
         node.rerender();
@@ -524,10 +524,10 @@ export class PropertyControl extends DraggableTreeLabel {
       const editor = part(ColorPicker, {
         hasFixedPosition: true
       });
-      inspector.openWidget = editor;
       editor.solidOnly = !gradientEnabled;
       editor.focusOnMorph(target, value);
       await editor.fadeIntoWorld(evt.positionIn(target.world()));
+      inspector.openWidget = editor;
       connect(editor, 'value', (fill) => {
         target[keyString] = fill;
         node.rerender();


### PR DESCRIPTION
This fixes a nasty bug which lead to widgets being positioned at the top left corner of the world. The reason for this was that the binding which closes open widgets on scroll kicked in too early, which messed up the correct fading into the world of the widget. Delaying the setting of the open widget resolves this, as then the binding cannot kick in prematurely.