### PR TITLE
🧰: fix destructuring error

### DIFF
--- a/lively.ide/text/map.js
+++ b/lively.ide/text/map.js
@@ -90,6 +90,7 @@ export default class TextMap extends Canvas {
 
   get measure () {
     let { width, height, textMorph } = this;
+    if (!textMorph) return;
     let { document: doc } = textMorph;
     let heightPerLine = Math.min(2, height / doc.lines.length);
     let widthPerChar = 0.5;
@@ -99,9 +100,11 @@ export default class TextMap extends Canvas {
   update () {
     let {
       context: ctx,
-      textMorph,
-      measure: { width, height, heightPerLine, widthPerChar }
+      textMorph
     } = this;
+    const measure = this.measure;
+    if (!measure) return;
+    let { width, height, heightPerLine, widthPerChar } = measure;
     function highlightRange (range, color, fullLine = false) {
       let { start, end } = range;
       let selHeight = Math.max((end.row - start.row + 1) * heightPerLine, 1);


### PR DESCRIPTION
Fixes an error that occurred super often when using the search inside of the system browser and then cancelling the search via clicking outside of the browser.
It was not particularly harmful, but annoyingly spammed the console.