### PR TITLE
🎨: fix empty string not showing in status message when evaluating code

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -454,7 +454,7 @@ export class Text extends Morph {
           return textAndAttributes;
         },
         set (value) {
-          if (!value) return;
+          if (!value && value !== '') return;
           typeof value === 'string'
             ? (this.textString = value)
             : (this.textAndAttributes = value);


### PR DESCRIPTION
Fixes a problem that was visible when just putting `''` inside of a workspace and executing that code. The result was that the result of the expression was not correctly applied due to the empty string being falsy, displaying the placeholder text in the component message.