### PR TITLE
❄️: remove invalid `link` tags with `preload` attribute for `mp3` &`mp4`

### DIFF
--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -818,17 +818,9 @@ export default class LivelyRollup {
   }
 
   generateAssetPreloads () {
-    return arr.compact(arr.uniq(this.projectAssets.map(asset => {
-      // also preload all of the used fonts in the bundle
-      if (asset.newName?.endsWith('.mp4')) {
-        return `<link rel="preload" href="${joinPath('./assets', `${asset.newName}`)}" as="video">`;
-      }
-      if (asset.newName?.endsWith('.mp3')) {
-        return `<link rel="preload" href="${joinPath('./assets', `${asset.newName}`)}" as="audio">`;
-      }
-    }))).concat(this.customFontFiles.map(fontFile => {
+    return arr.compact(arr.uniq(this.customFontFiles.map(fontFile => {
       return `<link rel="preload" href="${joinPath('./assets', `${fontFile.name()}`)}" as="font">`;
-    })).join('\n');
+    }))).join('\n');
   }
 
   async generateIndexHtml (importMap, modules) {


### PR DESCRIPTION
Something I introduced a while back that was too eager and that browsers do not like. We never caught it before, as we did not bundle video assets...