### PR TITLE
🧰: prevent layout control from nuking layouts on unfocus

### DIFF
--- a/lively.ide/studio/properties-panel.cp.js
+++ b/lively.ide/studio/properties-panel.cp.js
@@ -194,6 +194,7 @@ export class PropertiesPanelModel extends ViewModel {
     this.models.borderControl.targetMorph = null;
     this.models.borderControl.deactivate();
     this.models.textControl.deactivate();
+    this.models.layoutControl.targetMorph = null;
     this.models.layoutControl.deactivate();
 
     this.models.componentControl.closePopup();


### PR DESCRIPTION
Fixes an oversight from #1343.