### PR TITLE
🎨: add `sizeToAspectRatio` to `Image`

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2795,6 +2795,9 @@ export class Image extends Morph {
       },
       clipMode: {
         defaultValue: 'auto'
+      },
+      sizeToAspectRatio: {
+        defaultValue: true
       }
     };
   }
@@ -2861,6 +2864,11 @@ export class Image extends Morph {
     if (this.tooltip && this.renderingState.tooltip !== this.tooltip) {
       node.firstChild.alt = this.tooltip;
       this.renderingState.tooltip = this.tooltip;
+    }
+    if (this.renderingState.sizeToAspectRatio !== this.sizeToAspectRatio) {
+      if (this.sizeToAspectRatio) node.firstChild.style['object-fit'] = 'contain';
+      else node.firstChild.style['object-fit'] = 'fill';
+      this.renderingState.sizeToAspectRatio = this.sizeToAspectRatio;
     }
   }
 


### PR DESCRIPTION
Makes it so that by default, images will try to fill the extent of their morph extent, but only in so far as their aspect ratio is respected. By setting `sizeToAspectRatio` to `false` the old default behavior can be achieved, which leads to the image filling its morph extent no matter what.