### PR TITLE
Fix changing the inspector target via `FilterableList`

### DIFF
--- a/lively.ide/js/inspector/index.js
+++ b/lively.ide/js/inspector/index.js
@@ -813,7 +813,7 @@ export class Inspector extends ViewModel {
     this.closeOpenWidget();
     let newTarget;
     if (this.view.env.eventDispatcher.isKeyPressed('Shift')) {
-      [newTarget] = await $world.execCommand('select morph', { justReturn: true });
+      [newTarget] = await $world.execCommand('select morph', { filterFn: (m) => $world.morphsInWorldWithSubmorphs.concat([$world]).includes(m), justReturn: true });
     } else {
       this.toggleSelectionInstructions(true);
       newTarget = await InteractiveMorphSelector.selectMorph();

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -134,7 +134,7 @@ const commands = [
   {
     name: 'show morph',
     exec: (world, { morph, loop = false, color = Color.red }) => {
-      show(morph, loop, color);
+      return show(morph, loop, color);
     }
   },
 

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -214,7 +214,7 @@ const commands = [
         (opts.prependItems || []).concat(items),
         {
           historyId: 'lively.morphic-select morph',
-          onSelection: sel => {
+          onSelection: function (sel) {
             if (this.lastSelectionHalo) this.lastSelectionHalo.remove();
             if (sel && sel.show && lastSelected !== sel) {
               this.lastSelectionHalo = sel.show();

--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -199,7 +199,7 @@ const commands = [
                     fontWeight: isObjectPackage ? 'bolder' : 'normal',
                     fontStyle: isObjectPackage ? 'normal' : 'italic',
                     fontFamily: 'Inconsolata',
-                    fontSize: 16
+                    fontSize: 14
                   }, isObjectPackage ? ' [Object Class]' : '', {
                     opacity: 0.5
                   }],


### PR DESCRIPTION
When changing the inspectors target via Shift+Click, thus resulting in a list of all possible morphs showing, an error was triggered upon each selection. This PR fixes the problems.
This also makes it so that we filter the prompts included in the list so that only "custom"morphs are included and not tooling etc.