### PR TITLE
🎨: fix minimap not respecting `origins` other than `pt(0,0)`

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -293,7 +293,7 @@ export class Morph {
                 const posOnCanvasOfParent = parent._positionOnCanvas;
                 const globalPositionOfParent = parent.globalPosition;
                 const ownGlobalPosition = this.globalPosition;
-                const diff = pt(globalPositionOfParent.x - ownGlobalPosition.x, globalPositionOfParent.y - ownGlobalPosition.y).scaleBy(1 / $world.scaleFactor);
+                const diff = pt(globalPositionOfParent.x - ownGlobalPosition.x, globalPositionOfParent.y - ownGlobalPosition.y).subPt(parent.origin).scaleBy(1 / $world.scaleFactor);
                 parentFound = pt(posOnCanvasOfParent.x - (diff.x), posOnCanvasOfParent.y - (diff.y));
               }
             });


### PR DESCRIPTION
https://github.com/LivelyKernel/lively.next/assets/14252419/33a2c4de-382f-4dda-86f7-c4239665fa32

Closes #983.