### PR TITLE
🧰: fix reconciliation when renaming morph inside layout

### DIFF
--- a/lively.ide/components/reconciliation.js
+++ b/lively.ide/components/reconciliation.js
@@ -1481,7 +1481,7 @@ class RenameReconciliation extends PropChangeReconciliation {
     const { parsedComponent } = this.getDescriptorContext(interactiveDescriptor);
     const affectedPolicy = getMorphNode(parsedComponent, this.target.owner);
     const parentNode = getPropertiesNode(affectedPolicy, this.target.owner);
-    const parentSpec = interactiveDescriptor.stylePolicy.getSubSpecFor(!this.target.owner?.isComponent ? this.owner.name : null);
+    const parentSpec = interactiveDescriptor.stylePolicy.getSubSpecFor(!this.target.owner?.isComponent ? this.target.owner : null);
     if (parentSpec?.layout && parentNode) {
       parentSpec.layout.handleRenamingOf(this.oldName, this.newValue);
       this.patchPropIn(parentNode, 'layout', parentSpec.layout.__serialize__());


### PR DESCRIPTION
Solved a problem for me where I just renamed a morph inside of a layout which crashed the reconciliation.