### PR TITLE
Feature/add mermaid support

### DIFF
--- a/lively.freezer/tools/build.landing-page.mjs
+++ b/lively.freezer/tools/build.landing-page.mjs
@@ -33,6 +33,7 @@ try {
           'chai','mocha', // references old lgtg that breaks the build
           'rollup', // has a dist file that cant be parsed by rollup
           // other stuff that is only needed by rollup
+          'mermaid-it-markdown',
           '@babel/preset-env',
           '@babel/plugin-syntax-import-meta',
           '@rollup/plugin-json', 

--- a/lively.freezer/tools/build.loading-screen.mjs
+++ b/lively.freezer/tools/build.loading-screen.mjs
@@ -36,6 +36,7 @@ try {
           '@rollup/plugin-json', 
           '@rollup/plugin-commonjs',
           'rollup-plugin-polyfill-node',
+          'mermaid-it-markdown',
           'babel-plugin-transform-es2015-modules-systemjs'
         ],
         resolver

--- a/lively.ide/md/compiler.js
+++ b/lively.ide/md/compiler.js
@@ -5,6 +5,7 @@ import { html5Media } from 'esm://cache/markdown-it-html5-media';
 
 import markdownAttrs from 'esm://cache/markdown-it-attrs';
 import { string } from 'lively.lang';
+import markdownMermaid from 'mermaid-it-markdown';
 
 function addSourceLineMappingPlugin (md, options = {}) {
   options = { ...md.options, ...options };
@@ -28,7 +29,7 @@ class MarkdownCompiler {
   compileToHTML (src, options = {}) {
     let { linkedCSS, markdownWrapperTemplate } = options;
     options.html = true; // allow usage of HTML tags in all markdown
-    let md = markdownIt(options).use(externalizeLinksPlugin).use(addSourceLineMappingPlugin).use(markdownCheckbox).use(markdownAttrs).use(markdownCaption, { dataType: true, figcaption: true }).use(html5Media); // eslint-disable-line no-use-before-define
+    let md = markdownIt(options).use(externalizeLinksPlugin).use(addSourceLineMappingPlugin).use(markdownCheckbox).use(markdownAttrs).use(markdownCaption, { dataType: true, figcaption: true }).use(html5Media).use(markdownMermaid); // eslint-disable-line no-use-before-define
     let html = md.render(src);
 
     if (markdownWrapperTemplate) { html = string.format(markdownWrapperTemplate, html); }
@@ -44,7 +45,7 @@ class MarkdownCompiler {
 
   parse (editor, options) {
     options.html = true; // allow usage of HTML tags in all markdown
-    let md = markdownIt(options).use(externalizeLinksPlugin).use(markdownCheckbox).use(markdownCaption, { dataType: true, figcaption: true }).use(markdownAttrs).use(html5Media); // eslint-disable-line no-use-before-define
+    let md = markdownIt(options).use(externalizeLinksPlugin).use(markdownCheckbox).use(markdownCaption, { dataType: true, figcaption: true }).use(markdownAttrs).use(html5Media).use(markdownMermaid); // eslint-disable-line no-use-before-define
     let src = editor.textString;
     let parsed = md.parse(editor.textString, {});
     let lines = src.split('\n');

--- a/lively.ide/package.json
+++ b/lively.ide/package.json
@@ -26,7 +26,8 @@
   },
   "systemjs": {
     "map": {
-      "semver": "esm://cache/semver"
+      "semver": "esm://cache/semver",
+      "mermaid-it-markdown": "esm://run/mermaid-it-markdown"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for mermaid diagrams in markdown in lively. Since the markdown package is extremely large, we exclude them from the frozen bundles.