### PR TITLE
🎨: force text morph fixedWidth/Height true if resized by layout

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -238,14 +238,22 @@ export class Text extends Morph {
         group: 'text',
         isStyleProp: true,
         after: ['clipMode', 'renderingState'],
-        defaultValue: false
+        defaultValue: false,
+        get () {
+          if (this.owner?.layout?.resizesMorphHorizontally(this)) return true;
+          return this.getProperty('fixedWidth');
+        }
       },
 
       fixedHeight: {
         group: 'text',
         isStyleProp: true,
         after: ['clipMode', 'renderingState'],
-        defaultValue: false
+        defaultValue: false,
+        get () {
+          if (this.owner?.layout?.resizesMorphVertically(this)) return true;
+          return this.getProperty('fixedHeight');
+        }
       },
 
       autofit: {


### PR DESCRIPTION
Resolves fighting infinite loops between text morphs and layouts that were trying to resize them.
We decide that the layouts win. @linusha I checked various tools in the system, and could not encounter a broken looking one, so I assume this should work.