### PR TITLE
🎨: fix incorrenct behavior of different `line-wrapping` values

### DIFF
--- a/lively.morphic/assets/morphic.css
+++ b/lively.morphic/assets/morphic.css
@@ -198,13 +198,13 @@ input:placeholder {
 
 .newtext-text-layer.wrap-by-words {
   white-space: pre-wrap;
-  overflow-wrap: break-word;
+  word-break: break-word;
   max-width: 100%;
 }
 
 .newtext-text-layer.only-wrap-by-words {
   white-space: pre-wrap;
-  overflow-wrap: break-all;
+  word-break: normal;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Previously, the behavior of `break-words-only` was wrong, as it behaved like `by-chars`. 
For more information on the used CSS property see here: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break