### PR TITLE
Fix/polygon submorph

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -3484,7 +3484,7 @@ export class Path extends Morph {
       this.renderingState.startMarker = this.startMarker;
     }
 
-    if (!this.clipMode !== this.renderingState.clipMode) {
+    if (this.clipMode !== this.renderingState.clipMode) {
       renderer.renderPolygonClipMode(this);
       this.renderingState.clipMode = this.clipMode;
     }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -3485,7 +3485,7 @@ export class Path extends Morph {
     }
 
     if (this.clipMode !== this.renderingState.clipMode) {
-      renderer.renderPolygonClipMode(this, this.renderingState.submorphNode);
+      renderer.renderPolygonClipMode(this, node);
       this.renderingState.clipMode = this.clipMode;
     }
 

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -3485,7 +3485,7 @@ export class Path extends Morph {
     }
 
     if (this.clipMode !== this.renderingState.clipMode) {
-      renderer.renderPolygonClipMode(this);
+      renderer.renderPolygonClipMode(this, this.renderingState.submorphNode);
       this.renderingState.clipMode = this.clipMode;
     }
 

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -332,7 +332,7 @@ export default class Renderer {
       wrapperNode.style.setProperty('left', `${oX - (morph.isPath ? 0 : borderWidthLeft)}px`);
       wrapperNode.style.setProperty('top', `${oY - (morph.isPath ? 0 : borderWidthTop)}px`);
     }
-    if (morph.isPolygon) this.renderPolygonClipMode(morph, morph.renderingState.submorphNode);
+    if (morph.isPolygon) this.renderPolygonClipMode(morph, node);
     return wrapperNode;
   }
 
@@ -2321,7 +2321,10 @@ export default class Renderer {
     });
   }
 
-  renderPolygonClipMode (morph, submorphNode) {
+  renderPolygonClipMode (morph, node) {
+    const submorphNode = morph.renderingState.submorphNode;
+    node.style.overflow = morph.isClip() ? 'hidden' : 'visible';
+
     if (submorphNode) {
       submorphNode.style.setProperty('overflow', `${morph.clipMode}`);
       if (morph.clipMode !== 'visible') {

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -305,8 +305,6 @@ export default class Renderer {
    * @param {Boolean} fixChildNodes - Whether or not the nodes that are already children of `node` should be moved into the wrapper node.
    */
   installWrapperNodeFor (morph, node, fixChildNodes = false) {
-    if (morph.isPolygon) this.renderPolygonClipMode(morph, this.submorphWrapperNodeFor(morph));
-
     let wrapperNode = morph.renderingState.submorphNode;
     if (!wrapperNode) {
       this.submorphWrapperNodeFor(morph);
@@ -329,13 +327,13 @@ export default class Renderer {
           if (n !== wrapperNode && n !== wrapperNode.parentElement) { wrapperNode.appendChild(n); }
         });
       }
-      return wrapperNode;
     } else {
       let { borderWidthLeft, borderWidthTop, origin: { x: oX, y: oY } } = morph;
       wrapperNode.style.setProperty('left', `${oX - (morph.isPath ? 0 : borderWidthLeft)}px`);
       wrapperNode.style.setProperty('top', `${oY - (morph.isPath ? 0 : borderWidthTop)}px`);
-      return wrapperNode;
     }
+    if (morph.isPolygon) this.renderPolygonClipMode(morph, morph.renderingState.submorphNode);
+    return wrapperNode;
   }
 
   /**
@@ -2324,9 +2322,6 @@ export default class Renderer {
   }
 
   renderPolygonClipMode (morph, submorphNode) {
-    if (!submorphNode) {
-      submorphNode = Array.from(this.getNodeForMorph(morph).children).find(n => n.id && n.id.includes('submorphs'));
-    }
     if (submorphNode) {
       submorphNode.style.setProperty('overflow', `${morph.clipMode}`);
       if (morph.clipMode !== 'visible') {

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -412,7 +412,10 @@ export default class Renderer {
         // two SVG nodes are necessary
         // remove everything else, in the case that we have unwrapped submorph nodes
         node.childNodes.forEach(n => {
-          if (n.tagName !== 'svg') n.remove();
+          if (n.tagName !== 'svg') {
+            n.remove();
+            delete morph.renderingState.submorphNode;
+          }
         });
       } else if (morph.isText && morph.document) {
         // we need to keep markers, selections, syntax errors etc. around


### PR DESCRIPTION
Closes #1410.

1. The condition which we use to determine whether we need to patch the `clipMode` of a `Path` was malformed, so that we patched it always.
2. One `Path` specific code-path was missing a clearing of the `renderingState.submorphNode` property. This was the cause for the eaten submorphs.
3. Investigating 2) I found out that the  invocation and implementation of `renderPolygonClipMode` was not as well streamlined as it could be.
4. Adding a submorph into a `Path`, changing the `Path`s `clipMode` to `hidden` and then changing it back to `visible` resulted in the submorph being cutoff at the border of the bounds of the `Path`. This was due to to fact the we did not correctly update the `overflow` property of the `Paths` morph node itself.