### PR TITLE
🎛️: update item scroll if list extent change

### DIFF
--- a/lively.components/list.js
+++ b/lively.components/list.js
@@ -628,6 +628,11 @@ export class List extends Morph {
 
   onChange (change) {
     const { prop } = change;
+    if (prop === 'extent') {
+      if (this.itemHeight * this.items.length < this.height) {
+        this.itemScroll = pt(0, 0);
+      }
+    }
     const styleProps = [
       'fontFamily', 'fontColor', 'fontSize', 'padding',
       'selectionFontColor', 'selectionColor',


### PR DESCRIPTION
Fixes an annoying issue where resizing a scrolled list would lock in the scroll when the list was resized such that the scrollable area is exceeded by the new extent.