### PR TITLE
🎨❄️: ensure adequate load time for `Yoga`

### DIFF
--- a/lively.freezer/src/util/main-module.js
+++ b/lively.freezer/src/util/main-module.js
@@ -6,9 +6,11 @@
 import { MorphicEnv } from 'lively.morphic';
 import { World } from 'lively.morphic';
 import { pt } from 'lively.graphics';
+import { ensureYoga } from 'lively.morphic/layout.js';
 
 // fixme: what to do to make IDE worlds load? They require components before $world is a thing yet....
 export async function renderFrozenPart (node = document.body) {
+  await ensureYoga();
   prepare();
   if (!MorphicEnv.default().world) {
     let world = window.$world = window.$$world = new WORLD_CLASS({

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -3,11 +3,15 @@ import { arr, promise, Closure, num, obj, fun } from 'lively.lang';
 import { once, signal } from 'lively.bindings';
 import { loadYoga } from 'yoga-layout';
 
-let Yoga;
+let Yoga, _yoga;
 if (!Yoga) {
-  loadYoga().then((l) => {
+  _yoga = loadYoga().then((l) => {
     Yoga = l;
   });
+}
+
+export function ensureYoga () {
+  return _yoga
 }
 
 export function getYoga () { return Yoga; }


### PR DESCRIPTION
Fixes a problem that manifested on my machine in Firefox where `Yoga` was not loaded fast enough, resulting in an unrecoverable crash when loading a bundled page.