### PR TITLE
🎨❄️: improve `whenFontLoaded` performance

### DIFF
--- a/lively.freezer/src/util/load-template.html
+++ b/lively.freezer/src/util/load-template.html
@@ -9,7 +9,7 @@
   <meta http-equiv="refresh" content="0;url=noscript.html">
   </noscript>
   <title>__TITLE_TAG__</title>
-  <link type="text/css" rel="stylesheet" id="lively-font-bundle" href="assets/fonts/fonts.css">
+  <link type="text/css" rel="stylesheet" id="lively-font-bundle" href="assets/fonts/fonts.css" onload="document.LIVELY_FONTS_LOADED = true">
   <link type="text/css" rel="stylesheet" id="lively-morphic-css" href="assets/morphic.css">
   <link type="text/css" rel="stylesheet" id="lively-project-css" href="assets/bundle.css">
 

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -1086,16 +1086,11 @@ export class Text extends Morph {
 
   allFontsLoaded () {
     if (this._allFontsLoaded) return true;
-    // cache the result for as long as the font propertys are not reset
-    return this._allFontsLoaded = this.usedFonts().every(fontString => this.fontMetric.supportedFontCache.has(fontString) || document.fonts.check(fontString));
+    // cache the result for as long as the font properties are not reset
+    return this._allFontsLoaded = this.usedFonts().every(fontString => this.fontMetric.supportedFontCache.has(fontString) || (document.LIVELY_FONTS_LOADED && document.fonts.check(fontString)));
   }
 
   async whenFontLoaded () {
-    // FIXME: there seems to be a bug in the current version of chrome (120),
-    //        where fonts.check() returns true, even though the font face is still
-    //        unloaded or still loading. As a remporary measure, we will now
-    //        wait for the fonts.ready promise, which appears to fix the issues.
-    await document.fonts.ready;
     if (this.allFontsLoaded()) return true;
     const usedFonts = this.usedFonts();
     const success = await Promise.all(usedFonts.map(fontString => this.fontMetric.supportedFontCache.has(fontString) || document.fonts.load(fontString)));


### PR DESCRIPTION
If I remember our conversation about this correctly, the problem here was that we sometimes retrieved a `true` from `documents.fonts.check()` even though the font was not actually loaded yet, as the fonts CSS was not even loaded so far that the checked font was part of the `documents.fonts`.

Despite the comment I removed saying otherwise, this behavior is [not actually a bug](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/check#nonexistent_fonts) but consistent and logical behavior.

We spoke about using `check` only for fonts that are guaranteed to be part of the `FontFaceSet`. `FontFaceSet` provides a `has` method which I tried to use, but the `value` this method expects needs to be a `FontFace` object which we cannot just create on the fly based on a font name.

As we have all of the fonts that eventually become part of the `FontFaceSet` inside of the same CSS file, I opted to add an `onload` call to the loading of this file, which blocks calls to `check` as long as the CSS file is not yet fully loaded.

Again, I am not one hundred percent sure that this is what we talked about needing, but the result looked good to me.