### PR TITLE
🧰: do not show “more” border control for paths

### DIFF
--- a/lively.ide/studio/controls/border.cp.js
+++ b/lively.ide/studio/controls/border.cp.js
@@ -102,6 +102,7 @@ export class BorderControlModel extends PropertySectionModel {
    */
   focusOn (aMorph) {
     this.targetMorph = aMorph;
+    this.ui.moreButton.visible = !aMorph.isPath;
     if (
       Color.white.equals(this.targetMorph.borderColor.valueOf()) &&
       this.targetMorph.borderWidth.valueOf() === 0 &&


### PR DESCRIPTION
It does not make sense to control top,left,right,bottom border for shapes that just have a one dimensional border. So this will hide the "more" option from the border control in the sidebar.