### PR TITLE
🧰: run highlighting code after html export of markdown

### DIFF
--- a/lively.ide/md/morphs.js
+++ b/lively.ide/md/morphs.js
@@ -292,7 +292,8 @@ export class MarkdownPreviewMorph extends HTMLMorph {
 
       this.submorphs = [];
       this.env.forceUpdate(this);
-      this.html = ed.editorPlugin.renderedMarkdown();
+      this.html = ed.editorPlugin.renderedMarkdown(markdownOptions);
+      setTimeout(() => hljs.highlightAll());
     } else {
       const blocks = [];
       const exprSerializer = new ExpressionSerializer();


### PR DESCRIPTION
Fixes an issue where code highlighting was broken for markdown files that did not contain interactive elements.