### PR TITLE
🎨: avoid check for text style classes if not nessecary

### DIFF
--- a/lively.morphic/rendering/font-metric.js
+++ b/lively.morphic/rendering/font-metric.js
@@ -363,7 +363,7 @@ class DOMTextMeasure {
 
   canBeMeasuredViaCanvas (aMorph) {
     if (!aMorph.allFontsLoaded() && document.fonts.status !== 'loading') return false;
-    if (this.hasTextStyleClasses(aMorph) && !aMorph.fixedWidth) return false;
+    if (!aMorph.fixedWidth && this.hasTextStyleClasses(aMorph)) return false;
     const { fontFamily, fontWeight, fontStyle } = aMorph;
     const key = `${fontFamily}-${fontWeight}-${fontStyle}`;
     if (key in this.canvasCompatibility) return this.canvasCompatibility[key];


### PR DESCRIPTION
Previously especially in text morphs with a large document such as the editors inside the system browser, overly eager checks for certain text style classes would cause the performance to tank. This can be avoided by first checking wether or not the text morph is hugging its text contents or not. In case of hugging, the measurment via canvas has to be dispatched to each line, since textwrapping is not supported on canvas.