### PR TITLE
"Hot Reloading" 🥵

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ For some more advanced development operations (bulk testing from the command lin
 - `brotli`
 - `aspell`.
 
+> [!TIP]
+>
+> If you want to change files outside of `lively` (i.e., in a normal editor), while still having the changes be available in lively when opening the file, you'll need to install `entr` from its [repository](https://github.com/eradman/entr). Usually, when working inside of `lively.next`, this will not be an issue, but it can be handy when working heavily on the core of `lively`.
+
 ### Installation Instructions
 
 1. Clone this repository and run the `install.sh` script. This will install the necessary dependencies. Please note, that this process will take a few minutes.

--- a/lively.server/plugins/dav.js
+++ b/lively.server/plugins/dav.js
@@ -1,7 +1,8 @@
 /* global System, process */
 
 import { resource } from 'lively.resources';
-import { string } from 'lively.lang';
+import { string, fun } from 'lively.lang';
+import * as child from 'node:child_process';
 
 const COMPRESSABLE_URLS = [
   'components_cache'
@@ -52,6 +53,9 @@ export default class LivelyDAVPlugin {
   setup ({ server }) {
     server.once('close', () => this.server = null);
     this.server = server;
+    if (process.env.ENTR_SUPPORT === '1') {
+      child.exec('find | entr -r -d -s \'curl --header "x-lively-refresh-file-hashes: true" http://localhost:9011/file-hash-regeneration.js\'', () => { });
+    }
     this.patchServerForJsDAV(server);
     this.fileHashes = {};
     this.computeFileHashes();
@@ -96,6 +100,7 @@ export default class LivelyDAVPlugin {
           await this.computeFileHashes();
           res.writeHead(200);
           res.end();
+          return;
         })()
       return;
     }

--- a/lively.server/plugins/dav.js
+++ b/lively.server/plugins/dav.js
@@ -89,6 +89,17 @@ export default class LivelyDAVPlugin {
   }
 
   async handleRequest (req, res, next) {
+
+    if (req.headers['x-lively-refresh-file-hashes']){
+      fun.throttleNamed('file-hash-generation', 2000,
+        async () => {
+          await this.computeFileHashes();
+          res.writeHead(200);
+          res.end();
+        })()
+      return;
+    }
+
     let path = '';
     // Fix URL to allow non-root installations
     // In Apache config, set:

--- a/lively.server/plugins/dav.js
+++ b/lively.server/plugins/dav.js
@@ -50,11 +50,11 @@ export default class LivelyDAVPlugin {
 
   get after () { return ['cors', 'socketio', 'eval']; }
 
-  setup ({ server }) {
+  setup ({ server, port }) {
     server.once('close', () => this.server = null);
     this.server = server;
     if (process.env.ENTR_SUPPORT === '1') {
-      child.exec('find | entr -r -d -s \'curl --header "x-lively-refresh-file-hashes: true" http://localhost:9011/file-hash-regeneration.js\'', () => { });
+      child.exec(`find ${process.env.lv_next_dir} | entr -n -r -d -s \'curl --header "x-lively-refresh-file-hashes: true" http://localhost:${port}/file-hash-regeneration.js\'`, () => { });
     }
     this.patchServerForJsDAV(server);
     this.fileHashes = {};

--- a/start-server.sh
+++ b/start-server.sh
@@ -31,4 +31,15 @@ if [ -n "$2" ]; then
   options="$options --port $2"
 fi
 
+# https://stackoverflow.com/a/5947802/4418325 for colored output.
+RED='\033[0;31m'
+NC='\033[0m'
+# https://stackoverflow.com/a/677212/4418325 for POSIX compliant check if executable exists.
+if command -v entr &> /dev/null
+then
+  export ENTR_SUPPORT=1
+else
+  export ENTR_SUPPORT=0
+  echo -e "${RED}\`entr\` is not installed. Hot-reloading of files changed outside of \`lively.next\` will be disabled.${NC}"
+fi
 node $options


### PR DESCRIPTION
Solves #1126.

Make sure to install `entr` according to our and their README when testing this. I have confirmed that this works on Windows machines with `WSL`. @merryman please confirm that everything works on mac.

There is one known problem that we need to fix before merging this: Sometimes, especially when many actions trigger `entr` often, there will be an error message like "Cannot write headers after sending response to the client" or something like that. Any ideas on how to solve this, @merryman?

Additionally, this solution triggers the hash creation probably too often. One could think about a more aggressive throttling for one. More importantly, changes from within lively should trigger this as well, as they need to write to disk. This is not nice, but I deemed it to be unproblematic, thoughts? If we would like to prevent this, we would need to indicate to the server that we are currently saving and thus return early when retrieving the request.

**Note, that this only works for `.js` files at the moment. However, that is a limitation of `computeFileHashes()` method.

---

**This was estimated to take one week. This PR took 1 day.**