### PR TITLE
📂: let `projectAsset` be imported from `helpers` file

### DIFF
--- a/lively.project/index.js
+++ b/lively.project/index.js
@@ -5,4 +5,3 @@ import { gitResourceExtension } from 'lively.shell/git-client-resource.js';
 registerExtension(gitResourceExtension);
 
 export * from './project.js';
-export * from './helpers.js';


### PR DESCRIPTION
Importing via the `index.js` file lead to bundled project not loading anymore.