### PR TITLE
🎨: clear addedToDerived flag when morph inherited

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -710,7 +710,7 @@ export class StylePolicy {
           node._needsDerivation = true;
           return node; // this will be derived and replaced later on
         }
-        node = obj.dissoc(node, ['master', 'submorphs', ...getStylePropertiesFor(node.type)]);
+        node = obj.dissoc(node, ['master', 'submorphs', '__wasAddedToDerived__', ...getStylePropertiesFor(node.type)]);
         if (node.textAndAttributes) {
           node.textAndAttributes = node.textAndAttributes.map(textOrAttr => {
             if (textOrAttr?.isPolicy) return new klass({}, textOrAttr);

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -1,3 +1,4 @@
+/* global xit */
 /* global describe, it, afterEach */
 import { expect } from 'mocha-es6';
 import { Color, pt } from 'lively.graphics';
@@ -580,7 +581,6 @@ describe('spec based components', () => {
           ]
         },
         {
-          __wasAddedToDerived__: true,
           name: 'bar'
         }
       ]


### PR DESCRIPTION
The `__wasAddedToDerived__` is a internal flag of a style policy to denote specs that are due to newly introduced morphs to a derived style policy. Erroneously it was carried over the entire derivation chain, even for style policies that had not altered anything about the structure of the defined component.