### PR TITLE
🧰: disable drops for controls in system browser

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -773,6 +773,7 @@ const EmbeddedIcon = component(EmbeddedIconDefault, {
 const BrowserDirectoryControls = component({
   type: DirectoryControls,
   name: 'directory controls',
+  acceptsDrops: false,
   borderColor: Color.rgb(23, 160, 251),
   extent: pt(83.2, 30.8),
   fill: Color.rgba(0, 0, 0, 0),
@@ -823,6 +824,7 @@ const BrowserDirectoryControls = component({
 const BrowserPackageControls = component({
   type: PackageControls,
   name: 'browser package controls',
+  acceptsDrops: false,
   borderColor: Color.rgb(23, 160, 251),
   extent: pt(123.4, 30.8),
   fill: Color.rgba(0, 0, 0, 0),


### PR DESCRIPTION
Just some leftovers :slightly_smiling_face: 