### PR TITLE
🧰: fix missing spec updating during text reconciliation

### DIFF
--- a/lively.ide/components/reconciliation.js
+++ b/lively.ide/components/reconciliation.js
@@ -1534,6 +1534,8 @@ class TextChangeReconciliation extends PropChangeReconciliation {
     const { target: textMorph } = this.change;
     const { requiredBindings, modId } = this.getDescriptorContext();
     const specNode = this.getNodeForTargetInSource();
+    const styleSpec = this.getSubSpecForTarget();
+    styleSpec.textAndAttributes = textMorph.textAndAttributes;
     if (!specNode) {
       this.uncollapseSubmorphHierarchy();
       return this;


### PR DESCRIPTION
Resolves #1345.