### PR TITLE
🧩: only trace system loads in resurrection builds

### DIFF
--- a/lively.modules/src/system.js
+++ b/lively.modules/src/system.js
@@ -198,7 +198,7 @@ function makeSystem (cfg) {
 }
 
 function prepareSystem (System, config) {
-  System.trace = true;
+  if (typeof lively !== 'undefined') System.trace = lively.isResurrectionBuild;
   delete System.get;
   config = config || {};
 


### PR DESCRIPTION
Fixes #1506.