### PR TITLE
👼: prevent message title from being squashed for short expanded content

### DIFF
--- a/lively.halos/components/messages.js
+++ b/lively.halos/components/messages.js
@@ -187,17 +187,24 @@ export class StatusMessage extends ViewModel {
     if (this.sliding) await this.sliding;
     const world = this.view.world();
     if (!world || this.isMaximized) return;
+
     this.isMaximized = true;
     this.stayOpen = true;
     this.isCompact = false;
+
     const text = this.ui.messageText;
+    const title = this.ui.messageTitle;
+    const paddingLeft = title.left;
+    const paddingRight = this.view.width - title.right;
+
     Object.assign(text, { lineWrapping: 'no-wrap', clipMode: 'auto', readOnly: true, reactsToPointer: true });
+
     if (this.expandedContent) text.value = this.expandedContent;
     text.env.forceUpdate();
     delete text.renderingState.renderedTextAndAttributes; // force remeasure, needsRemeasure does not cut it for text with document
     text.invalidateTextLayout(true, true);
     text.env.forceUpdate(); // this really needs to be called twice holy moly
-    let ext = text.textBounds().extent();
+    let ext = text.textBounds().extent().maxPt(title.textBounds().extent().addXY(paddingLeft + paddingRight));
     const visibleBounds = world.visibleBoundsExcludingTopBar().insetBy(extraPadding);
     if (ext.y > visibleBounds.extent().y) ext.y = visibleBounds.height;
     if (ext.x > visibleBounds.extent().x) ext.x = visibleBounds.width;


### PR DESCRIPTION
Fixes the following that happens for error messages with small text:

![squashed](https://github.com/LivelyKernel/lively.next/assets/1296388/89118b1f-d500-4880-b421-57d71264627f)