### PR TITLE
🧰: forcefully update font color of `BooleanControl`

### DIFF
--- a/lively.components/tree.js
+++ b/lively.components/tree.js
@@ -314,7 +314,7 @@ export class Tree extends Text {
             this.computeTreeAttributes(nodes),
             false, false);
           this.invalidateTextLayout(true, false);
-        } else if (this._lastSelectedIndex) {
+        } else if (this._lastSelectedIndex && this._lastSelectedIndex !== this.selectedIndex) {
           this.recoverOriginalLine(this._lastSelectedIndex - 1);
         }
         this.lastTreeData = this.treeData;


### PR DESCRIPTION
The boolean controls in the inspector do not update their font color anymore. This is because in the tree logic, we mess quite a bit with the renderer. This solves this problem, but is quite hacky - if it makes stuff worse, I do not know. @merryman what do you think?