### PR TITLE
🧰: fit selected text morph if height/width set to hug

### DIFF
--- a/lively.ide/studio/controls/shape.cp.js
+++ b/lively.ide/studio/controls/shape.cp.js
@@ -360,6 +360,7 @@ export class ShapeControlModel extends ViewModel {
           target.withMetaDo({ reconcileChanges: true }, () => {
             target.fixedWidth = false;
           });
+          target.fit();
         } else {
           target.layout.hugContentsHorizontally = true;
           target.layout.wrapSubmorphs = false;
@@ -436,6 +437,7 @@ export class ShapeControlModel extends ViewModel {
           target.withMetaDo({ reconcileChanges: true }, () => {
             target.fixedHeight = false;
           });
+          target.fit();
         } else {
           target.layout.hugContentsVertically = true;
           target.layout.wrapSubmorphs = false;


### PR DESCRIPTION
This makes it so that toggling the hug behavior via the sidebar immediately fits the text morph to its hugging dimension.