### PR TITLE
🎨: remove `maskedProps` remnants after `vdom` removal

### DIFF
--- a/lively.morphic/rendering/animations.js
+++ b/lively.morphic/rendering/animations.js
@@ -59,11 +59,6 @@ export class AnimationQueue {
     this.animations = [];
   }
 
-  maskedProps (type) {
-    const l = this.animations.length;
-    return l > 0 ? obj.merge(this.animations.map(a => a.getAnimationProps(type)[0])) : {};
-  }
-
   get animationsActive () {
     const node = this.morph.env.renderer.getNodeForMorph(this.morph);
     return node?.getAnimations().length > 0;

--- a/lively.morphic/rendering/morphic-default.js
+++ b/lively.morphic/rendering/morphic-default.js
@@ -191,9 +191,6 @@ function defaultStyle (morph) {
   //          that render themselves based on the current extent in the model.
   // now we can render the other dom props
   const domStyle = styleProps(morph);
-  const maskedProps = morph._animationQueue.maskedProps('css');
-
-  if ('background-image' in maskedProps) delete domStyle.background;
 
   if (clipMode !== 'visible') {
     domStyle.overflow = clipMode;
@@ -208,7 +205,6 @@ function defaultStyle (morph) {
     domStyle['overflow-anchor'] = 'none';
   }
 
-  Object.assign(domStyle, maskedProps);
   domStyle.position = 'absolute';
   domStyle['pointer-events'] = reactsToPointer ? 'auto' : 'none';
   domStyle.cursor = nativeCursor;


### PR DESCRIPTION
Cleans up some code that introduced complexity that is entirely unused after we do not use the `vdom` anymore.