### PR TITLE
Fix Dropdown Tooltips

### DIFF
--- a/lively.components/list.js
+++ b/lively.components/list.js
@@ -81,7 +81,7 @@ export class ListItemMorph extends Label {
     } else if (typeof label === 'string') this.textAndAttributes = label;
     else this.textAndAttributes = label;
 
-    this.tooltip = item.tooltip || this.tooltip || this.textString;
+    this.tooltip = item.tooltip || item.textString;
     if (item.tooltip === false) this.tooltip = false;
     this.itemIndex = itemIndex;
     this.position = pos;

--- a/lively.ide/studio/controls/text.cp.js
+++ b/lively.ide/studio/controls/text.cp.js
@@ -109,7 +109,8 @@ export class RichTextControlModel extends ViewModel {
           return {
             value: font,
             string: font.name,
-            isListItem: true
+            isListItem: true,
+            tooltip: font.name
           };
         };
 


### PR DESCRIPTION
The bug could easily be observed when looking at the tooltips in the fontfamily selector after scrolling down a bit. The problem here is that at the place where we set the tooltip, we already know that we are displaying a **new** item. Reusing the tooltip from `this` is thus bound to lead to invalid values, as we need to use `item` since both are guaranteed to be different items. 