### PR TITLE
📂🧰: fix project version binding recovering from non-existing version

### DIFF
--- a/lively.ide/studio/version-checker.cp.js
+++ b/lively.ide/studio/version-checker.cp.js
@@ -215,6 +215,7 @@ class VersionChecker extends Morph {
    * Returns 2 when both compared versions are diverged.
    */
   static parseHashComparison (comparison) {
+    if (comparison === '') return 3;
     comparison = comparison.replace('\n', '').split('\t');
     const numberOfUniqueCommitsOnRemote = parseInt(comparison[0]);
     const numberOfUniqueCommitsLocal = parseInt(comparison[1]);
@@ -246,7 +247,7 @@ class VersionChecker extends Morph {
   indicateOfflineMode (offline) {
     if (!offline) return;
     const { status } = this.ui;
-    status.textAndAttributes = status.textAndAttributes.concat([' (results might be outdated in offline mode)', null]); 
+    status.textAndAttributes = status.textAndAttributes.concat([' (results might be outdated in offline mode)', null]);
   }
 
   showEven (version, offline) {

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -419,7 +419,7 @@ export class Project {
       if (remoteConfigured && !lively.isInOfflineMode) await this.setupDependencyPermissions();
     } else {
       console.warn('Dependency permissions might not be setup correctly. To ensure working dependencies remotely, the owner of the project needs to save it.');
-    };
+    }
     if (!this.configFile) {
       throw Error('No config file found. Should never happen.');
     }
@@ -467,44 +467,42 @@ export class Project {
   }
 
   async bindAgainstCurrentLivelyVersion (knownCompatibleVersion, onlyLoadNotOpen = false) {
-    const doesCommitExists = this.gitResource.runCommand(`git cat-file commit ${knownCompatibleVersion}`).whenDone().exitCode;
-    if (doesCommitExists) {
-      const { comparison } = await lively.checkedProjectVersionRelation || await VersionChecker.checkVersionRelation(knownCompatibleVersion, true);
-      const comparisonBetweenVersions = VersionChecker.parseHashComparison(comparison);
-      if (comparisonBetweenVersions > 0 && onlyLoadNotOpen) {
-        console.warn('A loaded project expects a different lively version than the one currently running.');
-        return;
+    const { comparison } = await lively.checkedProjectVersionRelation || await VersionChecker.checkVersionRelation(knownCompatibleVersion, true);
+    const comparisonBetweenVersions = VersionChecker.parseHashComparison(comparison);
+    if (comparisonBetweenVersions > 0 && onlyLoadNotOpen) {
+      console.warn('A loaded project expects a different lively version than the one currently running.');
+      return;
+    }
+    switch (comparisonBetweenVersions) {
+      case (0): {
+        if (!onlyLoadNotOpen) $world.setStatusMessage('Already using the latest lively version. All good!', StatusMessageConfirm);
+        return 'SUCCESS';
       }
-      switch (comparisonBetweenVersions) {
-        case (0): {
-          if (!onlyLoadNotOpen) $world.setStatusMessage('Already using the latest lively version. All good!', StatusMessageConfirm);
-          return 'SUCCESS';
-        }
-        case (1): {
-          const confirmed = await $world.confirm('This changes the required version of lively.next for this project.\n Are you sure you want to proceed?');
-          if (!confirmed) {
-            $world.setStatusMessage('Changing the required version of lively.next has been canceled.', StatusMessageError);
-            return 'CANCELED';
-          } else {
-            $world.setStatusMessage(`Updated the required version of lively.next for ${this.name}.`, StatusMessageConfirm);
-            const currentCommit = await VersionChecker.currentLivelyVersion(true);
-            this.config.lively.boundLivelyVersion = currentCommit;
-            await this.saveConfigData();
-            return 'UPDATED';
-          }
-        }
-        case (-1):
-        case (2) : {
-          $world.setStatusMessage(`You do not have the version of lively.next necessary to open this project. Please get version ${knownCompatibleVersion} of lively.next`, StatusMessageError);
-          return 'OUTDATED';
+      case (1): {
+        const confirmed = await $world.confirm('This changes the required version of lively.next for this project.\n Are you sure you want to proceed?');
+        if (!confirmed) {
+          $world.setStatusMessage('Changing the required version of lively.next has been canceled.', StatusMessageError);
+          return 'CANCELED';
+        } else {
+          $world.setStatusMessage(`Updated the required version of lively.next for ${this.name}.`, StatusMessageConfirm);
+          const currentCommit = await VersionChecker.currentLivelyVersion(true);
+          this.config.lively.boundLivelyVersion = currentCommit;
+          await this.saveConfigData();
+          return 'UPDATED';
         }
       }
-    } else {
-      $world.setStatusMessage(`The required version of lively.next ${this.name} has been overwritten. ${this.name} has been upgraded to use the latest version available to you.`, StatusMessageWarning);
-      const currentCommit = await VersionChecker.currentLivelyVersion(true);
-      this.config.lively.boundLivelyVersion = currentCommit;
-      await this.saveConfigData();
-      return 'UPDATED';
+      case (-1):
+      case (2): {
+        $world.setStatusMessage(`You do not have the version of lively.next necessary to open this project. Please get version ${knownCompatibleVersion} of lively.next`, StatusMessageError);
+        return 'OUTDATED';
+      }
+      case (3) : {
+        $world.setStatusMessage(`The required version of lively.next ${this.name} has been overwritten. ${this.name} has been upgraded to use the latest version available to you.`, StatusMessageWarning);
+        const currentCommit = await VersionChecker.currentLivelyVersion(true);
+        this.config.lively.boundLivelyVersion = currentCommit;
+        await this.saveConfigData();
+        return 'UPDATED';
+      }
     }
   }
 


### PR DESCRIPTION
We recently merged #1325 which was an absolute mess in hindsight.
We now utilize the already existing comparison mechanism, which I supplemented with a unique value for "empty" commit counts. Those will happen if we plugin a no longer existing commit hash in the comparison.