### PR TITLE
🛠️: move `lively.morphic` back into the middle of tested packages

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,6 @@ STARTED_SERVER=0
 FAILURE=0
 
 testfiles=(
-"lively.morphic"
 "lively.lang"
 "lively.resources"
 "lively.bindings"
@@ -34,6 +33,7 @@ testfiles=(
 "lively.modules"
 "lively-system-interface"
 "lively.graphics"
+"lively.morphic"
 "lively.components"
 "lively.ide"
 "lively.halos"


### PR DESCRIPTION
See #1524 for more information.

:pray: :pray: :pray: :pray: :pray: :pray: :pray: :pray: :pray: :pray: :pray: 