### PR TITLE
🎨: crash when comparing layouts to non layouts

### DIFF
--- a/lively.components/window.cp.js
+++ b/lively.components/window.cp.js
@@ -276,4 +276,4 @@ const SystemWindowDark = component(DarkWindow, {
   master: { states: { inactive: DarkWindowInactive } }
 });
 
-export { DefaultWindow, DarkWindow, DefaultWindowInactive, DarkWindowInactive, SystemWindow };
+export { DefaultWindow, DarkWindow, DefaultWindowInactive, DarkWindowInactive, SystemWindow, SystemWindowDark };

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -36,6 +36,8 @@ class Layout {
     this._padding = !padding ? Rectangle.inset(0) : typeof padding === 'number' ? Rectangle.inset(padding) : Rectangle.fromLiteral(padding);
   }
 
+  get isLayout () { return true; }
+
   hasEmbeddedContainer () {
     if (this.container?.owner?.isText) return false;
     return this.container.owner?.embeddedMorphMap?.has(this.container);
@@ -105,7 +107,7 @@ class Layout {
   }
 
   equals (otherLayout) {
-    return otherLayout.name() === this.name();
+    return otherLayout?.isLayout && otherLayout.name() === this.name();
   }
 
   get layoutableSubmorphs () {
@@ -340,7 +342,7 @@ export class TilingLayout extends Layout {
   }
 
   equals (other) {
-    return this.__serialize__().__expr__ === (other && other.__serialize__().__expr__);
+    return super.equals(other) && this.__serialize__().__expr__ === (other && other.__serialize__().__expr__);
   }
 
   name () { return 'Tiling'; }
@@ -1624,7 +1626,7 @@ export class ConstraintLayout extends Layout {
   }
 
   equals (other) {
-    return obj.equals(this.getSpec(), other.getSpec());
+    return super.equals(other) && obj.equals(this.getSpec(), other.getSpec());
   }
 
   getSpec () {


### PR DESCRIPTION
This fixes a crash that happened for instance when you tried to save `window.cp.js`.