### PR TITLE
❄️: surpress `fetchInfoPreflight` when creating a new project

### DIFF
--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -391,7 +391,7 @@ export async function bootstrap ({
     await polyfills();
     const oldEnv = $world.env;
     doBootstrap ? await bootstrapLivelySystem(progress, fastLoad) : await fastPrepLivelySystem();
-    if (projectName) {
+    if (projectName && projectName !== '__newProject__') {
       if (!lively.isInOfflineMode) {
         Project.fetchInfoPreflight(projectName);
       }


### PR DESCRIPTION
Fixes a visible failure in the `console`, introduced due to the `projectName` being set when a new project is created.