### PR TITLE
🎨: add lookup function to Icon

### DIFF
--- a/lively.morphic/text/icons.js
+++ b/lively.morphic/text/icons.js
@@ -45,6 +45,12 @@ export class Icon {  static makeLabel(iconName, props = {prefix: "", suffix: ""}
   static setIcon(label, iconName) {     label.textAndAttributes = this.textAttribute(iconName);
   }
 
+  static lookup(char) {
+    return Object.entries(Icons).find(([key, { code }]) => {
+      if (code === char) return true;
+    })?.[0];
+  }
+
 }
 
 export var Icons = {


### PR DESCRIPTION
Adds a helpful helper function to the `Icon` class, that returns us the name of a given icon code.