### PR TITLE
🎨: fix polygon transform origin property notation

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -3418,7 +3418,7 @@ export class Path extends Morph {
 
   renderStyles (style) {
     style = obj.select(style, ['position', 'filter', 'display', 'opacity',
-      'transform', 'top', 'left', 'transformOrigin', 'cursor', 'overflow', 'order', 'will-change']);
+      'transform', 'top', 'left', 'transform-origin', 'cursor', 'overflow', 'order', 'will-change']);
     if (typeof style['will-change'] === 'undefined') delete style['will-change'];
     style.width = this.width + 'px';
     style.height = this.height + 'px';


### PR DESCRIPTION
Fixes an issue where the transform of polygon morphs would not be rendered correctly.