### PR TITLE
🧰: ensure previoust component desc is REALLY component descr

### DIFF
--- a/lively.ide/components/editor.js
+++ b/lively.ide/components/editor.js
@@ -46,7 +46,7 @@ export class InteractiveComponentDescriptor extends ComponentDescriptor {
       return newDescr;
     }
     const prev = recorder?.[declaredName];
-    if (prev && !recorder?.__module_hash__) {
+    if (prev?.isComponentDescriptor && !recorder?.__module_hash__) {
       if (prev.constructor !== this) { obj.adoptObject(prev, this); }
       const dependants = prev.getDependants(true);
       prev.stylePolicy = newDescr.stylePolicy;


### PR DESCRIPTION
Fixes an issue where the previous presence of an object like variable with the same name as a component definition would cause a crash when saving the module.