### PR TITLE
🎨: declare master default value to be null

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -103,6 +103,7 @@ export class Morph {
         before: ['metadata'],
         after: ['clipMode'],
         group: 'core',
+        defaultValue: null,
         set (args) {
           args = args ? PolicyApplicator.for(this, args) : (args === false ? false : null);
           this.setProperty('master', args);

--- a/lively.morphic/tests/components-test.cp.js
+++ b/lively.morphic/tests/components-test.cp.js
@@ -620,9 +620,9 @@ describe('spec based components', () => {
       const m = part(e1);
       const e2Policy = new PolicyApplicator({}, e2);
       const spec = e2Policy.asBuildSpec();
-      expect(m.get('bob').master).to.be.undefined;
+      expect(m.get('bob').master).to.be.null;
       e2Policy.apply(m, true);
-      expect(m.get('bob').master).not.to.be.undefined;
+      expect(m.get('bob').master).not.to.be.null;
       expect(m.get('bob').master.parent).to.eql(spec.submorphs[1].master.parent, 'point to the same style policy');
       expect(m.master).not.to.eql(spec.master, 'does not set the root master automatically (still e1)');
     });
@@ -778,10 +778,10 @@ describe('components', () => {
 
     t1c.master.apply(t1c, true);
 
-    expect(T1.stylePolicy._autoMaster).not.to.be.undefined;
-    expect(t1c.get('bob').master).not.to.be.undefined;
+    expect(T1.stylePolicy._autoMaster).not.to.be.null;
+    expect(t1c.get('bob').master).not.to.be.null;
     expect(t1c.get('bob').fill).to.eql(Color.red);
-    expect(t1c.get('bob').master.synthesizeSubSpec(null).fill).not.to.be.undefined;
+    expect(t1c.get('bob').master.synthesizeSubSpec(null).fill).not.to.be.null;
     expect(t1c.get('alice').fill).to.eql(Color.blue);
 
     let inst = part(T1);

--- a/lively.serializer2/plugins/expression-serializer.js
+++ b/lively.serializer2/plugins/expression-serializer.js
@@ -575,7 +575,7 @@ function handleSpecProps (morph, exported, styleProto, path, masterInScope, opts
       // applied to morphs that previously did not have any masters (after the fact application)
       // The first case is easily detectable. The second case is tricky, since that is not
       // reified in the data structur of style policies as of now
-      let val = handleStylePolicy(morph.master, opts);
+      let val = morph.master && handleStylePolicy(morph.master, opts);
       if (val) exported.master = val;
       continue;
     }


### PR DESCRIPTION
Fixes a crash that would happen when creating a component definition from a morph structure.