### PR TITLE
🧩: ensure trace flag in makeSystem() at all times

### DIFF
--- a/lively.modules/src/system.js
+++ b/lively.modules/src/system.js
@@ -198,9 +198,7 @@ function makeSystem (cfg) {
 }
 
 function prepareSystem (System, config) {
-  if (typeof lively !== 'undefined' && lively.wasFastLoaded) {
-    System.trace = true;
-  }
+  System.trace = true;
   delete System.get;
   config = config || {};
 


### PR DESCRIPTION
Fixes a weird issue, where `lively.modules` tests would fail in slow load.