### PR TITLE
Dependencies in CI

### DIFF
--- a/lively.git/index.js
+++ b/lively.git/index.js
@@ -1,1 +1,29 @@
-"format esm";
+/* global fetch */
+import { currentUserToken } from 'lively.user';
+export class GitHubAPIWrapper {
+  static async remoteRepoInfos (repoOwner, repoName) {
+    const token = currentUserToken();
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}`, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    return await res.json();
+  }
+
+  static async listGithubBranches (repoOwner, repoName) {
+    const token = currentUserToken();
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/branches`, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    const branchData = await res.json();
+    // TODO: If this is called with a non-existing repository bad things happen!
+    return branchData.map(b => b.name);
+  }
+}

--- a/lively.git/index.js
+++ b/lively.git/index.js
@@ -86,6 +86,37 @@ export class GitHubAPIWrapper {
     });
   }
 
+  static async deleteRepositorySecret (repoOwner, repoName, secretName) {
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/actions/secrets/${secretName}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+  }
+
+  static async deleteDeployKey (repoOwner, repoName, title) {
+  // TODO: If this is called with a non-existing key bad things happen!
+    const resKeyList = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/keys`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    const deployKeys = await resKeyList.json();
+    const keyIdToRemove = deployKeys.find(key => key.title === title).id;
+
+    const resKeyDeletion = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/keys/${keyIdToRemove}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    }
+
   static async listGithubBranches (repoOwner, repoName) {
     const token = currentUserToken();
     const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/branches`, {

--- a/lively.git/index.js
+++ b/lively.git/index.js
@@ -1,5 +1,9 @@
 /* global fetch */
 import { currentUserToken } from 'lively.user';
+import { default as libsod } from 'esm://cache/libsodium-wrappers';
+
+// TODO: This could all use some sensible error handling -lh 15.02.2024
+
 export class GitHubAPIWrapper {
   static async remoteRepoInfos (repoOwner, repoName) {
     const token = currentUserToken();
@@ -11,6 +15,75 @@ export class GitHubAPIWrapper {
       }
     });
     return await res.json();
+  }
+
+  static async addDeployKey (repoOwner, repoName, title, key) {
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/keys`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      },
+      body: JSON.stringify({
+        title,
+        key,
+        read_only: 'true'
+      })
+    });
+  }
+
+  static async listActionSecrets (repoOwner, repoName) {
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/actions/secrets`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+
+    const secretData = await res.json();
+    return secretData.secrets.map(s => s.name);
+  }
+
+  static async retrieveRepositoriesPublicKey (repoOwner, repoName) {
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/actions/secrets/public-key`, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    const keyData = await res.json();
+    return {
+      key: keyData.key,
+      id: keyData.key_id
+    };
+  }
+
+  static async addOrUpdateRepositorySecret (repoOwner, repoName, secretName, secret, publicKey, publicKeyId) {
+    await libsod.ready;
+    // Convert the secret and key to a Uint8Array.
+    let binkey = libsod.from_base64(publicKey, libsod.base64_variants.ORIGINAL);
+    let binsec = libsod.from_string(secret);
+
+    // Encrypt the secret using libsodium
+    let encBytes = libsod.crypto_box_seal(binsec, binkey);
+
+    // Convert the encrypted Uint8Array to Base64
+    const encryptedSecret = libsod.to_base64(encBytes, libsod.base64_variants.ORIGINAL);
+    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/actions/secrets/${secretName}`, {
+      method: 'PUT',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${currentUserToken()}`,
+        'X-GitHub-Api-Version': '2022-11-28'
+      },
+      body: JSON.stringify({
+        encrypted_value: `${encryptedSecret}`,
+        key_id: publicKeyId
+      })
+    });
   }
 
   static async listGithubBranches (repoOwner, repoName) {

--- a/lively.git/js-keygen/LICENSE.md
+++ b/lively.git/js-keygen/LICENSE.md
@@ -1,0 +1,159 @@
+All Code in this folder was originally written by @PatrickRoumanoff on GitHub and distributed under the license standing below. Slight adaptions have been made by the `lively.next` team.
+
+# Creative Commons Attribution 4.0 International
+
+Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+### Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+* __Considerations for licensors:__ Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. [More considerations for licensors](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensors).
+
+* __Considerations for the public:__ By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. [More considerations for the public](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees).
+
+## Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+### Section 1 – Definitions.
+
+a. __Adapted Material__ means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+b. __Adapter's License__ means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+c. __Copyright and Similar Rights__ means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. __Effective Technological Measures__ means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+e. __Exceptions and Limitations__ means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+f. __Licensed Material__ means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+g. __Licensed Rights__ means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+h. __Licensor__ means the individual(s) or entity(ies) granting rights under this Public License.
+
+i. __Share__ means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+j. __Sui Generis Database Rights__ means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+k. __You__ means the individual or entity exercising the Licensed Rights under this Public License. __Your__ has a corresponding meaning.
+
+### Section 2 – Scope.
+
+a. ___License grant.___
+
+   1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+       A. reproduce and Share the Licensed Material, in whole or in part; and
+
+       B. produce, reproduce, and Share Adapted Material.
+
+   2. __Exceptions and Limitations.__ For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+   3. __Term.__ The term of this Public License is specified in Section 6(a).
+
+   4. __Media and formats; technical modifications allowed.__ The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+   5. __Downstream recipients.__
+
+       A. __Offer from the Licensor – Licensed Material.__ Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+       B. __No downstream restrictions.__ You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+   6. __No endorsement.__ Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. ___Other rights.___
+
+   1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+   2. Patent and trademark rights are not licensed under this Public License.
+
+   3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+### Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+a. ___Attribution.___
+
+   1. If You Share the Licensed Material (including in modified form), You must:
+
+       A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+         i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+         ii. a copyright notice;
+
+         iii. a notice that refers to this Public License;
+
+         iv. a notice that refers to the disclaimer of warranties;
+
+         v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+       B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+       C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+   2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+   3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+   4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+### Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+b. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+a. __Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.__
+
+b. __To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.__
+
+c. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+### Section 6 – Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+   1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+   2. upon express reinstatement by the Licensor.
+
+   For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+c. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+### Section 7 – Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+### Section 8 – Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+> Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at [creativecommons.org/policies](http://creativecommons.org/policies), Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+>
+> Creative Commons may be contacted at creativecommons.org

--- a/lively.git/js-keygen/base64url.js
+++ b/lively.git/js-keygen/base64url.js
@@ -1,0 +1,30 @@
+// adapted from https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-08#appendix-C
+
+function base64urlEncode (arg) {
+  const step1 = window.btoa(arg); // Regular base64 encoder
+  const step2 = step1.split('=')[0]; // Remove any trailing '='s
+  const step3 = step2.replace(/\+/g, '-'); // 62nd char of encoding
+  const step4 = step3.replace(/\//g, '_'); // 63rd char of encoding
+  return step4;
+}
+
+function base64urlDecode (s) {
+  const step1 = s.replace(/-/g, '+'); // 62nd char of encoding
+  const step2 = step1.replace(/_/g, '/'); // 63rd char of encoding
+  let step3 = step2;
+  switch (step2.length % 4) { // Pad with trailing '='s
+    case 0: // No pad chars in this case
+      break;
+    case 2: // Two pad chars
+      step3 += '==';
+      break;
+    case 3: // One pad char
+      step3 += '=';
+      break;
+    default:
+      throw new Error('Illegal base64url string!');
+  }
+  return window.atob(step3); // Regular base64 decoder
+}
+
+export { base64urlDecode, base64urlEncode };

--- a/lively.git/js-keygen/js-keygen.js
+++ b/lively.git/js-keygen/js-keygen.js
@@ -1,0 +1,52 @@
+import { encodePrivateKey, encodePublicKey } from './ssh-util.js';
+const extractable = true;
+
+function wrap (text, len) {
+  const length = len || 72;
+  let result = '';
+  for (let i = 0; i < text.length; i += length) {
+    result += text.slice(i, i + length);
+    result += '\n';
+  }
+  return result;
+}
+
+function rsaPrivateKey (key) {
+  return `-----BEGIN RSA PRIVATE KEY-----\n${key}-----END RSA PRIVATE KEY-----`;
+}
+
+function arrayBufferToBase64 (buffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+function generateKeyPair (name = 'lively.next') {
+  return window.crypto.subtle
+    .generateKey(
+      {
+        name: 'RSASSA-PKCS1-v1_5',
+        modulusLength: 2048, // can be 1024, 2048, or 4096
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+        hash: { name: 'SHA-1' } // can be "SHA-1", "SHA-256", "SHA-384", or "SHA-512"
+      },
+      extractable,
+      ['sign', 'verify']
+    )
+    .then(key => {
+      const privateKey = window.crypto.subtle
+        .exportKey('jwk', key.privateKey)
+        .then(encodePrivateKey)
+        .then(wrap)
+        .then(rsaPrivateKey);
+
+      const publicKey = window.crypto.subtle.exportKey('jwk', key.publicKey).then(jwk => encodePublicKey(jwk, name));
+      return Promise.all([privateKey, publicKey]);
+    });
+}
+
+export { arrayBufferToBase64, generateKeyPair };

--- a/lively.git/js-keygen/pkcs1To8.js
+++ b/lively.git/js-keygen/pkcs1To8.js
@@ -1,0 +1,71 @@
+/* eslint no-bitwise: 0 */
+
+function wrap (text, len) {
+  const length = len || 72;
+  let result = '';
+  for (let i = 0; i < text.length; i += length) {
+    result += text.slice(i, i + length);
+    result += '\n';
+  }
+  return result;
+}
+
+function pemPrivateKey (key) {
+  return `-----BEGIN PRIVATE KEY-----\n${wrap(key, 64)}-----END PRIVATE KEY-----`;
+}
+
+function stripPemFormatting (str) {
+  return str
+    .replace(/^-----BEGIN (?:RSA )?(?:PRIVATE|PUBLIC) KEY-----$/m, '')
+    .replace(/^-----END (?:RSA )?(?:PRIVATE|PUBLIC) KEY-----$/m, '')
+    .replace(/[\n\r]/g, '');
+}
+function arrayToPem (a) {
+  return window.btoa(a.map(c => String.fromCharCode(c)).join(''));
+}
+
+function stringToArray (s) {
+  return s.split('').map(c => c.charCodeAt());
+}
+
+function pemToArray (pem) {
+  return stringToArray(window.atob(pem));
+}
+
+const prefix = [
+  0x30,
+  0x82,
+  0x04,
+  0xbc,
+  0x02,
+  0x01,
+  0x00,
+  0x30,
+  0x0d,
+  0x06,
+  0x09,
+  0x2a,
+  0x86,
+  0x48,
+  0x86,
+  0xf7,
+  0x0d,
+  0x01,
+  0x01,
+  0x01,
+  0x05,
+  0x00,
+  0x04,
+  0x82,
+  0x04,
+  0xa6
+];
+
+export function pkcs1To8 (privateKeyPkcs1Pem) {
+  const pem = stripPemFormatting(privateKeyPkcs1Pem);
+  const privateKeyPkcs1Array = pemToArray(pem);
+  const prefixPkcs8 = prefix.concat(privateKeyPkcs1Array);
+  const privateKeyPkcs8Pem = arrayToPem(prefixPkcs8);
+  const pkcs8Pem = pemPrivateKey(privateKeyPkcs8Pem);
+  return pkcs8Pem;
+}

--- a/lively.git/js-keygen/publicSshToPem.js
+++ b/lively.git/js-keygen/publicSshToPem.js
@@ -1,0 +1,101 @@
+/* eslint no-bitwise: 0 */
+
+function wrap (text, len) {
+  const length = len || 72;
+  let result = '';
+  for (let i = 0; i < text.length; i += length) {
+    result += text.slice(i, i + length);
+    result += '\n';
+  }
+  return result;
+}
+
+function pemPublicKey (key) {
+  return `---- BEGIN RSA PUBLIC KEY ----\n${wrap(key, 65)}---- END RSA PUBLIC KEY ----`;
+}
+
+function integerToOctet (n) {
+  const result = [];
+  for (let i = n; i > 0; i >>= 8) {
+    result.push(i & 0xff);
+  }
+  return result.reverse();
+}
+
+function asnEncodeLen (n) {
+  let result = [];
+  if (n >> 7) {
+    result = integerToOctet(n);
+    result.unshift(0x80 + result.length);
+  } else {
+    result.push(n);
+  }
+  return result;
+}
+
+function checkHighestBit (v) {
+  if (v[0] >> 7 === 1) {
+    v.unshift(0); // add leading zero if first bit is set
+  }
+  return v;
+}
+
+function asn1Int (int) {
+  const v = checkHighestBit(int);
+  const len = asnEncodeLen(v.length);
+  return [0x02].concat(len, v); // int tag is 0x02
+}
+
+function asn1Seq (seq) {
+  const len = asnEncodeLen(seq.length);
+  return [0x30].concat(len, seq); // seq tag is 0x30
+}
+
+function arrayToPem (a) {
+  return window.btoa(a.map(c => String.fromCharCode(c)).join(''));
+}
+
+function arrayToString (a) {
+  return String.fromCharCode.apply(null, a);
+}
+
+function stringToArray (s) {
+  return s.split('').map(c => c.charCodeAt());
+}
+
+function pemToArray (pem) {
+  return stringToArray(window.atob(pem));
+}
+
+function arrayToLen (a) {
+  let result = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    result = result * 256 + a[i];
+  }
+  return result;
+}
+
+function decodePublicKey (s) {
+  const split = s.split(' ');
+  const prefix = split[0];
+  if (prefix !== 'ssh-rsa') {
+    throw new Error(`Unknown prefix: ${prefix}`);
+  }
+  const buffer = pemToArray(split[1]);
+  const nameLen = arrayToLen(buffer.splice(0, 4));
+  const type = arrayToString(buffer.splice(0, nameLen));
+  if (type !== 'ssh-rsa') {
+    throw new Error(`Unknown key type: ${type}`);
+  }
+  const exponentLen = arrayToLen(buffer.splice(0, 4));
+  const exponent = buffer.splice(0, exponentLen);
+  const keyLen = arrayToLen(buffer.splice(0, 4));
+  const key = buffer.splice(0, keyLen);
+  return { type, exponent, key, name: split[2] };
+}
+
+export function publicSshToPem (publicKey) {
+  const { key, exponent } = decodePublicKey(publicKey);
+  const seq = [key, exponent].map(asn1Int).reduce((acc, a) => acc.concat(a));
+  return pemPublicKey(arrayToPem(asn1Seq(seq)));
+}

--- a/lively.git/js-keygen/ssh-util.js
+++ b/lively.git/js-keygen/ssh-util.js
@@ -1,0 +1,121 @@
+import { base64urlDecode } from './base64url.js';
+/* eslint no-bitwise: 0 */
+
+function arrayToString (a) {
+  return String.fromCharCode.apply(null, a);
+}
+
+function stringToArray (s) {
+  return s.split('').map(c => c.charCodeAt());
+}
+
+function base64urlToArray (s) {
+  return stringToArray(base64urlDecode(s));
+}
+
+function pemToArray (pem) {
+  return stringToArray(window.atob(pem));
+}
+
+function arrayToPem (a) {
+  return window.btoa(a.map(c => String.fromCharCode(c)).join(''));
+}
+
+function arrayToLen (a) {
+  let result = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    result = result * 256 + a[i];
+  }
+  return result;
+}
+
+function integerToOctet (n) {
+  const result = [];
+  for (let i = n; i > 0; i >>= 8) {
+    result.push(i & 0xff);
+  }
+  return result.reverse();
+}
+
+function lenToArray (n) {
+  const oct = integerToOctet(n);
+  let i;
+  for (i = oct.length; i < 4; i += 1) {
+    oct.unshift(0);
+  }
+  return oct;
+}
+
+function decodePublicKey (s) {
+  const split = s.split(' ');
+  const prefix = split[0];
+  if (prefix !== 'ssh-rsa') {
+    throw new Error(`Unknown prefix: ${prefix}`);
+  }
+  const buffer = pemToArray(split[1]);
+  const nameLen = arrayToLen(buffer.splice(0, 4));
+  const type = arrayToString(buffer.splice(0, nameLen));
+  if (type !== 'ssh-rsa') {
+    throw new Error(`Unknown key type: ${type}`);
+  }
+  const exponentLen = arrayToLen(buffer.splice(0, 4));
+  const exponent = buffer.splice(0, exponentLen);
+  const keyLen = arrayToLen(buffer.splice(0, 4));
+  const key = buffer.splice(0, keyLen);
+  return { type, exponent, key, name: split[2] };
+}
+
+function checkHighestBit (v) {
+  if (v[0] >> 7 === 1) {
+    // add leading zero if first bit is set
+    v.unshift(0);
+  }
+  return v;
+}
+
+function jwkToInternal (jwk) {
+  return {
+    type: 'ssh-rsa',
+    exponent: checkHighestBit(stringToArray(base64urlDecode(jwk.e))),
+    name: 'name',
+    key: checkHighestBit(stringToArray(base64urlDecode(jwk.n)))
+  };
+}
+
+function encodePublicKey (jwk, name) {
+  const k = jwkToInternal(jwk);
+  k.name = name;
+  const keyLenA = lenToArray(k.key.length);
+  const exponentLenA = lenToArray(k.exponent.length);
+  const typeLenA = lenToArray(k.type.length);
+  const array = [].concat(typeLenA, stringToArray(k.type), exponentLenA, k.exponent, keyLenA, k.key);
+  const encoding = arrayToPem(array);
+  return `${k.type} ${encoding} ${k.name}`;
+}
+
+function asnEncodeLen (n) {
+  let result = [];
+  if (n >> 7) {
+    result = integerToOctet(n);
+    result.unshift(0x80 + result.length);
+  } else {
+    result.push(n);
+  }
+  return result;
+}
+
+function encodePrivateKey (jwk) {
+  const order = ['n', 'e', 'd', 'p', 'q', 'dp', 'dq', 'qi'];
+  const list = order.map(prop => {
+    const v = checkHighestBit(stringToArray(base64urlDecode(jwk[prop])));
+    const len = asnEncodeLen(v.length);
+    return [0x02].concat(len, v); // int tag is 0x02
+  });
+  let seq = [0x02, 0x01, 0x00]; // extra seq for SSH
+  seq = seq.concat(...list);
+  const len = asnEncodeLen(seq.length);
+  const a = [0x30].concat(len, seq); // seq is 0x30
+  return arrayToPem(a);
+}
+
+export { base64urlToArray, decodePublicKey, encodePublicKey, encodePrivateKey };

--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -14,9 +14,8 @@ import { Project } from 'lively.project';
 import { without, add } from 'lively.morphic/components/core.js';
 import { Text } from 'lively.morphic/text/morph.js';
 import { Path } from 'lively.morphic/morph.js';
-import GitShellResource from 'lively.shell/git-client-resource.js';
 import { Rectangle } from 'lively.graphics/geometry-2d.js';
-
+import { GitHubAPIWrapper } from 'lively.git';
 import { currentUserToken, isUserLoggedIn } from 'lively.user';
 import { resource } from 'lively.resources';
 import { defaultDirectory } from 'lively.ide/shell/shell-interface.js';
@@ -283,10 +282,10 @@ class ProjectVersionViewer extends WorldVersionViewer {
         $world.get('user flap').show();
       } else {
         // used to figure out the default branch on github or if no repo exists at all
-        repoInfos = await GitShellResource.remoteRepoInfos(_projectOwner, _projectName);
+        repoInfos = await GitHubAPIWrapper.remoteRepoInfos(_projectOwner, _projectName);
         notOnGithub = repoInfos.message === 'Not Found';
         // retrieves all branches that exist remotely
-        if (!notOnGithub) githubBranches = await GitShellResource.listGithubBranches(_projectOwner, _projectName);
+        if (!notOnGithub) githubBranches = await GitHubAPIWrapper.listGithubBranches(_projectOwner, _projectName);
       }
     }
 
@@ -356,7 +355,7 @@ class ProjectVersionViewer extends WorldVersionViewer {
       await localRepo.runCommand('git stash drop').whenDone();
     }
     if (stashApplicationCommand.exitCode !== 0 && !stashApplicationCommand.stderr.includes('is not a valid reference')) {
-      console.warn('Stash application failed due to conflict. Aborting stash application.');
+      console.warn('Stash application failed due to conflict. Aborting stash application.'); // eslint-disable-line no-console
       await localRepo.runCommand('git reset --hard').whenDone();
     }
     spinner.visible = false;

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -1259,11 +1259,14 @@ const commands = [
           $world.get('user flap').show();
           return;
         }
+        const li = $world.showLoadingIndicatorFor(null, 'Setting up Save operation...')
         await $world.openedProject.saveConfigData();
         if (!(await $world.openedProject.hasUncommitedChanges())) {
           $world.setStatusMessage('All changes are saved. Nothing to do.', StatusMessageConfirm);
+          li.remove();
           return;
         }
+        li.remove();
         saved = await $world.openPrompt(part(SaveProjectDialog, { viewModel: { project: $world.openedProject } }));
       } else { // in case there is another morph implementing save...
         const relayed = evt && world.relayCommandExecutionToFocusedMorph(evt);

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -637,7 +637,7 @@ export class Project {
         with:
           repository: ${owner}/${name}
           path: local_projects/${dep.name}/
-          ssh-key: \${{ secrets.${dep.name.replaceAll('/', '_').replaceAll('-', '_').replaceAll('__', '_')} }}`;
+          ssh-key: \${{ secrets.${dep.name.replaceAll('/', '_').replaceAll('-', '_')} }}`;
           if (!dep.privateRepo) depStatement = depStatement.replace(/\n\s*ssh-key.*}}/, '');
           depSetupStatements += depStatement;
         }

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -10,7 +10,7 @@ import { StatusMessageConfirm, StatusMessageError } from 'lively.halos/component
 import { join } from 'lively.modules/src/url-helpers.js';
 import { runCommand } from 'lively.shell/client-command.js';
 import ShellClientResource from 'lively.shell/client-resource.js';
-import { semver, PackageRegistry } from 'lively.modules/index.js';
+import { PackageRegistry } from 'lively.modules/index.js';
 import { currentUserToken, currentUserData, isUserLoggedIn, currentUser, currentUsername } from 'lively.user';
 import { reloadPackage } from 'lively.modules/src/packages/package.js';
 import { buildScriptShell } from './templates/build-shell.js';
@@ -28,6 +28,7 @@ import { promise } from 'lively.lang';
 import { setupLively2Lively, setupLivelyShell } from 'lively.morphic/world-loading.js';
 import { GitHubAPIWrapper } from 'lively.git';
 import { generateKeyPair } from 'lively.git/js-keygen/js-keygen.js';
+import * as semver from 'esm://cache/semver';
 
 export const repositoryOwnerAndNameRegex = /\.com\/(.+)\/(.*)/;
 const fontCSSWarningString = `/*\nDO NOT CHANGE THE CONTENTS OF THIS FILE!

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -53,9 +53,9 @@ export class Project {
       Project.projectDirectory(fullName).then(
         dir => dir.join('package.json').readJson().then(
           (config) => {
-        VersionChecker.checkVersionRelation(config.lively.boundLivelyVersion, true).then(
-          finishCheck);
-      }));
+            VersionChecker.checkVersionRelation(config.lively.boundLivelyVersion, true).then(
+              finishCheck);
+          }));
       await Project.pullUpstreamChangesIfRemote(gitResource);
     })();
   }
@@ -88,7 +88,7 @@ export class Project {
    * Used for internal operations and not intended to be exposed to the user.
    */
   get fullName () {
-    return this.url.replace(/.*\/local_projects\//, '').replace('/','');
+    return this.url.replace(/.*\/local_projects\//, '').replace('/', '');
   }
 
   get repoOwner () {
@@ -289,7 +289,7 @@ export class Project {
       switch (checkLivelyCompatibility) {
         case 'CANCELED':
         case 'OUTDATED': {
-          await $world.inform({title: 'The required lively version of this project conflicts with the running one.', text: 'You can proceed with OK, but be aware that some expected behaviour might differ or not work.' });
+          await $world.inform({ title: 'The required lively version of this project conflicts with the running one.', text: 'You can proceed with OK, but be aware that some expected behaviour might differ or not work.' });
         }
       }
     }
@@ -732,7 +732,7 @@ export class Project {
         }
       }
     }
-    if (showStatusReport && !onlyLoadNotOpen) $world.inform({title: 'Dependency Status', text: dependencyStatusReport.concat(['Loading has been successful, but be cautious.', { fontWeight: 700 }]) });
+    if (showStatusReport && !onlyLoadNotOpen) $world.inform({ title: 'Dependency Status', text: dependencyStatusReport.concat(['Loading has been successful, but be cautious.', { fontWeight: 700 }]) });
     if (showStatusReport && onlyLoadNotOpen) console.warn('A loaded project introduced a dependency version conflict.');
     // Reset this, so that nobody gets tempted to (ab)use this hot mess of a half-working feature...
     this.dependencyMap = null;

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -475,18 +475,18 @@ class ProjectSavePrompt extends AbstractPromptModel {
 
   async viewDidLoad () {
     const { promptTitle, diffButton, branchInput } = this.ui;
+    this.view.visible = false;
     const li = $world.showLoadingIndicatorFor(null, 'Setting up Save operation...');
     const dependencies = await this.project.generateFlatDependenciesList();
     const localDeps = dependencies.some(d => !d.hasRemote);
     this.ui.dependencyStatusInfo.visible = localDeps;
     branchInput.deactivate();
-    diffButton.disable();
     const currentBranchName = await this.project.gitResource.branchName();
     promptTitle.textAndAttributes = ['Save Project\n', null, '(currently on', { fontSize: 16 }, ` ${currentBranchName}`, { fontSize: 16, fontColor: Color.lively }, ')', null];
     await this.project.saveConfigData();
     if (await this.project.hasRemoteConfigured()) this.project.regeneratePipelines();
     li.remove();
-    diffButton.enable();
+    this.view.visible = true; 
   }
 
   async resolve () {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -22,8 +22,8 @@ import { once } from 'lively.bindings';
 import { ModeSelector } from 'lively.components/widgets/mode-selector.cp.js';
 import { fun } from 'lively.lang';
 import { repositoryOwnerAndNameRegex } from './project.js';
-import GitShellResource from 'lively.shell/git-client-resource.js';
 import { debounceNamed } from 'lively.lang/function.js';
+import { GitHubAPIWrapper } from 'lively.git';
 
 class ProjectSettingsPromptModel extends AbstractPromptModel {
   static get properties () {
@@ -180,8 +180,8 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     if (urlString.endsWith('.git')) urlString = urlString.replace('.git', '');
     const projectRepoOwner = urlString.match(repositoryOwnerAndNameRegex)[1];
     const projectName = urlString.match(repositoryOwnerAndNameRegex)[2];
-    const repoInfos = await GitShellResource.remoteRepoInfos(projectRepoOwner, projectName);
-    const branchListing = await GitShellResource.listGithubBranches(projectRepoOwner, projectName);
+    const repoInfos = await GitHubAPIWrapper.remoteRepoInfos(projectRepoOwner, projectName);
+    const branchListing = await GitHubAPIWrapper.listGithubBranches(projectRepoOwner, projectName);
     branchSelector.items = branchListing.map(b => ({ string: b, value: { name: b }, isListItem: true }));
     branchSelector.selection = this.ui.branchSelector.items.find(i => i.value.name === repoInfos.default_branch).value;
     branchSelector.visible = true;

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -475,6 +475,7 @@ class ProjectSavePrompt extends AbstractPromptModel {
 
   async viewDidLoad () {
     const { promptTitle, diffButton, branchInput } = this.ui;
+    const li = $world.showLoadingIndicatorFor(null, 'Setting up Save operation...');
     const dependencies = await this.project.generateFlatDependenciesList();
     const localDeps = dependencies.some(d => !d.hasRemote);
     this.ui.dependencyStatusInfo.visible = localDeps;
@@ -484,6 +485,7 @@ class ProjectSavePrompt extends AbstractPromptModel {
     promptTitle.textAndAttributes = ['Save Project\n', null, '(currently on', { fontSize: 16 }, ` ${currentBranchName}`, { fontSize: 16, fontColor: Color.lively }, ')', null];
     await this.project.saveConfigData();
     if (await this.project.hasRemoteConfigured()) this.project.regeneratePipelines();
+    li.remove();
     diffButton.enable();
   }
 

--- a/lively.project/templates/build-upload-action.js
+++ b/lively.project/templates/build-upload-action.js
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
-          path: local_projects/%PROJECT_NAME%
+          path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Build Project
         run: npm run build-minified --prefix local_projects/%PROJECT_NAME%
       - name: Upload Build Artifacts

--- a/lively.project/templates/deploy-pages-action.js
+++ b/lively.project/templates/deploy-pages-action.js
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
-          path: local_projects/%PROJECT_NAME%
+          path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Build Project
         run: npm run build-minified --prefix local_projects/%PROJECT_NAME%
       - name: Upload artifact

--- a/lively.project/templates/test-action.js
+++ b/lively.project/templates/test-action.js
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
-          path: local_projects/%PROJECT_NAME%
+          path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Start \`lively.next\`
         run: |
           ./start-server.sh > /dev/null 2>&1 &

--- a/lively.shell/git-client-resource.js
+++ b/lively.shell/git-client-resource.js
@@ -3,7 +3,6 @@
 import ShellClientResource from './client-resource.js';
 import { runCommand } from 'lively.ide/shell/shell-interface.js';
 import L2LClient from 'lively.2lively/client.js';
-import { currentUserToken } from 'lively.user';
 
 export default class GitShellResource extends ShellClientResource {
   constructor (url) {
@@ -16,36 +15,10 @@ export default class GitShellResource extends ShellClientResource {
     }
   }
 
-  static async remoteRepoInfos (repoOwner, repoName) {
-    const token = currentUserToken();
-    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}`, {
-      headers: {
-        accept: 'application/vnd.github+json',
-        authorization: `Bearer ${token}`,
-        'X-GitHub-Api-Version': '2022-11-28'
-      }
-    });
-    return await res.json();
-  }
-
-  static async listGithubBranches (repoOwner, repoName) {
-    const token = currentUserToken();
-    const res = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/branches`, {
-      headers: {
-        accept: 'application/vnd.github+json',
-        authorization: `Bearer ${token}`,
-        'X-GitHub-Api-Version': '2022-11-28'
-      }
-    });
-    const branchData = await res.json();
-    // TODO: If this is called with a non-existing repository bad things happen!
-    return branchData.map(b => b.name);
-  }
-
   async fetch (remote = 'origin') {
     await this.runCommand(`git fetch ${remote}`).whenDone();
   }
-  
+
   async branchesInRepository () {
     const output = await this.runCommand('git branch --all').whenDone();
     // TODO: insert error handling
@@ -112,9 +85,9 @@ export default class GitShellResource extends ShellClientResource {
    * @returns
    */
   async createAndCheckoutBranch (branchName, tracked = false) {
-    const branchCreationCmd = tracked ? 
-     `git checkout --track origin/${branchName}`:
-     `git checkout -b ${branchName}`;
+    const branchCreationCmd = tracked
+      ? `git checkout --track origin/${branchName}`
+      : `git checkout -b ${branchName}`;
     const cmd = this.runCommand(branchCreationCmd);
     await cmd.whenDone();
     // Branch could successfully be created and switched to.

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -142,7 +142,7 @@ export class UserFlapModel extends ViewModel {
         $world.setStatusMessage('Login is not possible while in offline mode');
         return;
       }
-      let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,delete_repo,workflow' https://github.com/login/device/code`;
+      let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,delete_repo,workflow,secrets' https://github.com/login/device/code`;
       const { stdout: resOne } = await runCommand(cmdString).whenDone();
       if (resOne === '') {
         $world.setStatusMessage('You seem to be offline.', StatusMessageError);


### PR DESCRIPTION
Closes #985.

This PR allows us to utilize the option of building/running tests in CI with projects that have dependencies.
The cases of public dependencies as well as private dependencies have been taken care of. In unusual circumstances (especially regarding multi-user usage of the same lively installation) it will be possible to break this. However, this scenario is rudimentary supported at best and really solving it would include a lot of security concerns which we decided not to tackle.

In general, the usage of private dependencies works by generating SSH keys in the browser and then using the private key as a secret inside of the project repository and uploading the public key to be used as a deploy key to GitHub. This way, the CI pipelines can authorize themselves to GitHub as being allowed to use the private repository. 

I also added a warning to the save project dialogue that gets shown when one adds a project as a dependency that is not available on GitHub, as that will usually inhibit other people from using/collaborating on that same project.

The setup can be seen working in [this repository](https://github.com/nextguys/project-demo).

**This was estimated to take 7.5d. Opening this PR took 5d.**