### PR TITLE
🧰: do not display empty component control in presence of breakpoints

### DIFF
--- a/lively.ide/studio/controls/component.cp.js
+++ b/lively.ide/studio/controls/component.cp.js
@@ -301,7 +301,7 @@ export class ComponentControlModel extends PropertySectionModel {
     while (true) {
       if (stylePolicy._breakpointStore) {
         autoMaster = stylePolicy._breakpointStore._breakpointMasters[0][0];
-        break;
+        if (autoMaster) break;
       }
       if (stylePolicy._autoMaster) {
         autoMaster = stylePolicy._autoMaster;


### PR DESCRIPTION
Fixes an issue where in the presence of breakpoints inside a component, the comonent of a morph would sometimes be displayed as empty, although it wasnt:

![empty component error](https://github.com/LivelyKernel/lively.next/assets/1296388/bb2a924f-bce5-4e04-8cd5-798f7e6efe97)
