### PR TITLE
🛠️: correctly measure the length of commit messages with emojis

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -6,13 +6,22 @@ test -n "$(grep -i '^[[:blank:]]*cleanup[[:blank:]]*$' "${1}")" && {
         exit 1
 }
 
+
+grep -q ':' ${1}
+if [[ $? != 0 ]]; then
+        printf >&2 "❌  Commit message needs to include a colon!\n"
+        exit 1   
+fi
+
 firstLine=$(sed -n '1p' "${1}")
 test -n "$(grep -E '^.*: [[:upper:]].*+$' <<< "$firstLine")" && {
         printf >&2 "❌  Do not use upper case letter to start your commit message.\n"
         exit 1
 }
 
-test "$(wc -m <<< "$firstLine")" -lt 74 || {
+length=$(node -e "const {emojifiedLength} = require('./scripts/commit-msg-length-emojis.js'); console.log(emojifiedLength('$firstLine'))")
+
+test $length -lt 74 || {
         printf >&2 "❌  The first line of your commit message should not be longer than 72 characters.\nFeel free to provide more context separated by a blank line.\n"
         exit 1
 }

--- a/scripts/commit-msg-length-emojis.js
+++ b/scripts/commit-msg-length-emojis.js
@@ -1,0 +1,48 @@
+const emojiLengths = {
+    '🗨️' : 3 ,
+    '🌳' : 2,
+    '🎀' : 2,
+    '🔣' : 2,
+    '🛠️' : 3,
+    '🧑‍🏫' : 5,
+    '💭' : 2,
+    '🎛️' : 3,
+    '🗺️' : 3,
+    '🫓' : 2,
+    '❄️' : 2,
+    '🛤️' : 3,
+    '🖌️' : 3,
+    '👼' : 2,
+    '🤕' : 2,
+    '🧰' : 2,
+    '📦' : 2,
+    '⌨️' : 2,
+    '📙' : 2,
+    '🧩' : 2,
+    '🎨' : 2,
+    '🔔' : 2,
+    '📂' : 2,
+    '🪨' : 2,
+    '🗒️' : 3,
+    '📇' : 2,
+    '👔' : 2,
+    '🐚' : 2,
+    '🔁' : 2,
+    '💾' : 2,
+    '📠' : 2,
+    '⚙️' : 2,
+    '👤' : 2,
+    '🖥️' : 3
+}
+
+function emojifiedLength (string){
+    let len = string.length;
+    for (const emoji in emojiLengths) {
+        const re = new RegExp(emoji,'g');
+        const count = (string.match(re) || []).length;
+        if (string.includes(emoji)) len -= count * (emojiLengths[emoji]-1);
+    };  
+    return len;
+} 
+
+exports.emojifiedLength = emojifiedLength;


### PR DESCRIPTION
As graphemes are not correctly counted in most programming languages without using a librabry and Git🐙 bundles its own `node` version that hijacks the hooks so that we cannot use the new `Intl.Segmenter` API, this is a functioning workaround. The previous behavior became really annoying.