### PR TITLE
🚨: small project fixes

### DIFF
--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -504,7 +504,7 @@ class ProjectSavePrompt extends AbstractPromptModel {
         const branchName = branchInput.textString.trim();
         success = await this.project.gitResource.createAndCheckoutBranch(branchName);
         if (!success) $world.setStatusMessage(`Could not create branch ${branchName}, possibly due to a name collision!`, StatusMessageError);
-      }
+      } else success = true;
 
       if (success) success = await this.project.save({ increaseLevel, message, tag: this.tag });
       li.remove();

--- a/lively.project/templates/build.js
+++ b/lively.project/templates/build.js
@@ -34,7 +34,7 @@ const build = await rollup({
       ],
       resolver
     }),
-    jsonPlugin({ exclude: /https\\\:\\\/\\\/jspm.dev\\\/.*\\\.json/}),
+    jsonPlugin({ exclude: [/https\:\/\/jspm.dev\/.*\.json/, /esm\:\/\/cache\/.*\.json/]}),
     babel({
      babelHelpers: 'bundled', 
      presets: [PresetEnv]


### PR DESCRIPTION
Fixes two problems with `lively.project`s:

1. Adapts the generated build scripts so that bundling is possible once more. @merryman uncovered a general problem: We currently generate this once (at creation time) and do not touch the script afterwards. This means that fixes like the one in this PR will not be automatically applied to already existing projects. We could now just force-create this with each save, thus guaranteeing that our fixes land in all projects. However, this will also override any customization one might have done to the bundling script. My proposed solution: We up the priority of #1223 and include therein thinking about a smart way of storing any customizations decoupled from the build script itself. Then, we can automatically generate an up to date and correct bundling script on each save. Thoughts?
 
2. Saving on the currently used branch was not possible due to an oversight when implementing #1246.  