### PR TITLE
🧰: fix text reconciliation when erasing entire text

### DIFF
--- a/lively.ide/components/helpers.js
+++ b/lively.ide/components/helpers.js
@@ -101,6 +101,9 @@ export function convertToExpression (aMorph, opts = {}) {
 }
 
 export function getTextAttributesExpr (textMorph) {
+  if (textMorph.textString === '') {
+    return { __expr__: '[\'\', null]', bindings: {} };
+  }
   const expr = convertToExpression(textMorph);
   const rootPropNode = getPropertiesNode(parse('(' + expr.__expr__ + ')'));
   let { start, end } = getProp(rootPropNode, 'textAndAttributes').value; // eslint-disable-line no-use-before-define

--- a/lively.ide/components/reconciliation.js
+++ b/lively.ide/components/reconciliation.js
@@ -1536,7 +1536,7 @@ class TextChangeReconciliation extends PropChangeReconciliation {
     const { textAndAttributes } = this.target;
     let stringIndex = 0; let j = 0;
     const startIndex = this.target.positionToIndex(range.start);
-    while (startIndex > stringIndex + textAndAttributes[j].length) {
+    while (j < textAndAttributes.length && startIndex > stringIndex + textAndAttributes[j].length) {
       stringIndex += textAndAttributes[j].length;
       j += 2;
     }


### PR DESCRIPTION
Fixes an issue where erasing the entire contents of a text morph would not get reconciled.