### PR TITLE
Fix/misaligned prompts

### DIFF
--- a/lively.components/prompts.cp.js
+++ b/lively.components/prompts.cp.js
@@ -13,10 +13,10 @@ export class AbstractPromptModel extends ViewModel {
       autoRemove: { defaultValue: true },
       answer: { defaultValue: null, derived: true },
       title: {
-        defaultValue: 'A prompt title',
+        defaultValue: 'A prompt title'
       },
       text: {
-        defaultValue: null,
+        defaultValue: null
       },
       isPrompt: {
         get () { return true; }
@@ -102,7 +102,7 @@ export class AbstractPromptModel extends ViewModel {
 export class InformPromptModel extends AbstractPromptModel {
   static get properties () {
     return {
-      lineWrapping: { defaultValue: true },
+      lineWrapping: { defaultValue: 'by-words' },
       bindings: {
         get () {
           return [
@@ -124,7 +124,7 @@ export class ConfirmPromptModel extends AbstractPromptModel {
   static get properties () {
     return {
       forceConfirm: { defaultValue: false },
-      lineWrapping: { defaultValue: true },
+      lineWrapping: { defaultValue: 'by-words' },
       confirmLabel: { defaultValue: 'OK' },
       rejectLabel: { defaultValue: 'CANCEL' },
       bindings: {
@@ -204,7 +204,7 @@ export class MultipleChoicePromptModel extends ConfirmPromptModel {
 export class TextPromptModel extends ConfirmPromptModel {
   static get properties () {
     return {
-      lineWrapping: { defaultValue: true },
+      lineWrapping: { defaultValue: 'by-words' },
       errorMessage: { defaultValue: 'Invalid Input' },
       confirmLabel: { defaultValue: 'OK' },
       rejectLabel: { defaultValue: 'CANCEL' },

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -1050,7 +1050,7 @@ export class LivelyWorld extends World {
 
   setStatusMessage (message, StatusMessageComponent, delay = 5000, optStyle = {}) {
     if (!StatusMessageComponent) StatusMessageComponent = StatusMessageDefault;
-    let consoleFunc = 'log'
+    let consoleFunc = 'log';
     if (StatusMessageComponent === StatusMessageError) consoleFunc = 'error';
     if (StatusMessageComponent === StatusMessageWarning) consoleFunc = 'warn';
     console[consoleFunc](message); // eslint-disable-line no-console
@@ -1097,6 +1097,7 @@ export class LivelyWorld extends World {
 
     return this.withRequesterDo(opts.requester, async (pos) => {
       promptMorph.openInWorld();
+      promptMorph.applyLayoutIfNeeded(); // manually apply layouts now since we do not want to wait for the renderer
       promptMorph.center = pos;
       if (promptMorph.height > visBounds.height) { promptMorph.height = visBounds.height - 5; }
 

--- a/lively.morphic/rendering/font-metric.js
+++ b/lively.morphic/rendering/font-metric.js
@@ -787,7 +787,7 @@ export function charBoundsOfLineViaCanvas (line, textMorph, fontMetric, measure)
     const lineWidth = arr.max(Object.values(boundsPerInnerLine).map(bs => arr.sum(bs.map(b => b[1][0]))));
     totalWidth = (line.width === textMorph.document.width ? lineWidth : textMorph.document.width) + paddedSpace;
   } else {
-    totalWidth = Math.max(textMorph.document.width + paddedSpace, totalWidth);
+    totalWidth = Math.max(textMorph.document ? textMorph.document.width + paddedSpace : 0, totalWidth);
   }
 
   for (let row in boundsPerInnerLine) {


### PR DESCRIPTION
Resolves the case reported in #1129 for prompts.

In order for this to work in a general way, we need to trigger the layout manually via the `bounds()` function of the Morph, which may lead to some performance issues. So this is a special case for now.