### PR TITLE
Fix/overly aggressive master overrides

### DIFF
--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -1423,36 +1423,11 @@ const ProjectPreviewTile = component(WorldPreviewTile, {
   }, {
     type: ProjectVersionViewer,
     name: 'version container',
-    fill: Color.rgb(253, 254, 254),
-    draggable: true,
-    extent: pt(515.7, 365.6),
-    grabbable: true,
-    position: pt(0, 0),
-    layoutable: false,
-    submorphs: [{
-      type: MorphList,
-      name: 'version list',
-      clipMode: 'hidden',
-      master: SystemList,
-      extent: pt(475.6, 285),
-      itemHeight: 45,
-      padding: rect(1, 1, 0, -1),
-      position: pt(20.1, 16.8),
-      touchInput: false
-    }, part(Spinner, {
-      name: 'version list spinner',
-      viewModel: { color: 'black' },
-      extent: pt(55.3, 66.9),
-      position: pt(244, 166.1),
-      scale: 0.5,
-      visible: false,
-      reactsToPointer: false
-    }), without('revert button'), {
+    submorphs: [without('revert button'), {
       name: 'visit button',
       submorphs: [{
         name: 'label',
         textAndAttributes: ['USE', null]
-
       }]
     }]
   }]

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -803,14 +803,14 @@ export class StylePolicy {
           // rms 13.7.22 OK to get rid of the descriptor here,
           // since we are "inside" of a def which is reevaluated on change anyways.
           localMaster = localMaster.isComponentDescriptor ? localMaster.stylePolicy : localMaster; // ensure the local master
-          return replace(parentSpec, new klass({ ...localSpec, master: localMaster }, parentSpec).splitBy(partitioningPolicy, parentSpec.name));
+          return replace(parentSpec, new klass({ ...localSpec, master: localMaster }, parentSpec));
         }
         if (parentSpec.isPolicy) { // we did not introduce a master and just adjusted stuff
           return replace(parentSpec, new klass(localSpec, parentSpec).splitBy(partitioningPolicy, parentSpec.name)); // insert a different style policy that has the correct overrides
         }
         if (localMaster) { // parent spec is not a policy, and we introduced a master here
           localMaster = localMaster.isComponentDescriptor ? localMaster.stylePolicy : localMaster; // ensure the local master
-          return replace(parentSpec, new klass({ ...localSpec, master: localMaster }, this.parent.extractStylePolicyFor(parentSpec.name)).splitBy(partitioningPolicy, parentSpec.name));
+          return replace(parentSpec, new klass({ ...localSpec, master: localMaster }, this.parent.extractStylePolicyFor(parentSpec.name)));
         }
 
         Object.assign(parentSpec, obj.dissoc(localSpec, ['submorphs'])); // just apply the current local spec

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -766,6 +766,13 @@ export class StylePolicy {
       const partitioningPolicy = this;
 
       const mergeSpecs = (parentSpec, localSpec) => {
+        // handle viewModel
+        const parentViewModel = parentSpec.spec?.viewModel || parentSpec.viewModel;
+        if (parentViewModel && localSpec.viewModel) {
+          localSpec.viewModel = obj.deepMerge(parentViewModel, localSpec.viewModel);
+        }
+
+        // handle text and attribute merging
         if (localSpec.textAndAttributes && parentSpec.textAndAttributes &&
             localSpec.textAndAttributes.length === parentSpec.textAndAttributes.length) {
           localSpec.textAndAttributes = arr.zip(
@@ -812,11 +819,7 @@ export class StylePolicy {
 
       mergeInHierarchy(baseSpec, spec, mergeSpecs, true, handleRemove, handleAdd);
 
-      if (baseSpec.viewModel && spec.viewModel) {
-        spec.viewModel = obj.deepMerge(baseSpec.viewModel, spec.viewModel);
-      }
-
-      // post process
+      // afterwards perform the replacement of nodes as requested by the replace() fn
       const finalSpec = tree.mapTree(baseSpec, (node, submorphs) => {
         if (toBeReplaced.has(node)) return toBeReplaced.get(node);
         else {
@@ -838,6 +841,7 @@ export class StylePolicy {
       return {
         ...obj.dissoc(baseSpec, ['master', 'submorphs', ...getStylePropertiesFor(baseSpec.type)]),
         ...spec,
+        ...finalSpec.viewModel ? { viewModel: finalSpec.viewModel } : {},
         submorphs: finalSpec.submorphs || []
       };
     }

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -734,6 +734,8 @@ export class StylePolicy {
 
     if (this.parent) {
       // we need to traverse the spec and the parent's build spec simultaneously
+      const overriddenMaster = this._autoMaster;
+      const partitioningPolicy = this;
       const toBeReplaced = new WeakMap();
       const baseSpec = this.generateBaseSpecFromParent();
 
@@ -761,9 +763,6 @@ export class StylePolicy {
           props: toBeAdded
         }, index);
       };
-
-      const overriddenMaster = this._autoMaster; // FIXME: what legitimizes the exceptional role of the _autoMaster?
-      const partitioningPolicy = this;
 
       const mergeSpecs = (parentSpec, localSpec) => {
         // handle viewModel
@@ -798,7 +797,7 @@ export class StylePolicy {
 
         let localMaster = localSpec.master;
         const overridden = overriddenMaster?.synthesizeSubSpec(localSpec.name);
-        localMaster = overridden?.isPolicy && overridden || localMaster;
+        if (!localMaster) localMaster = overridden?.isPolicy && overridden;
         delete parentSpec._needsDerivation;
         if (localMaster && parentSpec.isPolicy) {
           // rms 13.7.22 OK to get rid of the descriptor here,

--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -775,14 +775,14 @@ export class StylePolicy {
             return localAttr;
           });
         }
-        // ensure the presence of all nodes
+
+        // up to here everything regarding the root is done.
+        // last thing we do is carry over the name, if nothing was provided
+        // for convenience sake
         if (localSpec === spec) {
           if (!localSpec.name && parentSpec.name) localSpec.name = parentSpec.name;
           return;
         }
-        if (localSpec.isPolicy) {
-          return parentSpec && replace(parentSpec, localSpec.splitBy(partitioningPolicy, parentSpec.name));
-        } // do not tweak root
 
         let localMaster = localSpec.master;
         const overridden = overriddenMaster?.synthesizeSubSpec(localSpec.name);


### PR DESCRIPTION
Fixes various issues with the behavior of style policies that were not entirely according to spec.
For one, a component like:
```javascript
component(A, {
  submorphs: [{
    name: 'alice',
    master: B,
    submorphs: [{
      name: 'bob',
      master: C // before fix, C would not take affect if B also defined a master for 'bob'
    }] 
  }]
})
```

further breakpoints such as:
```javascript
component(A, {
  master: { breakpoints: [pt(500, 0), D]},
  submorphs: [{
   name: 'alice',
   master: C, // before fix, C would not take effect if D or A were also defining a master for 'alice'
  }]
})
```