### PR TITLE
Fix/scene graph blocked drops

### DIFF
--- a/lively.ide/studio/interactive-tree.js
+++ b/lively.ide/studio/interactive-tree.js
@@ -469,7 +469,7 @@ export class SceneGraphTree extends InteractiveTree {
     if (node === this._previewNode) return false; // preview does not represent a real morph
     if (this.treeData.root === node) {
       return !obj.equals(
-        this.treeData.root.children.map(m => m.container?.target.id),
+        arr.without(this.treeData.root.children, this._previewNode).map(m => m.container?.target.id),
         this.target.submorphs.filter(m => !this.ignoreMorph(m)).id);
     }
     if (node.container.nameNeedsUpdate) return true;

--- a/lively.ide/studio/scene-graph.cp.js
+++ b/lively.ide/studio/scene-graph.cp.js
@@ -312,10 +312,12 @@ export class MorphNodeModel extends ViewModel {
 
   showControls () {
     this.ui.visibilityIcon.visible = true;
+    this.ui.nameWrapper.startShowingFullTitle();
   }
 
   hideControls () {
     this.ui.visibilityIcon.visible = !this.target.visible;
+    this.ui.nameWrapper.stopShowingFullTitle();
   }
 
   async refresh () {
@@ -549,6 +551,8 @@ const MorphNode = component({
   }, {
     type: TitleWrapper,
     fill: Color.transparent,
+    reactsToPointer: false,
+    acceptsDrops: false,
     name: 'name wrapper',
     clipMode: 'hidden',
     maxLength: Infinity,


### PR DESCRIPTION
Fixes a couple issues with the scene graph I found:
1. drag and drop interface would barely work any more (nodes would not react to drag and drop).
2. dragging morphs from the outside into the scene graph was also not really working due to a crash.