### PR TITLE
Fix styling and encoding selector of `ColorPicker`

### DIFF
--- a/lively.ide/studio/dark-color-picker.cp.js
+++ b/lively.ide/studio/dark-color-picker.cp.js
@@ -1,9 +1,9 @@
-import { component, TilingLayout, part } from 'lively.morphic';
+import { component, TilingLayout } from 'lively.morphic';
 import { ColorPicker } from '../styling/color-picker.cp.js';
-import { Color, pt } from 'lively.graphics';
+import { Color } from 'lively.graphics';
 import { EnumSelector, TextInput, DarkNumberIconWidget, DarkThemeList, DarkCloseButton, DarkCloseButtonHovered } from './shared.cp.js';
 import { BackendButtonDefault } from '../js/browser/ui.cp.js';
-import { InputLineDark } from 'lively.components/inputs.cp.js';
+
 import { rect } from 'lively.graphics/geometry-2d.js';
 
 const DarkColorPicker = component(ColorPicker, {

--- a/lively.ide/studio/dark-color-picker.cp.js
+++ b/lively.ide/studio/dark-color-picker.cp.js
@@ -65,6 +65,7 @@ const DarkColorPicker = component(ColorPicker, {
                 borderRadius: 0,
                 submorphs: [{
                   name: 'value',
+                  fontSize: 11,
                   fontColor: Color.rgbHex('B2EBF2')
                 }]
               },
@@ -76,14 +77,15 @@ const DarkColorPicker = component(ColorPicker, {
               }]
           }, {
             name: '3 val encoding',
+            fill: Color.rgb(189, 195, 199),
             submorphs: [{
               name: 'opacity control',
               master: DarkNumberIconWidget,
               borderRadius: 0,
               submorphs: [{
                 name: 'value',
-                fontSize: 14,
-                fontColor: Color.rgbHex('B2EBF2')
+                fontColor: Color.rgbHex('B2EBF2'),
+                fontSize: 12
               }]
             }, {
               name: 'first value',
@@ -91,8 +93,8 @@ const DarkColorPicker = component(ColorPicker, {
               borderRadius: 0,
               submorphs: [{
                 name: 'value',
-                fontSize: 14,
-                fontColor: Color.rgbHex('B2EBF2')
+                fontColor: Color.rgbHex('B2EBF2'),
+                fontSize: 12
               }]
             },
             {
@@ -101,8 +103,8 @@ const DarkColorPicker = component(ColorPicker, {
               borderRadius: 0,
               submorphs: [{
                 name: 'value',
-                fontSize: 14,
-                fontColor: Color.rgbHex('B2EBF2')
+                fontColor: Color.rgbHex('B2EBF2'),
+                fontSize: 12
               }]
             }, {
               name: 'third value',
@@ -110,8 +112,8 @@ const DarkColorPicker = component(ColorPicker, {
               borderRadius: 0,
               submorphs: [{
                 name: 'value',
-                fontSize: 14,
-                fontColor: Color.rgbHex('B2EBF2')
+                fontColor: Color.rgbHex('B2EBF2'),
+                fontSize: 12
               }]
             }]
           }, {

--- a/lively.ide/studio/dark-color-picker.cp.js
+++ b/lively.ide/studio/dark-color-picker.cp.js
@@ -8,7 +8,6 @@ import { rect } from 'lively.graphics/geometry-2d.js';
 
 const DarkColorPicker = component(ColorPicker, {
   name: 'dark color picker',
-  master: DarkColorPicker,
   borderColor: Color.rgba(112, 123, 124, 1),
   fill: Color.rgb(66, 73, 73),
   submorphs: [{

--- a/lively.ide/styling/color-picker.cp.js
+++ b/lively.ide/styling/color-picker.cp.js
@@ -144,14 +144,15 @@ const HexEncoder = component({
       },
       submorphs: [{
         name: 'value',
-        fontSize: 14
+        fontSize: 11
       },
       without('button holder')]
     }),
     part(DefaultInputLine, {
       placeholder: 'Hex Code',
       fill: Color.white,
-      name: 'hex input'
+      name: 'hex input',
+      fontColor: Color.rgb(40, 116, 166)
     })]
 });
 
@@ -159,7 +160,7 @@ const ThreeValEncoder = component({
   name: 'three val encoder',
   borderColor: Color.rgb(23, 160, 251),
   extent: pt(140, 25),
-  fill: Color.transparent,
+  fill: Color.rgb(189, 195, 199),
   layout: new TilingLayout({
     align: 'center',
     axisAlign: 'center',
@@ -168,19 +169,21 @@ const ThreeValEncoder = component({
   submorphs: [
     part(DefaultNumberWidget, {
       name: 'opacity control',
+      borderRadius: 0,
       dropShadow: false,
-      extent: pt(40, 22),
+      extent: pt(44, 22),
       viewModel: {
         max: 1,
         min: 0,
         floatingPoint: false,
         scaleFactor: 100,
         borderRadius: 0,
-        unit: '%'
+        unit: '%',
+        autofit: true
       },
       submorphs: [{
         name: 'value',
-        fontSize: 14
+        fontSize: 12
       }, without('button holder')]
     }),
     part(DefaultNumberWidget, {
@@ -192,11 +195,12 @@ const ThreeValEncoder = component({
         max: 255,
         min: 0,
         floatingPoint: false,
-        unit: ''
+        unit: '',
+        autofit: true
       },
       submorphs: [{
         name: 'value',
-        fontSize: 14
+        fontSize: 12
       }, without('button holder')]
     }),
     part(DefaultNumberWidget, {
@@ -208,11 +212,12 @@ const ThreeValEncoder = component({
         floatingPoint: false,
         max: 255,
         min: 0,
-        unit: ''
+        unit: '',
+        autofit: true
       },
       submorphs: [{
         name: 'value',
-        fontSize: 14
+        fontSize: 12
       }, without('button holder')]
     }),
     part(DefaultNumberWidget, {
@@ -224,11 +229,12 @@ const ThreeValEncoder = component({
         floatingPoint: false,
         max: 255,
         min: 0,
-        unit: ''
+        unit: '',
+        autofit: true
       },
       submorphs: [{
         name: 'value',
-        fontSize: 14
+        fontSize: 12
       }, without('button holder')]
     })]
 });
@@ -256,10 +262,11 @@ const CssEncoder = component({
   submorphs: [part(DefaultInputLine, {
     name: 'css input',
     placeholder: 'CSS color string',
-    extent: pt(140, 23),
-    padding: rect(5, 3, -5, -3)
-  })],
-  visible: false
+    extent: pt(138, 23),
+    padding: rect(5, 3, -5, -3),
+    fontColor: Color.rgb(40, 116, 166),
+    fill: Color.white,
+  })]
 });
 
 const ColorEncoder = component({

--- a/lively.ide/styling/color-picker.js
+++ b/lively.ide/styling/color-picker.js
@@ -147,7 +147,7 @@ export class ColorInputModel extends ViewModel {
   }
 
   onPickerClosedWithClick () {
-    signal(this.view, 'onPickerClosedWithClick')
+    signal(this.view, 'onPickerClosedWithClick');
     this.onPickerClosed();
   }
 
@@ -349,7 +349,7 @@ export class ColorPickerModel extends ViewModel {
   }
 
   closeWithClick () {
-    signal(this.view,  'closeWithClick');
+    signal(this.view, 'closeWithClick');
     noUpdate(() => this.close());
   }
 
@@ -452,7 +452,7 @@ export class ColorEncoderModel extends ViewModel {
           ];
           return [
             {
-              model: 'color code selector', signal: 'selection', handler: 'selectEncoding'
+              target: 'color code selector', signal: 'selection', handler: 'selectEncoding'
             },
             {
               target: 'hex input', signal: 'inputAccepted', handler: 'confirm'


### PR DESCRIPTION
Fixes the broken encoding selector in the `ColorPicker` and unifies the appearance of the encoders.

@merryman please take a look at especially two changes:

1. The `DarkColorPicker` was assigned as its own master. I believe this was totally bonkers - am I missing something here?
2. I believe the `DarkColorPicker` showcases a bug in the component system. As you can see, I had to make a lot of changes (e.g., regarding the `fontSize`) in the dark variant as well as in the light variant. As the dark variant inherits from the light one, I believe this to be bug.