### PR TITLE
🧰: clean up search highlights if search widget is already closed

### DIFF
--- a/lively.ide/text/search.js
+++ b/lively.ide/text/search.js
@@ -414,7 +414,7 @@ export class SearchWidgetModel extends ViewModel {
 
   search () {
     debounceNamed('search', 500, () => {
-      if (!this.input) {
+      if (!this.input || !this.view.owner) {
         this.cleanup();
         this.showNoSearchHint();
         return;


### PR DESCRIPTION
Fixes an issue where the search highlights would remain in the text editor, when one changed the search string and directly afterwards closed the search widget. As the search operation is done with a slight delay, the highlights would then be kept around.