### PR TITLE
🧰: fix `open text window` command to fix text extent

### DIFF
--- a/lively.ide/world-commands.js
+++ b/lively.ide/world-commands.js
@@ -671,6 +671,8 @@ const commands = [
         textAndAttributes,
         clipMode: 'auto',
         name,
+        fixedWidth: true,
+        fixedHeight: true,
         extent
       });
       if (rangesAndStyles) { text.setTextAttributesWithSortedRanges(rangesAndStyles); }
@@ -729,7 +731,7 @@ const commands = [
           });
         }
 
-        const win = world.execCommand('open text window', opts);
+        const win = $world.execCommand('open text window', opts);
         const textMorph = win.targetMorph;
         win.extent = extent || pt(300, 200).maxPt(textMorph.textBounds().extent());
 


### PR DESCRIPTION
We recently changed `Text` to fit its content by default, which caused this command to produce funny-looking windows. 