### PR TITLE
🧰📇: properly escape characters when serialization txtAttrs to expr

### DIFF
--- a/lively.ide/components/reconciliation.js
+++ b/lively.ide/components/reconciliation.js
@@ -1567,7 +1567,7 @@ class TextChangeReconciliation extends PropChangeReconciliation {
       const insertionStartIndex = this.target.positionToIndex(changedRange.start);
       if (isDeletion) {
         const insertionEndIndex = this.target.positionToIndex(changedRange.end);
-        const deleteCharacters = undo.args[1][0].length;
+        const deleteCharacters = JSON.stringify(undo.args[1][0]).slice(1, -1).length;
         const deletionIndexInSource = stringNode.start + insertionStartIndex - attributeStart + 1;
         this.addChangesToModule(modId, [{ action: 'replace', start: deletionIndexInSource, end: deletionIndexInSource + deleteCharacters, lines: [''] }]);
         return this;
@@ -1575,7 +1575,11 @@ class TextChangeReconciliation extends PropChangeReconciliation {
 
       if (isInsertion) {
         const insertionIndexInSource = stringNode.start + insertionStartIndex - attributeStart + 1;
-        this.addChangesToModule(modId, [{ action: 'insert', start: insertionIndexInSource, lines: [attrReplacement[0]] }]);
+        this.addChangesToModule(modId, [{
+          action: 'insert',
+          start: insertionIndexInSource,
+          lines: [JSON.stringify(attrReplacement[0]).slice(1, -1)]
+        }]);
         return this;
       }
     }

--- a/lively.ide/tests/components/reconciliation-test.js
+++ b/lively.ide/tests/components/reconciliation-test.js
@@ -597,14 +597,14 @@ describe('component -> source reconciliation', function () {
     it('correctly replaces other text attributes, in case they are previously present', async () => {
       ComponentT.withMetaDo({ reconcileChanges: true }, () => {
         ComponentT.submorphs[0].textString += 'lol';
-        ComponentT.submorphs[1].textString += 'blubber';
+        ComponentT.submorphs[1].textString += '\nblubber';
       });
       await ComponentD._changeTracker.onceChangesProcessed();
       const updatedSource = await getSource();
       expect(updatedSource).not.to.include('textString: \'yo bro!blubber\'');
       expect(updatedSource).not.to.include('value: \'hello worldlol\'');
       expect(updatedSource).to.include('textAndAttributes: [\'hello worldlol\', null]');
-      expect(updatedSource).to.include('textAndAttributes: [\'yo bro!blubber\', null]');
+      expect(updatedSource).to.include('textAndAttributes: [\'yo bro!\\nblubber\', null]');
     });
 
     it('correctly reconciles text attributes when deleting trailing parts', async () => {

--- a/lively.serializer2/plugins/expression-serializer.js
+++ b/lively.serializer2/plugins/expression-serializer.js
@@ -405,12 +405,13 @@ function handleTextAndAttributes (aMorph, exported, styleProto, path, masterInSc
     if (styleProto?.textString !== aMorph.textString &&
         !obj.equals(styleProto?.textAndAttributes, aMorph.textAndAttributes)) {
       exported.textAndAttributes = aMorph.textAndAttributes.map((ea, i) => {
-        return ea && ea.isMorph
-          ? serializeSpec(ea, { // eslint-disable-line no-use-before-define
+        if (ea && ea.isMorph) {
+          return serializeSpec(ea, { // eslint-disable-line no-use-before-define
             ...opts,
             path: path ? path + '.textAndAttributes.' + i : 'textAndAttributes.' + i
-          })
-          : ea;
+          });
+        }
+        return ea;
       });
     }
     if (exposeMasterRefs && masterInScope?.managesMorph(aMorph.name)) {
@@ -422,7 +423,7 @@ function handleTextAndAttributes (aMorph, exported, styleProto, path, masterInSc
     // all of the above work is then discarded basically...
     if (asExpression && exported.textAndAttributes) {
       // properly serialize some of the attributes such as fontColor
-      exported.textAndAttributes = getArrayExpression('textAndAttributes', aMorph.textAndAttributes, path, opts);
+      exported.textAndAttributes = getArrayExpression('textAndAttributes', aMorph.textAndAttributes.map(ea => typeof ea === 'string' ? JSON.stringify(ea).slice(1, -1) : ea), path, opts);
     }
   }
 


### PR DESCRIPTION
Fixes an issue where entering line breaks into a component text morph, it would mess up the source code during reconciliation.