### PR TITLE
🧰: ensure component layouts applied before opening in world

### DIFF
--- a/lively.ide/js/browser/ui.cp.js
+++ b/lively.ide/js/browser/ui.cp.js
@@ -409,6 +409,9 @@ class ComponentEditButtonMorph extends Morph {
     } = this;
     const otherBrowsers = this.getAllOtherEqualBrowsers();
     const componentMorph = await componentDescriptor.edit();
+    if (componentMorph) {
+      componentMorph.applyLayoutIfNeeded();
+    }
     const btnPlaceholder = await this.ensureEditControlsFor(componentMorph);
     await this.animateSwapWithPlaceholder(btnPlaceholder, componentMorph);
     otherBrowsers.forEach(b => b.relayout());


### PR DESCRIPTION
This prevents erratic jumps of components that can happen due to delayed layout applications.