### PR TITLE
🧰: decouple markdown compilation from concrete node structure

### DIFF
--- a/lively.ide/md/morphs.js
+++ b/lively.ide/md/morphs.js
@@ -338,7 +338,7 @@ export class MarkdownPreviewMorph extends HTMLMorph {
             // but we also need to adjust the height of each html morph to fit its contents
             if (m.isHTMLMorph) {
               await m.whenRendered();
-              m.height = m.env.renderer.getNodeForMorph(m).children[0].children[1].offsetHeight + 10;
+              m.height = m.env.renderer.getNodeForMorph(m).children[0].getElementsByClassName('markdown-body')[0].offsetHeight + 10;
             }
           }
           hljs.highlightAll();

--- a/lively.ide/md/morphs.js
+++ b/lively.ide/md/morphs.js
@@ -335,11 +335,6 @@ export class MarkdownPreviewMorph extends HTMLMorph {
           const wrapper = this.submorphs[0];
           for (let m of wrapper.submorphs) {
             wrapper.layout.setResizePolicyFor(m, { width: 'fill', height: 'fixed' });
-            // but we also need to adjust the height of each html morph to fit its contents
-            if (m.isHTMLMorph) {
-              await m.whenRendered();
-              m.height = m.env.renderer.getNodeForMorph(m).children[0].getElementsByClassName('markdown-body')[0].offsetHeight + 10;
-            }
           }
           hljs.highlightAll();
           if (scrollBefore) wrapper.scroll = scrollBefore;


### PR DESCRIPTION
Otherwise, some of our documentation pages would error once we exclude the linked css, which alters the node structure of the result.