### PR TITLE
Fix/upgrade from overriden version

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -417,7 +417,7 @@ export class Project {
     await this.addMissingProjectDependencies();
     // We use author here, as owner can also be an org.
     // This assumes, that the author of org projects has sufficient rights (admin) to retrieve secrets.
-    if ($world.currentUser === this.config.author.name){
+    if (currentUsername() === this.config.author.name) {
       if (remoteConfigured && !lively.isInOfflineMode) await this.setupDependencyPermissions();
     } else {
       console.warn('Dependency permissions might not be setup correctly. To ensure working dependencies remotely, the owner of the project needs to save it.');

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -370,7 +370,7 @@ export class Project {
     const currUserName = currUser.login;
 
     // GH Pages is possible for non-private repositories in any case
-    if (!this.config.lively.repositoryIsPrivate){
+    if (!this.config.lively.repositoryIsPrivate) {
       this.config.lively.canUsePages = true;
       return;
     }
@@ -393,11 +393,9 @@ export class Project {
       // In case the command errors out, we just set the value to false to be on the save side
       if (checkOrgPlanCmd.exitCode !== 0) {
         this.config.lively.canUsePages = false;
-        return;
-      }
-      else {
+      } else {
         const planName = (JSON.parse(checkOrgPlanCmd.stdout))?.plan?.name;
-        if (planName && planName!== 'free') this.config.lively.canUsePages = true;
+        if (planName && planName !== 'free') this.config.lively.canUsePages = true;
         else this.config.lively.canUsePages = false;
       }
     }


### PR DESCRIPTION
We previously did not handle the case where the commit we bound the project against did no longer exist. This should be a super rare case, as we do not bind against branch commits but only the ones on `main`. However, we force-pushed on main recently which caused the lively version a project was bound to to be stuck.

Additionally, this fixes a bug due to calling a non-existing function (another :clown_face:).