### PR TITLE
🧰: do not switch back to uniform color if using eye dropper for gradient

### DIFF
--- a/lively.ide/styling/color-picker.js
+++ b/lively.ide/styling/color-picker.js
@@ -308,7 +308,7 @@ export class ColorPickerModel extends ViewModel {
 
   async triggerEyeDropper () {
     const chosenColor = await new window.EyeDropper().open();
-    this.withColor(Color.fromString(chosenColor.sRGBHex));
+    this.adjustColor(Color.fromString(chosenColor.sRGBHex));
   }
 
   toggleHalos (active) {


### PR DESCRIPTION
Fixes an insane bug in the color picker, where using the eye dropper when selecting the color of a color stop in gradient mode would switch the entire color back to a uniform color.