### PR TITLE
Fix Recursion when measuring static `Text`

### DIFF
--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1939,6 +1939,9 @@ export default class Renderer {
    * @returns {Rectangle} The actual bounds of `morph` when rendered into the DOM.
    */
   measureStaticTextBoundsFor (morph) {
+
+    morph._measuringTextBox = true;
+
     if (!morph.renderingState.needsRemeasure && morph._cachedBounds) return morph._cachedBounds;
 
     let node = this.getNodeForMorph(morph);
@@ -1987,6 +1990,9 @@ export default class Renderer {
       morph._cachedBounds = bounds;
       morph.renderingState.needsRemeasure = false;
     }
+
+   morph._measuringTextBox = false;
+
     return bounds;
   }
 

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1968,6 +1968,7 @@ export default class Renderer {
     this.placeholder.appendChild(textNode);
     const domMeasure = this.placeholder.getBoundingClientRect();
     textNode.style.removeProperty('width');
+    textNode.style.removeProperty('height');
     textNode.style.removeProperty('position');
     const bounds = new Rectangle(domMeasure.x, domMeasure.y, Math.ceil(domMeasure.width), Math.ceil(domMeasure.height));
 


### PR DESCRIPTION
This resolves an bug that only became apparent once one begins to ensure, that the `textLayer` is always the same node. Due to the `extent` getter measuring the text and us accessing width/height we triggered a measurement in the measurement, which fucked up the state of the node that is moved around inside of the placeholder for the measurement.

Preventing this behavior here has no downside to the measuring process, as we only access the width/height when the dimension is marked as fixed in the properties, i.e. we can retrieve a value guaranteed to be correct without measuring.