### PR TITLE
🚨 Revert "👤: grant GitHub lively app permission to interact with secrets"

### DIFF
--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -142,7 +142,7 @@ export class UserFlapModel extends ViewModel {
         $world.setStatusMessage('Login is not possible while in offline mode');
         return;
       }
-      let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,delete_repo,workflow,secrets' https://github.com/login/device/code`;
+      let cmdString = `curl -X POST -F 'client_id=${livelyAuthGithubAppId}' -F 'scope=user,repo,delete_repo,workflow' https://github.com/login/device/code`;
       const { stdout: resOne } = await runCommand(cmdString).whenDone();
       if (resOne === '') {
         $world.setStatusMessage('You seem to be offline.', StatusMessageError);


### PR DESCRIPTION
This reverts commit e8b428b21c7c2619619780ce1412d4d1948b0cb4.

I just added "secrets" as a scope out of a gut feeling and never actually tested it, as I was always logged in. Turns out, that scope does not exist. What a :clown_face: fiesta.