### PR TITLE
🧰: prevent browser from browsing already selected module

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -1104,6 +1104,8 @@ export class BrowserModel extends ViewModel {
       range
     } = browseSpec;
 
+    if (packageName && moduleName && packageName === this.selectedPackage?.name && moduleName === this.selectedModule?.name) return;
+
     const { sourceEditor } = this.ui;
 
     await this.ensureColumnViewData();


### PR DESCRIPTION
Previously, it was possible to select the already browsed module via Alt+T, which would result in the muller columns blanking upon hitting enter. This makes it so that the entry can still be selected via Alt+T, but the `browse` method will notice that nothing is to be done and return early, rescuing the columns.