### PR TITLE
🎛️: classify list update as layout action

### DIFF
--- a/lively.components/list.js
+++ b/lively.components/list.js
@@ -742,6 +742,12 @@ export class List extends Morph {
   // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   // rendering
 
+  dontRecordChangesWhile (cb) {
+    return this.withMetaDo({ isLayoutAction: true }, () => {
+      return super.dontRecordChangesWhile(cb);
+    });
+  }
+
   update () {
     const items = this.items;
     if (!items || !this.scroller) return; // pre-initialize


### PR DESCRIPTION
This allows layouts to ignore the changes a list performs internally, which never affects other enclosing layouts anyways. This saves compute.