### PR TITLE
🧰: do not reset image url on focus

### DIFF
--- a/lively.ide/studio/controls/fill.cp.js
+++ b/lively.ide/studio/controls/fill.cp.js
@@ -113,7 +113,7 @@ export class FillControlModel extends ViewModel {
     this.targetMorph = target;
     this.ui.imageControl.visible = !!target.isImage;
     if (target.isImage) {
-      this.updateImageInfo(target.imageUrl, false);
+      this.updateImageInfo(target.imageUrl);
     }
     this.models.fillColorInput.targetMorph = target;
     this.update();


### PR DESCRIPTION
@linusha I am not sure if this breaks other things, but it pretty much resolved the issue of resetting the imageUrl that happens when selecting an image morph with an open side bar. (try selecting the dog with the sidebar open).