### PR TITLE
🧰: fix asset browser blockage not being cleared

### DIFF
--- a/lively.ide/studio/asset-browser.cp.js
+++ b/lively.ide/studio/asset-browser.cp.js
@@ -226,6 +226,7 @@ class AssetBrowserModel extends ViewModel {
     if (this._promise) {
       this._promise.resolve(this.selectedAsset.imageUrl);
       this.container.remove();
+      signal(this.view.owner, 'close'); // clear blocking of windowed asset browsers
     } else {
       const image = new Image({ imageUrl: this.selectedAsset.imageUrl });
       image.determineNaturalExtent().then((extent) => {


### PR DESCRIPTION
Fixes a problem where, when the windowed asset browser was open and the sidebar was used to change the asset inside of an image with the popup version of the asset browser, the windowed asset browser was getting blocked as expected, but merely confirming a new asset inside of the popup, did not clear the windowed version again.