### PR TITLE
📂: add timestamp to output of projects build script

### DIFF
--- a/lively.project/templates/build-shell.js
+++ b/lively.project/templates/build-shell.js
@@ -1,4 +1,5 @@
 export const buildScriptShell = `#!/bin/bash
+echo "⏰: $(date +%F_%T)"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --verbose) verbose="--verbose"; shift 1;;


### PR DESCRIPTION
Small QOL improvement that puts a timestamp inside of the output of the build script of projects, so that it is easier to tell when one ran it the last time.