### PR TITLE
Fix mocha-es6 loading in Test Runner

### DIFF
--- a/lively.ide/test-runner.js
+++ b/lively.ide/test-runner.js
@@ -770,8 +770,9 @@ export default class TestRunner extends HTMLMorph {
       });
 
     // if (!pkg) return null
-
+    const li = LoadingIndicator.open('Finding Testmodules in Package');
     const tests = await findTestModulesInPackage(sys, pkg.url);
+    li.remove();
     const testItems = tests.map(url => {
       const nameInPackage = url.slice(pkg.url.length);
       return {

--- a/lively.ide/test-runner.js
+++ b/lively.ide/test-runner.js
@@ -786,12 +786,10 @@ export default class TestRunner extends HTMLMorph {
       historyId: 'lively.morphic-test-runner-load-tests-module-hist'
     });
 
-    const i = LoadingIndicator.open('running tests');
     try {
       for (const { url, nameInPackage } of selected) {
-        i.label = `Running ${nameInPackage}`;
         await this.runTestFile(url);
       }
-    } finally { i.remove(); }
+    } finally { /* noop */ }
   }
 }


### PR DESCRIPTION
Previously, opening the test runner before mocha-es6 was loaded (i.e., before opening a system browser) would crash and corrupt the global namespace in a way that would also wreck browsers opened later.