### PR TITLE
🎛️: prevent selection colors from entering color backup in tree

### DIFF
--- a/lively.components/tree.js
+++ b/lively.components/tree.js
@@ -198,10 +198,14 @@ export class Tree extends Text {
           continue;
         }
       }
-      const equalsSelectionAccent = attrs[i]?.fontColor?.equals(this.selectionFontColor);
       const prevBackup = this._originalColor?.row === row && this._originalColor[i]?.fontColor;
-      colorBackup[i] = (attrs[i] ? (equalsSelectionAccent ? prevBackup : attrs[i].fontColor) : null) || this.nonSelectionFontColor;
-      if (attrs[i]) { attrs[i].fontColor = this.selectionFontColor; } else { attrs[i] = { fontColor: this.selectionFontColor }; }
+      colorBackup[i] = (attrs[i] ? (attrs[i]?.isSelected ? prevBackup : attrs[i].fontColor) : null) || this.nonSelectionFontColor;
+      if (attrs[i]) {
+        attrs[i].fontColor = this.selectionFontColor;
+        attrs[i].isSelected = true;
+      } else {
+        attrs[i] = { fontColor: this.selectionFontColor, isSelected: true };
+      }
     }
     this._originalColor = colorBackup;
     this.document.setTextAndAttributesOfLine(row, attrs);
@@ -225,7 +229,7 @@ export class Tree extends Text {
     const { selectedIndex } = this;
     for (; i < nodes.length; i++) {
       j = 8 * (i - 1) + offset;
-      isSelected = selectedIndex == i;
+      isSelected = selectedIndex === i;
       nodes[i].node.isSelected = isSelected;
       // indent
       containerTextAndAttributes[j] = ' ';


### PR DESCRIPTION
Round two. This one should resolve #1229.
The basic idea here is to simply not cache colors that are equal to the selection color of the tree. The main issue here is though that there is no easy way to distinguish between attributes that were introduced by the selection mechanism and such that were manually set by the *user*. We solve this by placing a meta tag inside the attributes when setting the selection color inside the tree!