### PR TITLE
📂🧰: correctly use `livelyIncludePartsbinInList` in `localStorage`

### DIFF
--- a/lively.ide/studio/world-browser.cp.js
+++ b/lively.ide/studio/world-browser.cp.js
@@ -721,7 +721,7 @@ export class WorldBrowserModel extends ViewModel {
         visible: true, duration: 300
       });
     }
-    let entities = this.playgroundsMode ? await this.db.latestCommits('world') : await Project.listAvailableProjects();
+    let entities = this.playgroundsMode ? await this.db.latestCommits('world') : await Project.listAvailableProjects(true);
     this.reset();
     if (config.hideScrollbarsInWorldBrowser) worldList.clipMode = 'hidden';
     // Filter out the project that is opened anyways.

--- a/lively.project/project.js
+++ b/lively.project/project.js
@@ -146,7 +146,7 @@ export class Project {
     };
   }
 
-  static async listAvailableProjects () {
+  static async listAvailableProjects (forProjectBrowser = false) {
     const baseURL = (await Project.systemInterface.getConfig()).baseURL;
 
     const packageCache = lively.FreezerRuntime
@@ -162,7 +162,8 @@ export class Project {
       })
     );
     projectsCandidates = projectsCandidates.filter(p => p.url.includes('local_projects'));
-    if (!localStorage.getItem('livelyIncludePartsbinInList')) projectsCandidates = projectsCandidates.filter(p => p._name !== 'LivelyKernel--partsbin');
+    const includePartsbinSetting = localStorage.getItem('livelyIncludePartsbinInList');
+    if (forProjectBrowser && (!includePartsbinSetting || includePartsbinSetting == 'false')) projectsCandidates = projectsCandidates.filter(p => p._name !== 'LivelyKernel--partsbin');
     projectsCandidates.forEach(p => {
       p._projectName = p._name.replace(/.*--/, '');
       p._projectOwner = p._name.replace(/--.*/, '');
@@ -762,7 +763,7 @@ export class Project {
         const projectDir = await Project.projectDirectory(`${depRepoOwner}--${depName}`);
         await evalOnServer(`System.get("@lively-env").packageRegistry.addPackageAt(System.baseURL + 'local_projects/${depRepoOwner}--${depName}')`);
         await PackageRegistry.ofSystem(System).addPackageAt(projectDir);
-        availableProjects = await Project.listAvailableProjects(true);
+        availableProjects = await Project.listAvailableProjects();
       }
       // Add all transitive dependencies from the current dependency to the list.
       // **Note:** Actually, the transitive dependencies of a project could be different in different versions of this project.


### PR DESCRIPTION
Fixes two problems with the `livelyIncludePartsbinInList` hidden option:

First, the check whether this was active or not was not working as expected, as the values retrieved from the local storage are strings.

Second, the option was also used when `listAvailableProjects` was used for reasons other than filling the project browser.

Both of these should now be resolved. 