### PR TITLE
🧰: wrap lines by chars in terminal view for convenience

### DIFF
--- a/lively.ide/shell/terminal.js
+++ b/lively.ide/shell/terminal.js
@@ -68,7 +68,7 @@ export default class Terminal extends Morph {
             {
               type: TerminalView,
               name: 'output',
-              lineWrapping: 'no-wrap',
+              lineWrapping: 'by-chars',
               fixedWidth: true,
               fixedHeight: true,
               textString: '',


### PR DESCRIPTION
For the longest time It was quite inconvenient to have to scroll sideways to see long lines in the terminal fully. This enables wrapping by default for the terminal in lively.