### PR TITLE
🧰🎛️: use `null` instead of `false` when resetting master

### DIFF
--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -966,7 +966,7 @@ const ListPrompt = component(ConfirmPrompt, {
         itemHeight: 16,
         itemPadding: undefined,
         manualItemHeight: true,
-        master: false,
+        master: null,
         multiSelect: true,
         nonSelectionFontColor: Color.rgb(204, 204, 204),
         padding: rect(7, 6, -4, -3),

--- a/lively.ide/components/editor.js
+++ b/lively.ide/components/editor.js
@@ -195,7 +195,7 @@ export class InteractiveComponentDescriptor extends ComponentDescriptor {
 
   getDependants (immediate = false) {
     return $world.withAllSubmorphsSelect(m =>
-      m.master?.uses?.(this.stylePolicy, immediate)
+      m.master?.uses(this.stylePolicy, immediate)
     );
   }
 


### PR DESCRIPTION
@merryman as discussed, this basically reverts d2623f110d5ed5175d39165efe5b12fb6af20c95. The behavior of the safe-navigation operator (`?.`) does only cancel the access on `null` and `undefined` - this lead to an access on `false`. For cleaner semantics, we exchange this usage of `false` with `null` here.