### PR TITLE
🧰: fix quote toggling in richt text popup

### DIFF
--- a/lively.ide/studio/controls/text.cp.js
+++ b/lively.ide/studio/controls/text.cp.js
@@ -294,7 +294,7 @@ export class RichTextControlModel extends ViewModel {
   }
 
   toggleQuote () {
-    this.changeAttributeInSelectionOrMorph('quote', quoteActive =>
+    this.confirm('quote', quoteActive =>
       quoteActive === 1 ? 0 : 1);
     this.update();
   }


### PR DESCRIPTION
Fixes a crash that happened when toggling a quote style in a selected piece of text.