### PR TITLE
🧰: integrate general editor commands in markdown editor plugin

### DIFF
--- a/lively.ide/md/editor-plugin.js
+++ b/lively.ide/md/editor-plugin.js
@@ -142,7 +142,7 @@ export default class MarkdownEditorPlugin extends CodeMirrorEnabledEditorPlugin 
 
   getNavigator () { return new MarkdownNavigator(); }
 
-  getCommands (otherCommands) { return otherCommands.concat(commands); }
+  getCommands (otherCommands) { return [...super.getCommands(otherCommands), ...otherCommands.concat(commands)]; }
 
   getKeyBindings (other) {
     return other.concat([


### PR DESCRIPTION
For whatever reason the default editor commands (including the super useful toggle comment command) where never included in the markdown editor plugin. This fixes that.