### PR TITLE
Harden check for currently logged in user when creating a project

### DIFF
--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -278,6 +278,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     if (lively.isInOfflineMode) fromRemoteCheckbox.disable();
     privateCheckbox.disable();
     cancelButton.disable();
+    await this.ui.userFlap.setupComplete;
     if (!isUserLoggedIn()) {
       this.waitForLogin();
     } else {

--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -11,7 +11,7 @@ import { SaveWorldDialog } from 'lively.ide/studio/dialogs.cp.js';
 import { without } from 'lively.morphic/components/core.js';
 import { Label } from 'lively.morphic/text/label.js';
 import { Checkbox, LabeledCheckboxLight } from 'lively.components';
-import { currentUserToken, currentUsersOrganizations, currentUsername } from 'lively.user';
+import { currentUserToken, isUserLoggedIn, currentUsersOrganizations, currentUsername } from 'lively.user';
 import { Project } from 'lively.project';
 import { StatusMessageError, StatusMessageConfirm } from 'lively.halos/components/messages.cp.js';
 import { EnumSelector, Spinner } from 'lively.ide/studio/shared.cp.js';
@@ -278,7 +278,7 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
     if (lively.isInOfflineMode) fromRemoteCheckbox.disable();
     privateCheckbox.disable();
     cancelButton.disable();
-    if (!currentUserToken()) {
+    if (!isUserLoggedIn()) {
       this.waitForLogin();
     } else {
       const li = $world.showLoadingIndicatorFor(this.view);

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -73,7 +73,8 @@ export class UserFlapModel extends ViewModel {
   }
 
   async update () {
-    clearUserData();
+    // deleting the user data explicitly sometimes lead to cases where we had no user data but still kept a token around
+    // just overwrite
     await this.retrieveGithubUserData();
     this.showUserData();
   }

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -50,6 +50,11 @@ export class UserFlapModel extends ViewModel {
       withLoginButton: {
         defaultValue: false
       },
+      setupComplete: {
+        initialize () {
+          this.setupComplete = promise.deferred();
+        }
+      },
       bindings: {
         get () {
           return [
@@ -61,7 +66,7 @@ export class UserFlapModel extends ViewModel {
       },
       expose: {
         get () {
-          return ['updateNetworkIndicator', 'showUserData', 'onLogin', 'onLogout', 'showLoggedInUser', 'showGuestUser', 'toggleLoadingAnimation', 'login', 'update'];
+          return ['setupComplete','updateNetworkIndicator', 'showUserData', 'onLogin', 'onLogout', 'showLoggedInUser', 'showGuestUser', 'toggleLoadingAnimation', 'login', 'update'];
         }
       }
     };
@@ -115,6 +120,11 @@ export class UserFlapModel extends ViewModel {
     const { loginButton, leftUserLabel, rightUserLabel, avatar } = this.ui;
     await leftUserLabel.whenFontLoaded();
     await rightUserLabel.whenFontLoaded();
+
+    if (!isUserLoggedIn() && currentUserToken()) {
+      await this.retrieveGithubUserData();
+    }
+
     if (!isUserLoggedIn()) {
       if (this.withLoginButton) {
         avatar.visible = false;
@@ -133,6 +143,7 @@ export class UserFlapModel extends ViewModel {
       leftUserLabel.nativeCursor = 'auto';
     }
     promise.delay(100).then(() => this.view.animate({ opacity: 1, duration: 300 }));
+    this.setupComplete.resolve();
   }
 
   async login () {

--- a/lively.user/user-flap.cp.js
+++ b/lively.user/user-flap.cp.js
@@ -257,6 +257,12 @@ export class UserFlapModel extends ViewModel {
       }
     });
     const userData = await userRes.json();
+    // provided token is not valid, purge all data and reset login status throughout user flap 
+    if (userData.status === '401'){
+      this.logout();
+      return false;
+    }
+
     // retrieve the organizations in which the authenticated user is a member
     const orgsForUserRes = await fetch('https://api.github.com/user/orgs', {
       headers: {
@@ -270,6 +276,7 @@ export class UserFlapModel extends ViewModel {
     const orgNames = orgsForUser.map(org => org.login);
     storeCurrentUsersOrganizations(orgNames);
     storeCurrentUser(userData);
+    return true;
   }
 
   logout () {


### PR DESCRIPTION
The initial problem I observed was that the login button was displayed when creating a new project but the rest of the prompt was not disabled. Investigating showed that we in fact had a valid access token stored, but no user data in the local storage. Since we only checked for a token in the prompt but for the user data in the user flap (which is responsible for the login button), the prompt thought that everything was fine and disabled nothing. So the first change here is just making this check consistent.

Additionally, I made it so that in cases where we find a token but no user info, we try to retrieve the user info from github and thus "recover" the login. In cases where the token is not valid, we abort this and properly clean up all remaining user data, thus leading to a new, clean login being necessary.

The underlying problem, the userdata being lost while the token is still present is very likely caused by the `update()` method inside of the user flap. I removed what I believe to be the root cause, but as this only happens sporadically, I cannot really make sure of this, which is why I created these safeguards.

Now, you might ask - Linus, this sounds like a security nightmare. To which I say:

![8vspxb](https://github.com/LivelyKernel/lively.next/assets/14252419/d02be17a-03c8-4b31-9d09-7a30a3d0d429)
