### PR TITLE
🚨: fix halo cycle

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -206,7 +206,7 @@ export class LivelyWorld extends World {
 
     if (activeWindow && target === this) activeWindow.deactivate();
     if (
-      this.morphsInWorld.includes(target) ||
+      this.morphsInWorldWithSubmorphs.includes(target) ||
       target === $world
     ) this.handleHaloCycle(evt);
 


### PR DESCRIPTION
#1200 broke invocation of the halo when Ctrl+clicking on a morph which was not a direct descendant of $world, but was contained in another morph. This fixes it.