### PR TITLE
🎨: fix bogus fitting cancelation in response to policies

### DIFF
--- a/lively.morphic/text/morph.js
+++ b/lively.morphic/text/morph.js
@@ -2793,10 +2793,6 @@ export class Text extends Morph {
 
       if (fixedHeight && fixedWidth) return;
       if (!this.textLayout) return; /* not init'ed yet */
-      let synth;
-      if (this.master && (synth = this.master.synthesizeSubSpec())) {
-        if (synth.extent?.isPoint) return;
-      }
 
       const textBounds = this.textBounds().outsetByRect(this.padding);
       this.withMetaDo({ metaInteraction: true }, () => {


### PR DESCRIPTION
Text morphs that were controlled by policies would not properly hug their text content if configured to do so:

Before (wrong):
![old-save-flap](https://github.com/LivelyKernel/lively.next/assets/1296388/e7812013-f72d-4b4a-afce-1a3e0a747a5c)

After (correct):
![new-save-flap](https://github.com/LivelyKernel/lively.next/assets/1296388/edb5b2e2-0cb1-43fa-b83a-2452996f2965)
