### PR TITLE
🧰: close all halos belonging to component when closing component

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -205,9 +205,12 @@ class ComponentEditControlModel extends ViewModel {
       componentMorph,
       editor,
       view,
-      editButton
     } = this;
     await fun.guardNamed('collapse-' + componentMorph.id, async () => {
+      const halos = $world.halos();
+      halos.forEach(h => {
+        if (h.target.ownerChain().includes(componentMorph)) h.remove();
+      });
       const placeholderPos = view.position;
       const pos = componentMorph.position;
       const wrapper = morph({


### PR DESCRIPTION
I often had situations where I had halos open inside of a component to reconcile some changes and afterwards a "ghost halo" remained, as I closed the component when I was done. I believe this was not an issue before #1200, but now it was annoying.

The solution is to just close all halos related to the currently edited component once the editing session is to be terminated.