### PR TITLE
Fix interaction between loading indicators and commands

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -1497,7 +1497,7 @@ const SystemBrowser = component({
 });
 
 async function browse (browseSpec = {}, browserOrProps = {}, optSystemInterface) {
-  const browser = browserOrProps.isBrowser ? browserOrProps : part(SystemBrowser);
+  const browser = browserOrProps.isBrowser ? browserOrProps : part(SystemBrowser, browserOrProps);
   if (!browser.world()) browser.openInWindow();
   browser.env.forceUpdate();
   delete browser.state.selectedModule;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -951,9 +951,9 @@ const commands = [
       let browser;
       if (args.reuse) {
         browser = browserForFile(System.decanonicalize(fileName)) || await Browser.open();
-        browser.browse(loc);
+        await browser.browse(loc);
       } else {
-        browser = await Browser.browse(loc, { extent: pt(700, 600) });
+        browser = await Browser.browse(loc);
       }
       browser.getWindow().activate();
       return browser;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -991,12 +991,10 @@ const commands = [
           fuzzy: 'value.shortName'
         });
       const [jsModules, nonJsModules] = arr.partition(selected, ea => ea.url.match(/\.js(on)?/));
-      const { default: Browser } = await System.import('lively.ide/js/browser/index.js');
 
       await Promise.all(jsModules.map(ea => {
         const loc = { packageName: ea.package, moduleName: ea.url };
-        return Browser.browse(loc, browser, systemInterface)
-          .then(browser => browser.activate());
+        return world.execCommand('open browser', loc)
       }));
 
       if (nonJsModules.length) { await Promise.all(nonJsModules.map(({ url }) => world.execCommand('open file', { url }))); }

--- a/lively.morphic/CommandHandler.js
+++ b/lively.morphic/CommandHandler.js
@@ -85,7 +85,7 @@ export default class CommandHandler {
       console.error(`command ${name} has no exec function!`);
     }
 
-    if (this.progressIndicator) this.progressIndicator.remove();
+    if (this.progressIndicator && !command.handlesLoadingIndicator) this.progressIndicator.remove();
 
     // to not swallow errors
     if (result && typeof result.catch === 'function') {
@@ -96,7 +96,7 @@ export default class CommandHandler {
       });
       this.progressIndicator && promise.finally(result, () => this.progressIndicator.remove());
     } else {
-      this.progressIndicator && this.progressIndicator.remove();
+      this.progressIndicator && !command.handlesLoadingIndicator && this.progressIndicator.remove();
     }
 
     // handle count by repeating command


### PR DESCRIPTION
This PR started with me wanting to introduce a loading indicator while the browser is loading/setting itself up (remember, we talked about this, @merryman). While at it, I discovered that commands already allowed a `progressIndicator` to be specified and in theory automatically display this. However, for asynchronous functions, this did not work as expected, as they are removed too early. Making the whole command handling asynchronous would be an extremely intrusive change in the system, so that option was off the table.
Instead, we can access the loading indicator from within the command function and just take care of there. To do this, I introduced a new property that a command can have  `handleLoadingIndicator`.
While I was working on that part of the system anyway, I fixed some commands where I observed broken behavior.

---

@merryman another thing I observed while working on this: Initially, I additionally tried to make the browser invisible while it set itself up and then only make it visible once everything is done. Doing so has **severe** implications on the text rendering, basically making the whole system unusable as the renderer fights for each line to appear after toggling the visibility on again. Care to reproduce this? If you can observer this as well, I will add it to the list of stuff I'll compile for you regarding a text rendering overhaul. 