### PR TITLE
👼: ensure halos stick around after drop via grab

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1882,8 +1882,9 @@ export default class Halo extends Morph {
   }
 
   removeIfDetached (newOwner) {
+    const isGrabAction = this.target.undoInProgress?.name === 'grab-halo';
     setTimeout(() => {
-      if (this.target.undoInProgress?.name === 'grab-halo') {
+      if (isGrabAction) {
         return;
       }
       if (!newOwner || !this.target.owner) this.remove();


### PR DESCRIPTION
A further refinement of  #1353. I also noticed that we lost the default behavior of the halo to keep that target selected once it has been dropped onto a new location.