### PR TITLE
🎨: add 'Noto Emoji Color' to list of supported fonts

### DIFF
--- a/lively.morphic/rendering/fonts.js
+++ b/lively.morphic/rendering/fonts.js
@@ -93,6 +93,10 @@ export const DEFAULT_FONTS = [
     supportedWeights: [300, 400, 500, 600, 700]
   },
   {
+    name: 'Noto Emoji Color',
+    supportedWeights: [300, 400, 500, 600, 700]
+  },
+  {
     name: 'Nunito',
     supportedWeights: [200, 300, 400, 500, 600, 700, 800, 900]
   },


### PR DESCRIPTION
Oversight from #1549. :clown_face: 