### PR TITLE
🧰: fix crash for dependents with master: false

### DIFF
--- a/lively.ide/components/editor.js
+++ b/lively.ide/components/editor.js
@@ -192,7 +192,7 @@ export class InteractiveComponentDescriptor extends ComponentDescriptor {
 
   getDependants (immediate = false) {
     return $world.withAllSubmorphsSelect(m =>
-      m.master?.uses(this.stylePolicy, immediate)
+      m.master?.uses?.(this.stylePolicy, immediate)
     );
   }
 


### PR DESCRIPTION
For components where `master: false` in order to invalidate inherited styles, the `InteractiveDescriptor.getDependents()` method would crash when component modules got saved.