### PR TITLE
🚨🚨🚨 Fix/frozen module reviving issue

### DIFF
--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -833,7 +833,10 @@ export default class LivelyRollup {
   async generateBundle (plugin, bundle, depsCode, importMap, opts) {
     const modules = Object.values(bundle);
     modules.forEach(chunk => {
-      if (chunk.code) chunk.code = chunk.code.replace("'use strict'", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\n");
+      if (chunk.code) {
+        if (this.isResurrectionBuild) chunk.code = chunk.code.replace('System.register', 'BootstrapSystem.register');
+	chunk.code = chunk.code.replace("'use strict'", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\n");
+      }
     });
     if (this.minify && opts.format !== 'esm') {
       modules.forEach((chunk, i) => {

--- a/lively.freezer/src/landing-page.cp.js
+++ b/lively.freezer/src/landing-page.cp.js
@@ -97,7 +97,7 @@ class WorldLandingPage extends Morph {
   }
 }
 
-class ShapeMorpher extends ViewModel {
+export class ShapeMorpher extends ViewModel {
   static get properties () {
     return {
       isZoomed: { defaultValue: false },

--- a/lively.freezer/src/util/helpers.js
+++ b/lively.freezer/src/util/helpers.js
@@ -292,6 +292,7 @@ export async function generateLoadHtml (htmlConfig, importMap, resolver, modules
             }
           }
         });
+        ${isResurrectionBuild ? 'window.BootstrapSystem = System;' : ''}
         System.trace = ${isResurrectionBuild ? 'true' : 'false'};
         System.import("./${entryPoint}").then(m => { m.renderFrozenPart(domNode); });
       }

--- a/lively.modules/src/module.js
+++ b/lively.modules/src/module.js
@@ -80,10 +80,10 @@ export async function updateBundledModules (system, modulesToUpdate) {
   // finally update the frozen records that require update
   for (let m in registry) {
     if (registry[m].updateRecord) {
-      const realignedId = m.startsWith('esm://') ? m : string.joinPath(System.baseURL, m);
+      const realignedId = m.startsWith('esm://') ? m : string.joinPath(system.baseURL, m);
       const mod = module(system, realignedId);
       if (!mod._frozenModule) continue;
-      system.set(realignedId, System.newModule(R.exportsOf(m)));
+      system.set(realignedId, system.newModule(R.exportsOf(m)));
       mod._recorder = registry[m].recorder;
     }
   }

--- a/lively.morphic/world-loading.js
+++ b/lively.morphic/world-loading.js
@@ -21,6 +21,7 @@ async function reportWorldLoad (world, user) {
 }
 
 export async function setupLively2Lively (world) {
+  const { importPackage } = await System.import('lively.modules');
   const { currentUser } = await System.import('lively.user');
   const user = { name: currentUser().login };
   const info = { world: world.name };
@@ -29,7 +30,7 @@ export async function setupLively2Lively (world) {
     info.userRealm = user.realm;
   }
 
-  await lively.modules.importPackage('lively.2lively');
+  await importPackage('lively.2lively');
   const { default: L2LClient } = await System.import('lively.2lively/client.js');
   const client = await L2LClient.forLivelyInBrowser(info);
   console.log(`[lively] lively2lively client created ${client}`);
@@ -42,7 +43,8 @@ export async function setupLively2Lively (world) {
 }
 
 export async function setupLivelyShell (opts) {
-  await lively.modules.importPackage('lively.shell');
+  const { importPackage } = await System.import('lively.modules');
+  await importPackage('lively.shell');
   const { default: ClientCommand } = await System.import('lively.shell/client-command.js');
   const { resourceExtension } = await System.import('lively.shell/client-resource.js');
   const { l2lClient } = opts;
@@ -53,7 +55,8 @@ export async function setupLivelyShell (opts) {
 }
 
 async function loadLocalConfig () {
-  const localconfig = lively.modules.module('localconfig.js');
+  const { module } = await System.import('lively.modules');
+  const localconfig = module('localconfig.js');
   try {
     // reload so that localconfig module actually executes, even if it was loaded before
     if (await resource(localconfig.id).exists()) { await localconfig.reload({ resetEnv: false, reloadDeps: false }); }


### PR DESCRIPTION
Fixes the server bug in #1643.

After we merged 9741894, there was a serious bug uncovered that happened to never surface before.
Concretely it was a bug with reviving of modules where we re-execute the split bundle parts in order to inject updated entities of changed modules into the frozen bundle.
This was buggy, since during re-execution of the bundle parts, the `System` variable would no longer be the one that was used during initial load. This is because the System we use gets swapped out after bootstrapping is done.
We now had a situation where reviving would ping pong between two different instances of System causing crashes.
I really do no entirely understand why this ping pong situation was avoided until this commit.
What appears to have caused it was the removal of a remaining reference to `lively.modules` from `lively.morphic/world-loading.js`. Somehow the top level inclusion of `lively.modules` into `lively.morphic` caused the reload to accidentally replace the top level System variable temporarily, avoiding the issue described. But this is really just a theory.

The solution fortunately is easier to explain: When we now bundle for revivable builds, we adjust the compiled bundle parts to reference a specific `BootstrapSystem` variable that always references the initial instance of System. That avoids the ping pong.