### PR TITLE
🎨: add top bar callback stub to vanilla world

### DIFF
--- a/lively.morphic/world.js
+++ b/lively.morphic/world.js
@@ -286,6 +286,8 @@ export class World extends Morph {
 
   relayout () { /* subclass responsibility */ }
 
+  withTopBarDo () {}
+
   defaultMenuItems (morph) {
     return []; /* subclass responsibility */
   }


### PR DESCRIPTION
Avoids crashes when opening ide specific tools are used in vanilla worlds (i.e. frozen apps).