### PR TITLE
Fix/halo world scroll interference

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -2332,6 +2332,11 @@ export default class Halo extends Morph {
     if (!this.changingName) { this.buttonControls.map(b => b.onKeyUp(evt)); }
   }
 
+  onMouseWheel (evt) {
+    const { deltaX, deltaY } = evt.domEvt;
+    this.world().scrollWorld(deltaX, deltaY);
+  }
+
   indicateLooseMovement (active) {
     this.borderBox.borderStyle = active ? 'dotted' : 'solid';
   }

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -339,7 +339,7 @@ export class LivelyWorld extends World {
         m.position = this.worldToScreen(m.positionOnCanvas);
       });
     });
-    this.halos().forEach(h => h.alignWithTarget()); // also update the nested ones
+    this.halos().forEach(h => h.target.owner !== this && h.alignWithTarget()); // also update the nested ones
   }
 
   onMouseWheel (evt) {

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -331,6 +331,7 @@ export class LivelyWorld extends World {
   }
 
   scrollWorld (dx, dy) {
+    if (!config.ide.studio.canvasModeEnabled) return;
     this.offsetX += dx;
     this.offsetY += dy;
 


### PR DESCRIPTION
Fixes two issues I discovered with the halo:

1. Halos used to block world scrolling, especially annoying for large morphs.
2. Some halos used to receive double updates when they realign due to world scroll events.