### PR TITLE
Fix/optimize morph derivation from component

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -950,8 +950,6 @@ export class StylePolicy {
   }
 
   asFullySynthesizedSpec () {
-    // caching does not work that way, since it requires more dynamicity depending on the event/breakpoint state of each morph in the morph hierarchy. Instead we can only cache on a per morph x state basis, always having to assemble the spec ad hoc.
-    // if (this._cachedFullySynthesized) return this._cachedFullySynthesized;
     const extractBuildSpecs = (specOrPolicy, submorphs) => {
       if (specOrPolicy.COMMAND === 'add') {
         specOrPolicy = specOrPolicy.props;
@@ -1000,10 +998,10 @@ export class StylePolicy {
       return synthesized;
     };
     const buildSpec = tree.mapTree(this.spec, extractBuildSpecs, node => node.props?.submorphs || node.submorphs);
-    // do not add a master, since that would tigger an application
     const self = this;
     buildSpec.onLoad = function () {
-      const policy = self; // PolicyApplicator.for(this, {}, self); // eslint-disable-line no-use-before-define
+      const policy = self;
+      // do not trigger master setter, since that would cause an application
       this.setProperty('master', policy);
       policy.attach(this);
     };

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1658,11 +1658,13 @@ export class Morph {
       this.makeDirty();
       submorph.resumeSteppingAll();
 
-      submorph.withAllSubmorphsDo(ea => ea.onOwnerChanged(this));
+      submorph.withAllSubmorphsDo(ea => {
+        ea.onOwnerChanged(this);
+      });
 
-      if (submorph._requestMasterStyling) {
-        submorph.master && submorph.master.applyIfNeeded(true);
-        submorph._requestMasterStyling = false;
+      if (this.world() && !this.isText) {
+        this.env.forceUpdate(this);
+        this.withAllSubmorphsDo(m => m.makeDirty());
       }
     });
 

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -886,6 +886,7 @@ export class Morph {
     if (props.__wasAddedToDerived__) this.__wasAddedToDerived__ = true;
 
     if (typeof this.onLoad === 'function' && !this.isComponent) this.onLoad();
+    if (typeof props.onLoad === 'function' && !this.isComponent) props.onLoad.bind(this)();
   }
 
   get __serialization_id_property__ () { return '_id'; }

--- a/lively.morphic/rendering/renderer.js
+++ b/lively.morphic/rendering/renderer.js
@@ -145,6 +145,8 @@ export default class Renderer {
       }
     }
 
+    this.worldMorph.applyLayoutIfNeeded();
+
     // handling these first allows us to assume correct wrapping, when we have submorphs already!
     for (let morph of morphsToHandle) {
       if (morph.renderingState.hasCSSLayoutChange) this.renderLayoutChange(morph);


### PR DESCRIPTION
Fixes an issue explained here https://github.com/LivelyKernel/lively.next/issues/599#issuecomment-1410149036, where when deriving new morphs from a component a completely unnecessary initial application step was performed.
We now avoid that by simply passing the stylized properties directly to the morph constructors. We also avoid overly permature policy application during morph addition that happens for morphs not yet mounted into the world. 