### PR TITLE
🎛️: expose `title` and `text` props of prompts

### DIFF
--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -28,7 +28,7 @@ export class AbstractPromptModel extends ViewModel {
       },
       expose: {
         get () {
-          return ['keybindings', 'commands', 'activate', 'isActive', 'isPrompt', 'isEpiMorph'];
+          return ['keybindings', 'commands', 'activate', 'isActive', 'isPrompt', 'isEpiMorph', 'title', 'text'];
         }
       }
     };


### PR DESCRIPTION
This is necessary for https://github.com/engageLively/galyleo-dashboard/pull/187. Also, it just makes sense to allow programmatic changes to these values and thus they need to be part of the official interface, which is given by `expose` via convention.