### PR TITLE
Fix/selection bug

### DIFF
--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -1350,14 +1350,14 @@ export default class Renderer {
       if (isWrapped) {
         // since wrapped lines spread multiple "rendered" rows, we need to do add in a couple of
         // additional selection parts here
-        const rangesToRender = textLayout.rangesOfWrappedLine(morph, row);
+        let rangesToRender = textLayout.rangesOfWrappedLine(morph, row);
         let isFirstSubLine = isFirstLine;
         let subLineMinY = 0;
         let subCharBounds;
         let subLineMaxBottom;
+        rangesToRender = rangesToRender.map(r => r.intersect(selection)).filter(r => !r.isEmpty());
         const isMultiline = rangesToRender.length > 1;
-        for (const r of rangesToRender.map(r => r.intersect(selection)).filter(r => !r.isEmpty())) {
-          if (r.isEmpty()) continue;
+        for (const r of rangesToRender) {
           const addTrailingSpace = isMultiline && (r.end.column !== cursorPosition.column || r === rangesToRender[0]);
           subCharBounds = charBounds.slice(r.start.column, r.end.column + (addTrailingSpace ? 1 : 0));
 

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -347,7 +347,6 @@ export default class Renderer {
    * @param {Morph} morph - Morph of which the submorphs should be unwrapped.
    */
   unwrapSubmorphNodesIfNecessary (node, morph) {
-    let children = Array.from(node.children);
     // do nothing if submorph nodes are not wrapped
     // e.g. in case we have had a css layout already, this can be skipped
     const wrapperNode = morph.renderingState.submorphNode;
@@ -421,8 +420,7 @@ export default class Renderer {
           if (n.id === `submorphs-${morph.id}`) {
             n.remove();
             delete morph.renderingState.submorphNode;
-          }
-          else if (!n.className) n.remove();
+          } else if (!n.className) n.remove();
           else if (n.classList.contains('morph')) n.remove();
         });
       } else {
@@ -667,7 +665,7 @@ export default class Renderer {
    * @param {Morph} morph - a morph to be rendered.
    * @returns {Node} A `DIV` node.
    */
-  nodeForMorph (morph) {
+  nodeForMorph (morph) { // eslint-disable-line no-unused-vars
     return this.doc.createElement('div');
   }
 
@@ -694,7 +692,7 @@ export default class Renderer {
     return node;
   }
 
-  nodeForImage (morph) {
+  nodeForImage (morph) { // eslint-disable-line no-unused-vars
     const node = this.doc.createElement('div');
     const imageNode = this.doc.createElement('img');
 
@@ -774,7 +772,7 @@ export default class Renderer {
       node.appendChild(textLayerForFontMeasure);
       morph.renderingState.fontMeasureNode = textLayerForFontMeasure;
       this.scrollWrapperFor(morph);
-      const scrollWrapper = morph.renderingState.scrollWrapper
+      const scrollWrapper = morph.renderingState.scrollWrapper;
       node.appendChild(scrollWrapper);
       scrollWrapper.appendChild(textLayer);
     } else node.appendChild(textLayer);


### PR DESCRIPTION
The problem occurred due the fact that we too eagerly classified stuff as multi-line, which caused the selection to grow once to the right, as that is added for multi-line-stuff to cover the line break properly.
We classified all selections in wrapped lines as being multi-line, despite the important part being that the check whether the selection itself also covers multiple lines.
