### PR TITLE
🪨: fix linebreak removal crash when encountering buffer objects

### DIFF
--- a/flatn/flatn-cjs.js
+++ b/flatn/flatn-cjs.js
@@ -10104,7 +10104,7 @@ function isConstructorOrProto (obj, key) {
 }
 
 function ensurePlatformIndependentCharacters (text) {
-  return text.replaceAll(/\r\n/g, '\n');
+  return typeof text === 'string' ? text.replaceAll(/\r\n/g, '\n') : text;
 }
 
 function applyExclude$1 (exclude, resources) {

--- a/lively.resources/src/helpers.js
+++ b/lively.resources/src/helpers.js
@@ -1,5 +1,5 @@
 export function ensurePlatformIndependentCharacters (text) {
-  return text.replaceAll(/\r\n/g, '\n');
+  return typeof text === 'string' ? text.replaceAll(/\r\n/g, '\n') : text;
 }
 
 export function applyExclude (exclude, resources) {


### PR DESCRIPTION
Fixes a crash that would happen if attempting to upload files in lively. Oversight from #1239.