### PR TITLE
Fix/ci puppeteer cache

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -31,6 +31,12 @@ jobs:
           path: | 
             lively.next-node_modules/
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
+      - name: Cleanup puppeteer to force reinstallation
+        if: ${{ steps.cache-lively-deps.outputs.cache-hit == 'true' }}
+        run: |
+          rm -rf lively.next-node_modules/puppeteer
+          rm -rf lively.next-node_modules/puppeteer-core
+          rm -rf lively.next-node_modules/@puppeteer__SLASH__browsers
       - name: Install `lively.next`
         run: |
           chmod a+x ./install.sh

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           path: | 
             lively.next-node_modules/
-            .puppeteer-browser-cache/
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
       - name: Install `lively.next`
         run: |
@@ -44,7 +43,6 @@ jobs:
         with:
           path: |
             lively.next-node_modules/
-            .puppeteer-browser-cache/           
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
       - name: Check if Bundled Artifacts are up to Date 
         run:  ./scripts/check-build-status.py

--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           path: |
             lively.next-node_modules/ 
-            .puppeteer-browser-cache/          
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
       - name: Install `lively.next`
         run: |
@@ -41,7 +40,6 @@ jobs:
         with:
           path: |
             lively.next-node_modules/
-            .puppeteer-browser-cache/           
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
       - name: Run CI Test Script
         run:  ./scripts/test.sh

--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -28,6 +28,12 @@ jobs:
           path: |
             lively.next-node_modules/ 
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('lively*/package.json') }}
+      - name: Cleanup puppeteer to force reinstallation
+        if: ${{ steps.cache-lively-deps.outputs.cache-hit == 'true' }}
+        run: |
+          rm -rf lively.next-node_modules/puppeteer
+          rm -rf lively.next-node_modules/puppeteer-core
+          rm -rf lively.next-node_modules/@puppeteer__SLASH__browsers
       - name: Install `lively.next`
         run: |
           chmod a+x ./install.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,7 @@ STARTED_SERVER=0
 FAILURE=0
 
 testfiles=(
+"lively.morphic"
 "lively.lang"
 "lively.resources"
 "lively.bindings"
@@ -33,7 +34,6 @@ testfiles=(
 "lively.modules"
 "lively-system-interface"
 "lively.graphics"
-"lively.morphic"
 "lively.components"
 "lively.ide"
 "lively.halos"


### PR DESCRIPTION
We recently observed that the daily pipeline check fails for some tests in `lively.morphic`. We could not reproduce the failure locally and also did not observe them when changing `lively.morphic` and thus running its tests separately.

Removing the `puppeteer` installation after receiving the cache contents and thus forcing a new installation does resolve this issue.