### PR TITLE
📂: enable actions by default and swap branch dynamically

### DIFF
--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -520,8 +520,6 @@ export class Project {
 
     // OPINIONATED DEFAULTS
     const livelyConfig = config.lively;
-    livelyConfig.testActionEnabled = true;
-    livelyConfig.buildActionEnabled = false;
     livelyConfig.testOnPush = true;
     livelyConfig.buildOnPush = false;
     livelyConfig.deployOnPush = false;
@@ -614,29 +612,16 @@ export class Project {
     const livelyConfig = this.config.lively;
 
     pipelineFile = join(this.url, '.github/workflows/ci-tests.yml');
-    if (livelyConfig.testActionEnabled) {
-      content = await this.fillPipelineTemplate(workflowDefinition, livelyConfig.testOnPush);
-      await (await resource(pipelineFile).ensureExistance()).write(content);
-    } else {
-      if ((await resource(pipelineFile).exists())) await resource(pipelineFile).remove();
-    }
+    content = await this.fillPipelineTemplate(workflowDefinition, livelyConfig.testOnPush);
+    await (await resource(pipelineFile).ensureExistance()).write(content);
 
     pipelineFile = join(this.url, '.github/workflows/build-upload-action.yml');
-    if (livelyConfig.buildActionEnabled) {
-      content = await this.fillPipelineTemplate(buildRemoteScript, livelyConfig.buildOnPush);
-      await (await resource(pipelineFile).ensureExistance()).write(content);
-    } else {
-      if ((await resource(pipelineFile).exists())) await resource(pipelineFile).remove();
-    }
+    content = await this.fillPipelineTemplate(buildRemoteScript, livelyConfig.buildOnPush);
+    await (await resource(pipelineFile).ensureExistance()).write(content);
 
     pipelineFile = join(this.url, '.github/workflows/deploy-pages-action.yml');
-    if (!livelyConfig.hasOwnProperty('deployActionEnabled')) livelyConfig.deployActionEnabled = this.canDeployToPages;
-    if (livelyConfig.deployActionEnabled && this.canDeployToPages) {
-      content = await this.fillPipelineTemplate(deployScript, livelyConfig.deployOnPush);
-      await (await resource(pipelineFile).ensureExistance()).write(content);
-    } else {
-      if ((await resource(pipelineFile).exists())) await resource(pipelineFile).remove();
-    }
+    content = await this.fillPipelineTemplate(deployScript, livelyConfig.deployOnPush);
+    await (await resource(pipelineFile).ensureExistance()).write(content);
   }
 
   async fillPipelineTemplate (workflowDefinition, triggerOnPush = false) {

--- a/lively.project/templates/build-upload-action.js
+++ b/lively.project/templates/build-upload-action.js
@@ -47,6 +47,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
+          ref: \${{ github.ref }}
           path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Build Project
         run: npm run build-minified --prefix local_projects/%PROJECT_NAME%

--- a/lively.project/templates/deploy-pages-action.js
+++ b/lively.project/templates/deploy-pages-action.js
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
+          ref: \${{ github.ref }}
           path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Build Project
         run: npm run build-minified --prefix local_projects/%PROJECT_NAME%

--- a/lively.project/templates/test-action.js
+++ b/lively.project/templates/test-action.js
@@ -47,6 +47,7 @@ jobs:
       - name: Checkout Project Repository
         uses: actions/checkout@v4
         with:
+          ref: \${{ github.ref }}
           path: local_projects/%PROJECT_NAME%%PROJECT_DEPENDENCIES%
       - name: Start \`lively.next\`
         run: |


### PR DESCRIPTION
We recently discovered that enabling GitHub Actions follows a quite unintuitive logic where an action can only be triggered manually on a branch if its defining file also exists on the `main` branch. 
This was problematic as this meant that it is not possible to manually trigger a deploy from a branch inside of a project, without interfering with the main branch. However, deploying the branch is often useful for testing purposes.

Therefore, I have made the following changes:

1. We now create all workflow files all the time it makes sense to create workflow files.
2. By default, those need to be triggered manually. 
3. When triggering a workflow manually, the branch for which it is triggered is respected.
4. It is still possible to add a `push` trigger to the actions. This is only possible for the `main` branch. This has been made clearer inside of the `ProjectSettingsPrompt`, which now looks like this:

![image](https://github.com/LivelyKernel/lively.next/assets/14252419/81148df5-dd19-43ee-97b0-40dce724ae34)
