### PR TITLE
Fix/animations meta

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1314,7 +1314,7 @@ export class Morph {
     const animationConfigs = Object.values(arr.groupBy(changes, change => change.target.id))
       .map((changes) => {
         const animConfig = { ...config };
-        let target;
+        let target; let meta = {};
         // group all of the changes by prop
         Object.values(arr.groupBy(changes, change => change.prop)).forEach(changes => {
           let [change] = changes;
@@ -1330,11 +1330,12 @@ export class Morph {
             change.reverseApply();
           });
           animConfig[change.prop] = change.value;
+          Object.assign(meta, change.meta);
         });
-        return [target, animConfig];
+        return [target, animConfig, meta];
       });
-    await Promise.all(animationConfigs.map(([target, animConfig]) => {
-      return target && target.animate(animConfig);
+    await Promise.all(animationConfigs.map(([target, animConfig, meta]) => {
+      return target?.withMetaDo(meta, () => target.animate(animConfig));
     }));
   }
 

--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -110,6 +110,7 @@ export class PropertyAnimation {
     this.queue = queue;
     this.morph = morph;
     this.isStyleApplication = config.isStyleApplication;
+    this.metaAtRegistration = { ...morph.env.changeManager.defaultMeta };
     delete config.isStyleApplication;
     if (morph.isPath && 'fill' in config) {
       const fillBefore = morph.fill || Color.transparent; const fillAfter = config.fill;
@@ -438,7 +439,9 @@ export class PropertyAnimation {
             customTween(easingFn(p));
           }));
         if (p >= 1) {
-          customTween(easingFn(1));
+          this.morph.withMetaDo(this.metaAtRegistration, () => {
+            customTween(easingFn(1));
+          });
           return this.finish('css');
         }
         requestAnimationFrame(draw);


### PR DESCRIPTION
Previously the following would not apply the changed animation with a enclosed meta:
```javascript
aMorph.withMetaDo({ /* some meta */ }, () => aMorph.animate({ fill: Color.lively }));
```