### PR TITLE
🎨: fix computation of bounds for hugging `HTMLMorph`s

### DIFF
--- a/lively.morphic/html-morph.js
+++ b/lively.morphic/html-morph.js
@@ -124,7 +124,7 @@ export class HTMLMorph extends Morph {
 
       const newBounds = nodeBounds.reduce((a, b) => {
         if (!a.isNonEmpty()) return b;
-        return a.translatedBy(parentPos.negated()).union(b);
+        return a.union(b);
       });
       if (!this.fixedHeight && this.height !== newBounds.height) this.height = newBounds.height;
       if (!this.fixedWidth && this.width !== newBounds.width) this.width = newBounds.width;


### PR DESCRIPTION
Solves a problem where the extent of hugging `HTMLMorph`s got huge, due to a feedback loop.