### PR TITLE
🎨: fix ensure spec when adding plain morphs

### DIFF
--- a/lively.ide/text/map.js
+++ b/lively.ide/text/map.js
@@ -13,7 +13,7 @@ export default class TextMap extends Canvas {
 
   static get properties () {
     return {
-      textMorph: {},
+      textMorph: { serialize: false },
       relativeBoundsInTextMorph: {},
       extent: { defaultValue: pt(60, 50) },
       markers: {},

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1462,7 +1462,7 @@ export class PolicyApplicator extends StylePolicy {
     if (currSpec) return currSpec;
 
     // spec could not be found, so we prepare for inserting a spec
-    currSpec = submorph.master || { };
+    currSpec = submorph.master || submorph.spec(true);
     currSpec.name = submorph.name;
     if (this.parent && !this.mentionedByParents(targetName)) {
       // if we have a parent policy, this means we are derived


### PR DESCRIPTION
Previously added morphs would just end up as an empty object in the spec.