### PR TITLE
🪨: make sure to only write one type of line ending to disk

### DIFF
--- a/flatn/flatn-cjs.js
+++ b/flatn/flatn-cjs.js
@@ -10103,6 +10103,10 @@ function isConstructorOrProto (obj, key) {
     return key === 'constructor' && typeof obj[key] === 'function' || key === '__proto__';
 }
 
+function ensurePlatformIndependentCharacters (text) {
+  return text.replaceAll(/\r\n/g, '\n');
+}
+
 function applyExclude$1 (exclude, resources) {
   if (Array.isArray(exclude)) {
     return exclude.reduce((intersect, exclude) =>
@@ -14990,6 +14994,8 @@ class WebDAVResource extends Resource {
 
   async write (content) {
     if (!this.isFile()) throw new Error(`Cannot write a non-file: ${this.url}`);
+    content = ensurePlatformIndependentCharacters(content);
+
     const res = await upload(this, content);
 
     if (!between(res.status, 200, 300) && this.errorOnHTTPStatusCodes) { throw new Error(`Cannot write ${this.url}: ${res.statusText} ${res.status}`); }
@@ -15167,6 +15173,7 @@ class NodeJSFileResource extends Resource {
   }
 
   async write (content) {
+    content = ensurePlatformIndependentCharacters(content);
     if (this.isDirectory()) throw new Error(`Cannot write into a directory: ${this.path()}`);
     await writeFileP(this.path(), content);
     return this;
@@ -15416,6 +15423,7 @@ class LocalResource extends Resource {
     if (this.isDirectory()) { throw new Error(`Cannot write into a directory! (${this.url})`); }
     const spec = this.localBackend.get(this.path());
     if (spec && spec.isDirectory) { throw new Error(`${this.url} already exists and is a directory (cannot write into it!)`); }
+    content = ensurePlatformIndependentCharacters(content);
     this.localBackend.write(this.path(), content);
     return Promise.resolve(this);
   }

--- a/lively.resources/src/fs-resource.js
+++ b/lively.resources/src/fs-resource.js
@@ -1,6 +1,6 @@
 /* global process */
 import Resource from './resource.js';
-import { applyExclude, windowsURLPrefixRe, windowsRootPathRe } from './helpers.js';
+import { applyExclude, windowsURLPrefixRe, windowsRootPathRe, ensurePlatformIndependentCharacters } from './helpers.js';
 
 import { createWriteStream, createReadStream, readFile, writeFile, stat, mkdir, rmdir, unlink, readdir, lstat, rename, constants, access } from 'fs';
 
@@ -48,6 +48,7 @@ export class NodeJSFileResource extends Resource {
   }
 
   async write (content) {
+    content = ensurePlatformIndependentCharacters(content);
     if (this.isDirectory()) throw new Error(`Cannot write into a directory: ${this.path()}`);
     await writeFileP(this.path(), content);
     return this;

--- a/lively.resources/src/helpers.js
+++ b/lively.resources/src/helpers.js
@@ -1,3 +1,7 @@
+export function ensurePlatformIndependentCharacters (text) {
+  return text.replaceAll(/\r\n/g, '\n');
+}
+
 export function applyExclude (exclude, resources) {
   if (Array.isArray(exclude)) {
     return exclude.reduce((intersect, exclude) =>

--- a/lively.resources/src/http-resource.js
+++ b/lively.resources/src/http-resource.js
@@ -1,7 +1,7 @@
 /* global fetch, DOMParser, XPathEvaluator, XPathResult, Namespace,System,global,process,XMLHttpRequest,Buffer */
 
 import Resource from './resource.js';
-import { applyExclude } from './helpers.js';
+import { applyExclude, ensurePlatformIndependentCharacters } from './helpers.js';
 import { promise, num } from 'lively.lang';
 import { emit } from 'lively.notifications/index.js';
 
@@ -240,6 +240,8 @@ export default class WebDAVResource extends Resource {
 
   async write (content) {
     if (!this.isFile()) throw new Error(`Cannot write a non-file: ${this.url}`);
+    content = ensurePlatformIndependentCharacters(content);
+
     const res = await upload(this, content);
 
     if (!num.between(res.status, 200, 300) && this.errorOnHTTPStatusCodes) { throw new Error(`Cannot write ${this.url}: ${res.statusText} ${res.status}`); }

--- a/lively.resources/src/local-resource.js
+++ b/lively.resources/src/local-resource.js
@@ -1,5 +1,5 @@
 import Resource from './resource.js';
-import { createFiles } from './helpers.js';
+import { createFiles, ensurePlatformIndependentCharacters } from './helpers.js';
 
 const debug = false;
 const slashRe = /\//g;
@@ -99,6 +99,7 @@ export default class LocalResource extends Resource {
     if (this.isDirectory()) { throw new Error(`Cannot write into a directory! (${this.url})`); }
     const spec = this.localBackend.get(this.path());
     if (spec && spec.isDirectory) { throw new Error(`${this.url} already exists and is a directory (cannot write into it!)`); }
+    content = ensurePlatformIndependentCharacters(content);
     this.localBackend.write(this.path(), content);
     return Promise.resolve(this);
   }


### PR DESCRIPTION
This should solve #174 once and for all. Mind, that this of course makes it so that the actual writable contents inside of lively are now reduced. We talked about this and decided that people that actually require a specific line ending to be used for stuff to work are on their own. :clown_face: 