### PR TITLE
🛠️: clear server side module cache when rebuilding artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,17 @@ clear-headless-cache:
 artifacts: classes-runtime landing-page loading-screen
 
 classes-runtime:
+	rm -rf lively.server/.module_cache
 	rm -rf lively.classes/build
 	env CI=true npm --prefix lively.classes run build
 
 landing-page:
+	rm -rf lively.server/.module_cache
 	rm -rf lively.freezer/landing-page
 	env CI=true npm --prefix lively.freezer run build-landing-page
 
 loading-screen:
+	rm -rf lively.server/.module_cache
 	rm -rf lively.freezer/loading-screen
 	env CI=true npm --prefix lively.freezer run build-loading-screen
 


### PR DESCRIPTION
For some changes (as of this PR we only now about the ones in #1416) it is important to clear the server side module cache, as otherwise the changes do not reflect in the bundles. We do not know for sure why that is.