### PR TITLE
Fix/css layout bounds computation

### DIFF
--- a/lively.morphic/changes.js
+++ b/lively.morphic/changes.js
@@ -178,9 +178,10 @@ export class ChangeManager {
     // and resulting in an endless loop which shows visible jiggle of text.
     const isScrollChange = change.prop === 'scroll';
     const isStaticText = !morph.document;
+    const skipRender = this.defaultMeta.skipRender;
     const scrollingStaticText = isStaticText && isScrollChange;
 
-    if ((isDocumentChange || isUpdatingChange) && !scrollingStaticText) morph.makeDirty();
+    if ((isDocumentChange || isUpdatingChange) && !scrollingStaticText && !skipRender) morph.makeDirty();
 
     const grouping = arr.last(this.changeGroupStack);
     if (grouping && grouping.consumesChanges()) {

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1510,7 +1510,7 @@ export class PolicyApplicator extends StylePolicy {
 
     const parentSpecOrPolicy = this.ensureSubSpecFor(submorph.owner);
     let parentSpec;
-    if (parentSpecOrPolicy.isPolicy) parentSpec = parentSpecOrPolicy.spec;
+    if (parentSpecOrPolicy.isPolicy) return parentSpecOrPolicy.ensureSubSpecFor(submorph, wrapAsAdded);
     else parentSpec = parentSpecOrPolicy;
     const { submorphs = [] } = parentSpec;
     if (wrapAsAdded) currSpec = add(currSpec);

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1482,7 +1482,7 @@ export class PolicyApplicator extends StylePolicy {
 
   overrideProp (target, prop) {
     if (target.isComponent || target.ownerChain().find(m => m.isComponent)) return; // handled by reconciliation
-    const spec = this.getSubSpecFor(target.name);
+    const spec = this.getSubSpecFor(this.targetMorph === target ? null : target.name);
     if (spec) spec[prop] = target.isComponent ? target[prop] : skippedValue;
   }
 

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1203,10 +1203,14 @@ export class StylePolicy {
    */
   isResizedByLayout (aSubmorph) {
     const layout = aSubmorph.owner && aSubmorph.owner.layout;
-    if (!layout) return false;
-    if (layout.resizePolicies) {
-      const heightPolicy = layout.getResizeHeightPolicyFor(aSubmorph);
-      const widthPolicy = layout.getResizeWidthPolicyFor(aSubmorph);
+    let heightPolicy = 'fixed'; let widthPolicy = 'fixed';
+    if (aSubmorph.isText) {
+      if (!aSubmorph.fixedHeight) heightPolicy = 'hug';
+      if (!aSubmorph.fixedWidth) widthPolicy = 'hug';
+    }
+    if (layout?.resizePolicies) {
+      if (heightPolicy !== 'hug') heightPolicy = layout.getResizeHeightPolicyFor(aSubmorph);
+      if (widthPolicy !== 'hug') widthPolicy = layout.getResizeWidthPolicyFor(aSubmorph);
       if (heightPolicy === 'fill' || widthPolicy === 'fill') return { widthPolicy, heightPolicy };
     }
     return false;

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1445,6 +1445,14 @@ export class PolicyApplicator extends StylePolicy {
     return [this.targetMorph, ...this.targetMorph.ownerChain()].find(m => m.isComponent && !m.viewModel?.view);
   }
 
+  isCurrentlyAnimated (aMorph) {
+    while (aMorph) {
+      if (aMorph.master?._animating) return true;
+      aMorph = aMorph.owner;
+    }
+    return false;
+  }
+
   /**
    * Callback that is invoked once a morph that is managed by the applicator changes.
    * In general this means that if the change is a style property, we override this style prop locally.
@@ -1454,10 +1462,7 @@ export class PolicyApplicator extends StylePolicy {
   onMorphChange (changedMorph, change) {
     if (change.meta?.metaInteraction ||
         !this.targetMorph ||
-        !![
-          changedMorph,
-          ...changedMorph.ownerChain()
-        ].find(m => m.master?._animating)
+        this.isCurrentlyAnimated(changedMorph)
     ) return;
     if (changedMorph._isDeserializing) return;
     if (this.isStaleComponentContext) return;

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1477,8 +1477,9 @@ export class PolicyApplicator extends StylePolicy {
   }
 
   overrideProp (target, prop) {
+    if (target.isComponent || target.ownerChain().find(m => m.isComponent)) return; // handled by reconciliation
     const spec = this.getSubSpecFor(target.name);
-    if (spec) spec[prop] = skippedValue;
+    if (spec) spec[prop] = target.isComponent ? target[prop] : skippedValue;
   }
 
   /**

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -203,6 +203,8 @@ class Layout {
     this.scheduleApply(submorph, animation);
   }
 
+  onOwnerChanged (newOwner) {}
+
   onChange ({ selector, args, prop, value, prevValue, meta }) {
     const anim = this.reactToSubmorphAnimations && meta && meta.animation;
     const submorph = args && args[0];
@@ -753,6 +755,15 @@ export class TilingLayout extends Layout {
 
   onContainerResized (morph) {} // eslint-disable-line no-unused-vars
 
+  onOwnerChanged (newOwner) {
+    this.container._yogaNode?.free();
+    delete this.container._yogaNode;
+    delete this.layoutableSubmorphBounds;
+    this.container.submorphs.forEach(m => {
+      m._yogaNode?.free();
+      delete m._yogaNode;
+    });
+  }
   /**
    * Invoked once a new morph is added to the container.
    * @override

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -389,7 +389,7 @@ export class TilingLayout extends Layout {
     this._resizePolicies = new WeakMap();
     if (Array.isArray(resizePolicies)) {
       resizePolicies.map(([morphName, policy]) => {
-        const m = layoutableSubmorphs.find(m => m.name === morphName);
+        const m = this.container.submorphs.find(m => m.name === morphName);
         if (m) this.setResizePolicyFor(m, policy);
         arr.remove(layoutableSubmorphs, m);
       });

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -359,9 +359,7 @@ export class TilingLayout extends Layout {
   }
 
   attach () {
-    this._initializingPolicies = true;
     this.initializeResizePolicies();
-    this._initializingPolicies = false;
     super.attach();
     this.measureAfterRender(this.container);
   }
@@ -377,9 +375,13 @@ export class TilingLayout extends Layout {
     return aMorph._yogaNode || (aMorph._yogaNode = Yoga.Node.create());
   }
 
-  initializeResizePolicies () {
+  initializeResizePolicies (_initializingPoliciesAfterwards = false) {
+    this._initializingPolicies = true;
     const resizePolicies = this._resizePolicies;
-    if (resizePolicies && !Array.isArray(resizePolicies)) return;
+    if (resizePolicies && !Array.isArray(resizePolicies)) {
+      this._initializingPolicies = _initializingPoliciesAfterwards;
+      return;
+    }
     const { layoutableSubmorphs } = this;
     this._resizePolicies = new WeakMap();
     if (Array.isArray(resizePolicies)) {
@@ -396,6 +398,7 @@ export class TilingLayout extends Layout {
         });
       });
     }
+    this._initializingPolicies = _initializingPoliciesAfterwards;
   }
 
   scheduleApply (submorph, animation, change = {}) {
@@ -502,9 +505,7 @@ export class TilingLayout extends Layout {
   getSpec () {
     if (!this.container) return this.sanitizeConfig(this.config);
     if (Array.isArray(this._resizePolicies)) {
-      this._initializingPolicies = true;
       this.initializeResizePolicies();
-      this._initializingPolicies = false;
     }
     let {
       axis, align, axisAlign, spacing, orderByIndex, resizePolicies,
@@ -1119,10 +1120,7 @@ export class TilingLayout extends Layout {
   ensureResizePolicies (layoutableSubmorphs) {
     if (!layoutableSubmorphs.every(m => this._resizePolicies.has(m))) {
       this._resizePolicies = this.config.resizePolicies;
-      const before = this._initializingPolicies;
-      this._initializingPolicies = true;
-      this.initializeResizePolicies();
-      this._initializingPolicies = before;
+      this.initializeResizePolicies(this._initializingPolicies);
     }
   }
 

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -237,7 +237,7 @@ class Layout {
   }
 
   onConfigUpdate () {
-    this.apply();
+    this.scheduleApply();
     if (!this._configChanged) {
       this._configChanged = true;
       this.layoutableSubmorphs.forEach(m => m.makeDirty());

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -329,7 +329,7 @@ export class TilingLayout extends Layout {
     this._justifySubmorphs = props.justifySubmorphs || 'packed';
     this._hugContentsVertically = props.hugContentsVertically || false;
     this._hugContentsHorizontally = props.hugContentsHorizontally || false;
-    this._orderByIndex = props.orderByIndex || false;
+    this._orderByIndex = props.orderByIndex || true;
     this._wrapSubmorphs = false;
     if (typeof props.wrapSubmorphs !== 'undefined') {
       this._wrapSubmorphs = props.wrapSubmorphs;

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -734,6 +734,7 @@ export class TilingLayout extends Layout {
   }
 
   get embeddedInTiling () {
+    if (!this.container.isLayoutable) return false;
     return this.container.owner?.layout?.name() === 'Tiling';
   }
 

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -926,14 +926,16 @@ export class TilingLayout extends Layout {
         margin.left = 0;
         margin.right = 0;
       } else {
-        style.width = 'unset';
+        // style.width = 'unset';
+        style.width = `calc(100% + ${margin.offset}px)`;
         style['flex-grow'] = 1;
         style['flex-shrink'] = 1;
       } // let flex handle that
     }
     if (this.getResizeHeightPolicyFor(morph) === 'fill') {
       if (isVertical) {
-        style.height = 'unset';
+        style.height = `calc(100% + ${margin.offset}px)`;
+        // style.height = 'unset';
         style['flex-grow'] = 1; // let flex handle that
         style['flex-shrink'] = 1;
       } else {

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -149,10 +149,10 @@ class Layout {
   }
 
   get noLayoutActionNeeded () {
-    return !this.submorphBoundsChanged &&
-            !this.boundsChanged(this.container) &&
+    return !this.submorphsChanged &&
             !this.extentChanged(this.container) &&
-            !this.submorphsChanged;
+            !this.boundsChanged(this.container) &&
+            !this.submorphBoundsChanged;
   }
 
   get __dont_serialize__ () { return ['lastAnim', 'animationPromise']; }

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -32,7 +32,7 @@ class Layout {
       this.layoutOrder = layoutOrder;
       this.layoutOrderSource = JSON.stringify(String(layoutOrder));
     }
-    this.spacing = spacing || 0;
+    this._spacing = spacing || 0;
     this._padding = !padding ? Rectangle.inset(0) : typeof padding === 'number' ? Rectangle.inset(padding) : Rectangle.fromLiteral(padding);
   }
 
@@ -232,6 +232,10 @@ class Layout {
            !obj.equals(value, prevValue);
   }
 
+  get isLayoutAction () {
+    return this.container?.env.changeManager.defaultMeta.isLayoutAction;
+  }
+
   onConfigUpdate () {
     this.apply();
     if (!this._configChanged) {
@@ -243,7 +247,7 @@ class Layout {
       }
     }
     if (this._initializingPolicies) return;
-    this.getAffectedPolicy()?.overrideProp(this.container, 'layout');
+    if (!this.isLayoutAction) this.getAffectedPolicy()?.overrideProp(this.container, 'layout');
   }
 
   onSubmorphChange (submorph, change) {
@@ -768,8 +772,10 @@ export class TilingLayout extends Layout {
    */
   onSubmorphAdded (submorph) {
     if (!this._resizePolicies.get(submorph)) {
-      this.setResizePolicyFor(submorph, {
-        width: 'fixed', height: 'fixed'
+      submorph.withMetaDo({ isLayoutAction: true }, () => {
+        this.setResizePolicyFor(submorph, {
+          width: 'fixed', height: 'fixed'
+        });
       });
     }
   }

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -244,6 +244,7 @@ class Layout {
         this.container.renderingState.hasCSSLayoutChange = true;
       }
     }
+    if (this._initializingPolicies) return;
     this.getAffectedPolicy()?.overrideProp(this.container, 'layout');
   }
 
@@ -356,7 +357,9 @@ export class TilingLayout extends Layout {
   }
 
   attach () {
+    this._initializingPolicies = true;
     this.initializeResizePolicies();
+    this._initializingPolicies = false;
     super.attach();
     this.measureAfterRender(this.container);
   }
@@ -503,7 +506,11 @@ export class TilingLayout extends Layout {
    */
   getSpec () {
     if (!this.container) return this.sanitizeConfig(this.config);
-    if (Array.isArray(this._resizePolicies)) { this.initializeResizePolicies(); }
+    if (Array.isArray(this._resizePolicies)) {
+      this._initializingPolicies = true;
+      this.initializeResizePolicies();
+      this._initializingPolicies = false;
+    }
     let {
       axis, align, axisAlign, spacing, orderByIndex, resizePolicies,
       reactToSubmorphAnimations, renderViaCSS, padding, wrapSubmorphs,
@@ -1074,7 +1081,10 @@ export class TilingLayout extends Layout {
   ensureResizePolicies (layoutableSubmorphs) {
     if (!layoutableSubmorphs.every(m => this._resizePolicies.has(m))) {
       this._resizePolicies = this.config.resizePolicies;
+      const before = this._initializingPolicies;
+      this._initializingPolicies = true;
       this.initializeResizePolicies();
+      this._initializingPolicies = before;
     }
   }
 

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -755,6 +755,7 @@ export class TilingLayout extends Layout {
   onContainerResized (morph) {} // eslint-disable-line no-unused-vars
 
   onOwnerChanged (newOwner) {
+    if (newOwner) return;
     this.container._yogaNode?.free();
     delete this.container._yogaNode;
     delete this.layoutableSubmorphBounds;

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -368,15 +368,8 @@ export class TilingLayout extends Layout {
 
   ensureLayoutComputed (curr) {
     const origNode = this.ensureYogaNodeFor(curr);
-    while (curr.owner?._yogaNode && curr.isLayoutable) curr = curr.owner;
-    try {
-      curr._yogaNode.calculateLayout();
-    } catch (err) {
-      // the node needs to be replaced
-      curr._yogaNode.free();
-      delete curr._yogaNode;
-      this.ensureYogaNodeFor(curr);
-    }
+    while (curr.owner?._yogaNode && curr.owner.layout && curr.isLayoutable) curr = curr.owner;
+    curr._yogaNode.calculateLayout();
     return origNode;
   }
 

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -67,10 +67,6 @@ class Layout {
     const submorphNode = this.getNodeFor(layoutableSubmorph);
     if (!layoutableSubmorph.isLayoutable) return;
     this.onDomResize(submorphNode, layoutableSubmorph);
-    if (layoutableSubmorph._correctRender) {
-      layoutableSubmorph._correctRender(submorphNode);
-      delete layoutableSubmorph._correctRender;
-    }
   }
 
   copy () { return new this.constructor(this); }
@@ -752,6 +748,8 @@ export class TilingLayout extends Layout {
    * the layoutable submorphs from there.
    */
   onDomResize (node, morph) {} // eslint-disable-line no-unused-vars
+
+  measureSubmorph () {} // do nothing
 
   onContainerResized (morph) {} // eslint-disable-line no-unused-vars
 

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1743,7 +1743,13 @@ export class Morph {
    * In case it was attached to a new parent, that morph is referenced by `newOwner`.
    * @param { Morph|null } newOwner - If applicable, the new owner the morph is assigned to.
    */
-  onOwnerChanged (newOwner) { delete this._ownerChain; }
+  onOwnerChanged (newOwner) {
+    delete this._ownerChain;
+    this.withAllSubmorphsDo(m => {
+      m._yogaNode?.free();
+      delete m._yogaNode;
+   });
+  }
 
   async fadeOut (duration = 1000) {
     await this.animate({ opacity: 0, duration, easing: easings.outQuad });

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2540,8 +2540,9 @@ export class Morph {
   }
 
   applyLayoutIfNeeded () {
-    for (let i = 0; i < this.submorphs.length; i++) { this.submorphs[i].applyLayoutIfNeeded(); }
+    if (!this.needsRerender()) return;
     this.layout && !this.layout.manualUpdate && this.layout.onContainerRender();
+    for (let i = 0; i < this.submorphs.length; i++) { this.submorphs[i].applyLayoutIfNeeded(); }
   }
 
   requestMasterStyling () {

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1199,7 +1199,9 @@ export class Morph {
     const anim = change.meta && change.meta.animation;
     const { prop, value } = change;
 
-    if (prop === 'origin') this.renderingState.hasStructuralChanges = true;
+    if (prop === 'origin' || prop && prop.includes('borderWidth')) {
+      this.renderingState.hasStructuralChanges = true;
+    }
 
     if (prop === 'position' || prop === 'rotation' ||
         prop === 'scale' ||

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1747,10 +1747,7 @@ export class Morph {
    */
   onOwnerChanged (newOwner) {
     delete this._ownerChain;
-    this.withAllSubmorphsDo(m => {
-      m._yogaNode?.free();
-      delete m._yogaNode;
-   });
+    this.layout?.onOwnerChanged(newOwner);
   }
 
   async fadeOut (duration = 1000) {

--- a/lively.morphic/package.json
+++ b/lively.morphic/package.json
@@ -47,7 +47,8 @@
       "jsdiff": "esm://cache/jsdiff",
       "dom-to-image": "esm://cache/dom-to-image",
       "bowser": "esm://cache/bowser@1.4.1",
-      "webfontloader": "esm://cache/webfontloader"
+      "webfontloader": "esm://cache/webfontloader",
+      "yoga-layout": "esm://cache/yoga-layout"
     }
   },
   "scripts": {

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -153,7 +153,7 @@ export default class Renderer {
     for (let morph of morphsToHandle) {
       if (morph.renderingState.hasMorphRemoved) this.morphsWithStructuralChanges.unshift(morph);
       else if (morph.renderingState.hasStructuralChanges) this.morphsWithStructuralChanges.push(morph);
-      if (morph.renderingState.needsRerender) this.renderedMorphsWithChanges.push(morph);
+      if (morph.renderingState.needsRerender) this.renderedMorphsWithChanges.unshift(morph);
       if (morph.renderingState.animationAdded) this.renderedMorphsWithAnimations.push(morph);
       if (morph.renderingState.cssLayoutToMeasureWith) this.renderedMorphsToBeMeasured.unshift([morph, morph.renderingState.cssLayoutToMeasureWith]);
     }

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -153,7 +153,7 @@ export default class Renderer {
     for (let morph of morphsToHandle) {
       if (morph.renderingState.hasMorphRemoved) this.morphsWithStructuralChanges.unshift(morph);
       else if (morph.renderingState.hasStructuralChanges) this.morphsWithStructuralChanges.push(morph);
-      if (morph.renderingState.needsRerender) this.renderedMorphsWithChanges.unshift(morph);
+      if (morph.renderingState.needsRerender) this.renderedMorphsWithChanges.push(morph);
       if (morph.renderingState.animationAdded) this.renderedMorphsWithAnimations.push(morph);
       if (morph.renderingState.cssLayoutToMeasureWith) this.renderedMorphsToBeMeasured.unshift([morph, morph.renderingState.cssLayoutToMeasureWith]);
     }
@@ -185,8 +185,7 @@ export default class Renderer {
         this.morphsToRevisit.push(morph);
       }
     }
-
-    for (let morph of this.morphsToRevisit.reverse()) {
+    for (let morph of this.morphsToRevisit) {
       this.renderStylingChanges(morph);
     }
 


### PR DESCRIPTION
Fixes performance issues with the bounds updates of morphs affected by tiling layouts. Also addresses various other issues that causes tiling layouts to break when used in tandem with style policies.

- [x] Fix tests
- [x] Ensure the case for nested layouts and bounds computation works (via tests)
- [x] Still some lagging behavior in submitting bounds adjustment. Maybe move the bounds computation entirely in front of the render pass.