### PR TITLE
Improve UX of right-clicks

### DIFF
--- a/lively.morphic/events/EventDispatcher.js
+++ b/lively.morphic/events/EventDispatcher.js
@@ -614,6 +614,9 @@ export default class EventDispatcher {
     this.activations++;
 
     let err;
+
+    if (method === 'onMouseDown' && evt.domEvt.button === 2) evt.targetMorphs = evt.targetMorphs.filter(m => m.handleRightClickAsLeftClick);
+
     for (let j = evt.targetMorphs.length - 1; j >= 0; j--) {
       try {
         evt.targetMorphs[j][method](evt);

--- a/lively.morphic/events/EventDispatcher.js
+++ b/lively.morphic/events/EventDispatcher.js
@@ -1,4 +1,5 @@
 /* global System */
+/* eslint-disable no-use-before-define */
 import { arr, fun, Path, promise } from 'lively.lang';
 import { pt } from 'lively.graphics';
 import config from '../config.js';
@@ -86,7 +87,7 @@ const focusTargetingEvents = [
   'cut', 'copy', 'paste'
 ];
 
-const textOnlyEvents = [
+const textOnlyEvents = [ // eslint-disable-line no-unused-vars
   'input', 'compositionstart', 'compositionupdate', 'compositionend'
 ];
 
@@ -94,7 +95,7 @@ const textOnlyEvents = [
 // helpers
 
 function dragStartEvent (domEvt, dispatcher, targetMorph, state, hand, halo, layoutHalo) {
-  var evt = new Event('morphicdragstart', domEvt, dispatcher, [targetMorph], hand, halo, layoutHalo)
+  const evt = new Event('morphicdragstart', domEvt, dispatcher, [targetMorph], hand, halo, layoutHalo)
     .onDispatch(() => {
       state.draggedMorph = targetMorph;
       state.dragStartMorphPosition = targetMorph.position;
@@ -111,7 +112,7 @@ function dragStartEvent (domEvt, dispatcher, targetMorph, state, hand, halo, lay
 }
 
 function dragEvent (domEvt, dispatcher, targetMorph, state, hand, halo, layoutHalo) {
-  var evt = new Event('morphicdrag', domEvt, dispatcher, [state.draggedMorph], hand, halo, layoutHalo)
+  const evt = new Event('morphicdrag', domEvt, dispatcher, [state.draggedMorph], hand, halo, layoutHalo)
     .onDispatch(() => {
       state.dragDelta = (state.draggedMorph.owner || dispatcher.world)
         .getInverseTransform()
@@ -130,7 +131,7 @@ function dragEvent (domEvt, dispatcher, targetMorph, state, hand, halo, layoutHa
 
 function dragEndEvent (domEvt, dispatcher, targetMorph, state, hand, halo, layoutHalo) {
   const ctx = state.draggedMorph || targetMorph;
-  var evt = new Event('morphicdragend', domEvt, dispatcher, [ctx], hand, halo, layoutHalo)
+  const evt = new Event('morphicdragend', domEvt, dispatcher, [ctx], hand, halo, layoutHalo)
     .onDispatch(() => {
       state.dragDelta = (ctx.owner || dispatcher.world)
         .getInverseTransform()
@@ -253,7 +254,7 @@ export default class EventDispatcher {
   }
 
   isMorphClicked (morph) {
-    return this.eventState.clickedMorph == morph;
+    return this.eventState.clickedMorph === morph;
   }
 
   isKeyPressed (keyName) {
@@ -300,7 +301,7 @@ export default class EventDispatcher {
   }
 
   uninstallHandler (handler) {
-    const handlerToBeRemoved = this.handlerFuntions.find(({ type }) => type == handler);
+    const handlerToBeRemoved = this.handlerFuntions.find(({ type }) => type === handler);
     if (handlerToBeRemoved) { handlerToBeRemoved.node.removeEventListener(handlerToBeRemoved.node, handlerToBeRemoved.fn, handlerToBeRemoved.capturing); }
   }
 
@@ -358,8 +359,8 @@ export default class EventDispatcher {
       case 'click':
         // Note, we currently don't subscribe to click DOM events, this is just a
         // convenience for event simulation
-        var { events: downEvents } = this.processDOMEvent(new SimulatedDOMEvent({ ...domEvt, type: 'pointerdown' }), targetMorph);
-        var { events: upEvents } = this.processDOMEvent(new SimulatedDOMEvent({ ...domEvt, type: 'pointerup' }), targetMorph);
+        const { events: downEvents } = this.processDOMEvent(new SimulatedDOMEvent({ ...domEvt, type: 'pointerdown' }), targetMorph);
+        const { events: upEvents } = this.processDOMEvent(new SimulatedDOMEvent({ ...domEvt, type: 'pointerup' }), targetMorph);
         events = downEvents.concat(upEvents);
         break;
 
@@ -386,10 +387,7 @@ export default class EventDispatcher {
 
           let repeatedClick = false; let prevClickCount = 0;
           if (state.prevClick) {
-            const {
-              clickedOnMorph, clickedOnPosition,
-              clickedAtTime, clickCount
-            } = state.prevClick;
+            const { clickedOnMorph, clickedAtTime, clickCount } = state.prevClick;
             const clickInterval = Date.now() - clickedAtTime;
             repeatedClick = clickedOnMorph === targetMorph &&
                          clickInterval < config.repeatClickInterval;
@@ -507,11 +505,11 @@ export default class EventDispatcher {
       case 'pointerover':
         if (state.hover.unresolvedPointerOut) { state.hover.unresolvedPointerOut = false; }
 
-        var hoveredOverMorphs = [targetMorph].concat(targetMorph.ownerChain()).reverse();
-        var hoverOutEvents = arr.withoutAll(state.hover.hoveredOverMorphs, hoveredOverMorphs)
+        const hoveredOverMorphs = [targetMorph].concat(targetMorph.ownerChain()).reverse();
+        const hoverOutEvents = arr.withoutAll(state.hover.hoveredOverMorphs, hoveredOverMorphs)
           .map(m => new Event('hoverout', domEvt, this, [m], hand, halo, layoutHalo)
             .onDispatch(() => arr.remove(state.hover.hoveredOverMorphs, m)));
-        var hoverInEvents = arr.withoutAll(hoveredOverMorphs, state.hover.hoveredOverMorphs)
+        const hoverInEvents = arr.withoutAll(hoveredOverMorphs, state.hover.hoveredOverMorphs)
           .map(m => new Event('hoverin', domEvt, this, [m], hand, halo, layoutHalo)
             .onDispatch(() => arr.pushIfNotIncluded(state.hover.hoveredOverMorphs, m)));
         events = hoverOutEvents.concat(hoverInEvents);
@@ -559,8 +557,8 @@ export default class EventDispatcher {
             const scrollInProgress = !!state.scroll.interactiveScrollInProgress;
             if (!scrollInProgress) {
               const { promise: p, resolve } = promise.deferred();
-              let delay = bowser.name == 'Firefox' ? 500 : 250;
-              if (bowser.name == 'Safari') delay = 1000; // safari recently became more sensitive to this
+              let delay = bowser.name === 'Firefox' ? 500 : 250;
+              if (bowser.name === 'Safari') delay = 1000; // safari recently became more sensitive to this
               state.scroll.interactiveScrollInProgress = p;
               p.debounce = fun.debounce(delay, () => {
                 state.scroll.interactiveScrollInProgress = null;
@@ -572,7 +570,7 @@ export default class EventDispatcher {
             const target = targetNode.documentElement || targetNode;
             const { scrollLeft: newX, scrollTop: newY, style } = target;
             const { x, y } = targetMorph.scroll;
-            if (style.overflow != 'hidden' && x !== newX || y !== newY) targetMorph.scroll = pt(newX, newY);
+            if (style.overflow !== 'hidden' && x !== newX || y !== newY) targetMorph.scroll = pt(newX, newY);
           })];
         break;
 
@@ -622,7 +620,7 @@ export default class EventDispatcher {
       } catch (e) {
         err = new Error(`Error in event handler ${evt.targetMorphs[j]}.${method}: ${e.stack || e}`);
         err.originalError = e;
-        typeof this.world !== 'undefined' ? this.world.logError(err) : console.error(err);
+        typeof this.world !== 'undefined' ? this.world.logError(err) : console.error(err); // eslint-disable-line no-console
       }
       if (err || evt.stopped) break;
     }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2343,8 +2343,13 @@ export class Morph {
   onKeyUp (evt) {}
 
   onContextMenu (evt) {
+    const { targetMorph } = evt;
     // FIXME: if (lively.FreezerRuntime) return; // do not stop propagation if in freezer mode
-    if (evt.targetMorph !== this) return;
+    if (targetMorph !== this) return;
+    if ($world.isIDEWorld && !$world.morphsInWorldWithSubmorphs.includes(this) && !this.isWorld && !this.forceContextMenu) {
+      evt.stop();
+      return;
+    }
     if (!lively.FreezerRuntime) evt.stop();
     Promise
       .resolve(this.menuItems(evt)).then(items => this.openMenu(items, evt))

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -126,6 +126,11 @@ export class Morph {
         defaultValue: false
       },
 
+      handleRightClickAsLeftClick: {
+        group: 'interaction',
+        defaultValue: false
+      },
+
       draggable: {
         group: 'interaction',
         isStyleProp: true,

--- a/lively.morphic/tests/input-event-test.js
+++ b/lively.morphic/tests/input-event-test.js
@@ -99,6 +99,17 @@ describe('pointer event related', function () {
       'onMouseDown-submorph2']);
   });
 
+  it('right click on morph gets handled correctly', () => {
+    let i = 0;
+    submorph2.onMouseDown = () => { i++; };
+    env.eventDispatcher.simulateDOMEvents({ type: 'pointerdown', button: 2, target: submorph2 });
+    expect(i).equals(0);
+    submorph2.handleRightClickAsLeftClick = true;
+    env.eventDispatcher.simulateDOMEvents({ type: 'pointerdown', button: 2, target: submorph2 });
+    expect(i).equals(1);
+    delete submorph2.onMouseDown;
+  });
+
   it('world has hand and moves it', () => {
     env.eventDispatcher.simulateDOMEvents({ type: 'pointermove', target: submorph2, position: pt(120, 130), isPrimary: true });
     expect(world.submorphs[0]).property('isHand', true);

--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -3168,6 +3168,12 @@ export class Text extends Morph {
 
   onContextMenu (evt) {
     if (evt.targetMorph !== this) return;
+
+    if (!this.document) {
+      super.onContextMenu(evt);
+      return;
+    }
+
     evt.stop();
 
     const posClicked = this.textPositionFromPoint(this.localize(evt.position));


### PR DESCRIPTION
There are three things, all require some thoughts and testing, @merryman:

1. I preemptively leave the `onMouseDown` handler if the clicked button is  the right one. Please test if this works on your machine as well. I remember that we had something similar in the past, but ran into problems with regards to platform compatibility!? Another thing is: In theory, executing `onMouseDown` upon a right click is not wrong. However, I'd argue that we basically always use `onMouseDown` as 'left mouse button down'. What do you think? I encountered this problem because a lot of behavior can be toggled with the right mouse button, for example the side-bar flaps, which is unexpected imo.

2. This should be the least controversial one - just a fix for previously broken behavior of text that we never thought of when implementing the smart text with the dynamic document.

3. A change that prohibits context menus on most morphs. We briefly talked about this, and the solution I opted for now is quite brutal. However, I actually think it leaves all options one would usually want on the table. As stuff in windows etc. gets brutally excluded, I additionally introduced a flag `allowContextMenu`, that allows us to override this behavior on demand. Otherwise, this PR would basically kill off all custom tooling in windows, which is, at least in theory, a handy thing to have (see qinoq). 