### PR TITLE
🎨: allow configuring color scheme via config

### DIFF
--- a/lively.morphic/config.js
+++ b/lively.morphic/config.js
@@ -59,6 +59,7 @@ const config = {
   hideScrollbarsInWorldBrowser: false,
   scrollbarOffset: detectScrollbarWidth(),
   onloadURLQuery: parseURLQuery(),
+  colorScheme: typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
 
   /* browser support 2 ways to render shadows:
 

--- a/lively.morphic/world.js
+++ b/lively.morphic/world.js
@@ -3,6 +3,7 @@ import bowser from 'bowser';
 import { Rectangle, Color, pt } from 'lively.graphics';
 import { arr, Path, obj } from 'lively.lang';
 import { signal } from 'lively.bindings';
+import { config } from 'lively.morphic';
 
 import { MorphicEnv } from './env.js';
 import { Morph } from './morph.js';
@@ -34,8 +35,7 @@ export class World extends Morph {
       colorScheme: {
         derived: true,
         get () {
-          // place somewhere were it is called less often???
-          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          return config.colorScheme;
         }
       }
     };

--- a/lively.morphic/world.js
+++ b/lively.morphic/world.js
@@ -35,7 +35,7 @@ export class World extends Morph {
       colorScheme: {
         derived: true,
         get () {
-          return config.colorScheme;
+          return config.colorScheme === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light' : config.colorScheme;
         }
       }
     };


### PR DESCRIPTION
Made the color scheme configurable via `localconfig.js` while defaulting to the systems default value.