### PR TITLE
🎨: fix `editit` keybinding that was double-bound previously

### DIFF
--- a/lively.morphic/config.js
+++ b/lively.morphic/config.js
@@ -225,7 +225,7 @@ const config = {
       { keys: { win: 'Alt-Ctrl-Enter', mac: 'Meta-P' }, command: 'printit' },
       { keys: { win: 'Alt-Ctrl-Shift-Enter', mac: 'Meta-I' }, command: 'print inspectit' },
       { keys: { win: 'Ctrl-Shift-I', mac: 'Meta-Shift-I' }, command: 'inspectit' },
-      { keys: { win: 'Ctrl-Shift-E', mac: 'Meta-Shift-E' }, command: 'editit' },
+      { keys: { win: 'Ctrl-Alt-E', mac: 'Ctrl-Alt-E' }, command: 'editit' },
       { keys: { win: 'Ctrl-Shift-U', mac: 'Meta-Shift-U' }, command: 'undefine variable' },
       { keys: { win: 'Alt-B', mac: 'Alt-B' }, command: 'blame line' },
       { keys: { win: 'Shift-Ctrl-B', mac: 'Shift-Ctrl-B' }, command: 'blame selection' },


### PR DESCRIPTION
@merryman please check if this now also works on mac devices. I checked on my machine and the depicted keybinding now works as expected.

The reason for this keybinding not working on Linux/Windows machines before was that there was a duplicate keybinding between "Ctrl-Shit-E" and "Shift-Ctrl-E". I am not sure what the problem on mac might have been.