### PR TITLE
🎨: allow inline components for breakpoints

### DIFF
--- a/lively.morphic/components/core.js
+++ b/lively.morphic/components/core.js
@@ -643,7 +643,7 @@ export function component (masterComponentOrProps, overriddenProps) {
   if (masterComponentOrProps) {
     return new PolicyApplicator(props, masterComponentOrProps);
   } else {
-    return props;
+    return new PolicyApplicator(props);
   }
 }
 


### PR DESCRIPTION
**This is not yet fully fleshed out, and there might be cases where this messes up the reconciliation.** However, this feature is extremely handy as it allows us to build responsive components extremely fast, for example by swapping out layouts inside of complex morph structures without the need to extract partial hierarchies into separate components. 