### PR TITLE
📂: indicate invalid input when leaving text field in project creation

### DIFF
--- a/lively.project/prompts.cp.js
+++ b/lively.project/prompts.cp.js
@@ -129,7 +129,9 @@ class ProjectCreationPromptModel extends AbstractPromptModel {
               }
             },
             { target: 'remote url', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' },
-            { target: 'project name', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' }
+            { target: 'remote url', signal: 'onBlur', handler: 'checkValidity', converter: '() => false' },
+            { target: 'project name', signal: 'onInputChanged', handler: 'checkValidity', converter: '() => false' },
+            { target: 'project name', signal: 'onBlur', handler: 'checkValidity', converter: '() => false' }
           ];
         }
       }


### PR DESCRIPTION
Just a tiny QOL change that makes it easier to follow the creation of projects.