### PR TITLE
🧰: only show loading indicator for markdown render when window present

### DIFF
--- a/lively.ide/md/editor-plugin.js
+++ b/lively.ide/md/editor-plugin.js
@@ -46,11 +46,10 @@ let commands = [
 
       if (preview.getWindow() && preview.world()) {
         $world.addMorph(preview.getWindow()).activate();
+        $world.withRequesterDo(preview.getWindow(), async () => {
+          await $world.withLoadingIndicatorDo(() => preview.renderMarkdown(), preview.getWindow(), 'rendering markdown');
+        });
       }
-
-      $world.withRequesterDo(preview.getWindow(), async () => {
-        await $world.withLoadingIndicatorDo(() => preview.renderMarkdown(), preview.getWindow(), 'rendering markdown');
-      });
 
       return preview;
     }


### PR DESCRIPTION
Previously, just saving a `md` file lead to an error, as the loading indicator could not find the world of the (non-mounted) preview window.