### PR TITLE
Loading Snapsopt via GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ lively.freezer/landing-page/
 lively.freezer/loading-screen/
 lively.classes/build/
 local_projects/
+snapshots/

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ export FLATN_PACKAGE_DIRS=
 export FLATN_PACKAGE_COLLECTION_DIRS=$lv_next_dir/lively.next-node_modules
 eval $(node -p 'let PWD=process.cwd();let packages = JSON.parse(require("fs").readFileSync(PWD+"/lively.installer/packages-config.json")).map(ea => require("path").join(PWD, ea.name));`export FLATN_DEV_PACKAGE_DIRS=${packages.join(":")}`')                                                              
 mkdir lively.next-node_modules
+mkdir snapshots
 mkdir esm_cache
 mkdir local_projects
 mkdir .puppeteer-browser-cache

--- a/lively.freezer/src/loading-screen.cp.js
+++ b/lively.freezer/src/loading-screen.cp.js
@@ -101,7 +101,8 @@ export class WorldLoadingScreen extends Morph {
     $world._cachedWindowBounds = null;
     this.setBounds($world.windowBounds());
     this.get('background').fit();
-    this.get('json target indicator').topRight = this.innerBounds().insetBy(25).topRight();
+    // Hardcode the eventual width of the indicator, as the positioning will be off otherwise.
+    this.get('json target indicator').position = pt(this.extent.x - 72 - 25, 25);
   }
 
   indicateMissing (project) {

--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -8,6 +8,7 @@ import { Color } from 'lively.graphics/color.js';
 import { install as installHook } from 'lively.modules/src/hooks.js';
 import { updateBundledModules } from 'lively.modules/src/module.js';
 import { Project } from 'lively.project/project.js';
+import { pathForBrowserHistory } from 'lively.morphic/helpers.js';
 
 lively.modules = modulePackage; // temporary modules package used for bootstrapping
 
@@ -500,6 +501,10 @@ export async function bootstrap ({
             browserURL: '/worlds/load?file=' + filePath
           }
         );
+        if (window.history) {
+          const path = pathForBrowserHistory(filePath).replaceAll('%2F', '/');
+          window.history.pushState({}, 'lively.next', path);
+        }
       }
     } catch (err) {
       window.__loadError__ = err;

--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -858,7 +858,7 @@ export class ComponentBrowserModel extends ViewModel {
       });
     }
     const openedProject = $world.openedProject;
-    if (!(openedProject.owner === 'LivelyKernel' && openedProject.name === 'partsbin') && !$world._partsbinUpdated) {
+    if (!(openedProject?.owner === 'LivelyKernel' && openedProject?.name === 'partsbin') && !$world._partsbinUpdated) {
       const li = $world.showLoadingIndicatorFor(null, 'Updating `partsbin`');
       // This relies on the assumption, that the default directory the shell command gets dropped in is `lively.server`.
       // `install.sh` ensures that the partsbin repository exists.

--- a/lively.ide/studio/dialogs.cp.js
+++ b/lively.ide/studio/dialogs.cp.js
@@ -42,7 +42,7 @@ class SaveWorldDialogModel extends ConfirmPromptModel {
   get bindings () {
     return [
       ...super.bindings, {
-        model: 'storage type selector',
+        target: 'storage type selector',
         signal: 'selection',
         handler: 'refresh'
       }];

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -533,7 +533,6 @@ export class WorldBrowserModel extends ViewModel {
 
   async chooseAndOpenSnapshot () {
     const pickerOpts = {
-      multiple: true,
       types: [
         {
           description: 'lively.next Playground Snaphot',

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -1,3 +1,4 @@
+/* global FormData */
 /* eslint-disable no-use-before-define */
 import { easings, ViewModel, touchInputDevice, World, MorphicDB, Image, HTMLMorph, Morph, Icon, TilingLayout, Label, ConstraintLayout, ShadowObject, component, part } from 'lively.morphic';
 import { Color, LinearGradient, rect, pt } from 'lively.graphics/index.js';
@@ -550,7 +551,7 @@ export class WorldBrowserModel extends ViewModel {
       $world.setStatusMessage('You can only open one snapshot at a time!');
       return;
     }
-    const file = await files[0].getFile()
+    const file = await files[0].getFile();
     const snapshotInFolder = await resource(System.baseURL).join('../snapshots/').join(file.name).withRelativePartsResolved().exists();
     // "copy" (upload, as we are going through the server) into the lively.next/snapshots directory in order to open it
     if (!snapshotInFolder) {
@@ -559,8 +560,8 @@ export class WorldBrowserModel extends ViewModel {
       const res = resource(System.baseURL).join(`../upload?uploadPath=${encodeURIComponent('/snapshots/')}`).withRelativePartsResolved();
       await res.write(fd);
     }
+    await this.fadeOut();
     const { bootstrap } = await System.import('lively.freezer/src/util/bootstrap.js');
-    this.fadeOut();
     await bootstrap({ filePath: `snapshots/${file.name}`, fastLoad: !lively.doNotUseFastLoad, progress: this.progressIndicator });
   }
 


### PR DESCRIPTION
Adds a button that allows to open snapshots directly from the landing page, without the need to know the magic URL options lively provides.
In the case the snapshot to be opened is not already inside of the `snapshot/` dir of the lively folder, we upload it there and open if afterwards.
Should also take care of the fact that fast load toggling with snapshots did not work previously.

@merryman please take a look, at the transition from the world browser to the loading screen when opening a snapshot - it look laggy to me, but I am not sure if that is just my machine or if I introduces a bad animation?

Closes #980. **This was estimated with 2d. Until opening the PR, less than 8h were spent.**