### PR TITLE
Add OFFLINE_MODE toggle for `VersionChecker`

### DIFF
--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -201,12 +201,12 @@ class VersionChecker extends Morph {
     currentLivelyVersion = await VersionChecker.currentLivelyVersion();
     let commonAncestor;
     if (compareLatestAncestor) {
-      const findLatestMainAncestorCmd = 'git merge-base origin/main HEAD';
+      const findLatestMainAncestorCmd = `git merge-base ${lively.isInOfflineMode ? '' : 'origin'}/main HEAD`;
       ({ stdout: commonAncestor } = await runCommand(findLatestMainAncestorCmd, { cwd }).whenDone());
       commonAncestor = commonAncestor.trim();
     }
     // See https://stackoverflow.com/a/27940027 for how this works
-    if (!hashToCheckAgainst) hashToCheckAgainst = 'origin/main';
+    if (!hashToCheckAgainst) hashToCheckAgainst = `${lively.isInOfflineMode ? '' : 'origin'}/main`;
     const comparingCmd = `git rev-list --left-right --count ${hashToCheckAgainst}...${compareLatestAncestor ? commonAncestor : '@'}`;
     ({ stdout: comparison } = await runCommand(comparingCmd, { cwd }).whenDone());
     return { comparison, hash: currentLivelyVersion };

--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -69,6 +69,10 @@ class VersionChecker extends Morph {
 
   async checkVersion () {
     this.reset();
+    if (lively.isInOfflineMode){
+      this.showOffline();
+      return;
+    }
     await this.displayLivelyVersionStatus();
   }
 
@@ -295,6 +299,13 @@ class VersionChecker extends Morph {
     this.updateShownIcon('error');
   }
 
+  showOffline () {
+    const { status, copyButton } = this.ui;
+    status.value = 'Cannot check version while offline';
+    copyButton.visible = false;
+    this.updateShownIcon('offline');
+  }
+
   updateShownIcon (mode) {
     const { checking, statusIcon } = this.ui;
     switch (mode) {
@@ -320,6 +331,11 @@ class VersionChecker extends Morph {
       }
       case 'error': {
         statusIcon.textAndAttributes = Icon.textAttribute('exclamation-triangle');
+        statusIcon.fontColor = Color.rgb(231, 76, 60);
+        break;
+      }
+      case 'offline': {
+        statusIcon.textAndAttributes = Icon.textAttribute('mi-wifi_off');
         statusIcon.fontColor = Color.rgb(231, 76, 60);
         break;
       }

--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -245,8 +245,9 @@ class VersionChecker extends Morph {
   }
 
   showEven (version) {
-    const { status } = this.ui;
+    const { status, copyButton } = this.ui;
     status.value = ['Version: ', {}, `[${version}]`, { fontWeight: 'bold' }];
+    copyButton.visible = true;
     this.updateShownIcon('even');
   }
 
@@ -255,16 +256,18 @@ class VersionChecker extends Morph {
     const currentBranchCmd = 'git rev-parse --abbrev-ref HEAD';
     let currBranch = await runCommand(currentBranchCmd, { cwd }).whenDone();
     currBranch = currBranch.stdout.replace('\n', '');
-    const { status, updateButtonWrapper } = this.ui;
+    const { status, updateButtonWrapper, copyButton } = this.ui;
     if (currBranch === 'main') {
       updateButtonWrapper.visible = updateButtonWrapper.isLayoutable = true;
       status.reactsToPointer = true;
       status.nativeCursor = 'pointer';
       this.bounceUpdateButton();
       status.value = ['Press here to update!', { fontWeight: 'bold' }];
+      copyButton.visible = true;
       this.updateShownIcon('none');
     } else {
       status.value = ['Version: ', {}, `[${version}]`, { fontWeight: 'bold' }, ' (Please update!)'];
+      copyButton.visible = true;
       this.updateShownIcon('behind');
     }
   }
@@ -282,20 +285,23 @@ class VersionChecker extends Morph {
   }
 
   showAhead (version) {
-    const { status } = this.ui;
+    const { status, copyButton } = this.ui;
     status.value = ['Version: ', {}, `[${version}]`, { fontWeight: 'bold' }];
+    copyButton.visible = true;
     this.updateShownIcon('ahead');
   }
 
   showDiverged (version) {
-    const { status } = this.ui;
+    const { status, copyButton } = this.ui;
     status.value = ['Version: ', {}, `[${version}]`, { fontWeight: 'bold' }, ' (Please update!)'];
+    copyButton.visible = true;
     this.updateShownIcon('diverged');
   }
 
   showError () {
-    const { status } = this.ui;
+    const { status, copyButton } = this.ui;
     status.value = 'Error while checking';
+    copyButton.visible = false;
     this.updateShownIcon('error');
   }
 

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -237,6 +237,8 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
         }
 
         createdProject = new Project(enteredName, { author: currentUsername(), description: description.textString, repoOwner: repoOwner });
+        // TODO: We currently assume that project creation is not done in offline mode, but do nothing to actually enforce this.
+        // Once we tackle this, this code needs to be checked.
         const currentLivelyVersion = await VersionChecker.currentLivelyVersion(true);
         createdProject.config.lively.boundLivelyVersion = currentLivelyVersion;
         try {


### PR DESCRIPTION
The `VersionChecker` in the bottom left corner will now show a fitting message if lively is in offline mode and therefore possibly information regarding the status of lively will be retrieved.
Additionally, I removed the commit copy button when an error occurred.
Where possible we use the most recent local information when accessing the version information, e.g. when checking if the version of lively a project uses needs to be updated.


