### PR TITLE
🧰: do not close browser when module deletion is cancelled

### DIFF
--- a/lively.ide/js/browser/commands.js
+++ b/lively.ide/js/browser/commands.js
@@ -247,7 +247,7 @@ export default function browserCommands (browser) {
           await system.interactivelyRemoveModule(browser, m.url || m.name || m.id);
         } catch (e) {
           if (e !== 'Canceled') browser.showError(`Error while trying to load modules:\n${e.stack || e}`);
-          return true;
+          return false;
         }
 
         await browser.updateModuleList(m);

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -2526,19 +2526,22 @@ export class BrowserModel extends ViewModel {
     const textStyle = { fontSize: 16, fontWeight: 'normal' };
     if (!selectedNodeInDir) return;
     if (this.isModule(selectedNodeInDir)) {
+      let removed = false;
       // if is .md or .json, just remove the file
       // else remove module!
       if (selectedNodeInDir.url.match(/(\.md|\.json)$/)) {
-        await this.execCommand('remove module');
+        removed = await this.execCommand('remove module');
       } else {
-        await this.execCommand('remove module', { mod: selectedNodeInDir });
+        removed = await this.execCommand('remove module', { mod: selectedNodeInDir });
       }
       // clear the module
-      this.deactivateEditor();
-      this.world()
-        .withAllSubmorphsSelect(m =>
-          m.isBrowser && m.selectedModule?.url === selectedNodeInDir.url)
-        .forEach(m => m.getWindow().close(false));
+      if (removed) {
+        this.deactivateEditor();
+        this.world()
+          .withAllSubmorphsSelect(m =>
+            m.isBrowser && m.selectedModule?.url === selectedNodeInDir.url)
+          .forEach(m => m.getWindow().close(false));
+      }
       return;
     }
     if (selectedNodeInDir.type === 'directory') {


### PR DESCRIPTION
Fixes a bug where the browser was closed regardless of whether one goes through with the module deletion or not. While that makes sense for when the currently opened module gets deleted, closing the browser when one wanted to keep the module is confusing and not helpful.