### PR TITLE
❄️🧰: delay linter module loading to improve loading time

### DIFF
--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -9,6 +9,8 @@ import { install as installHook } from 'lively.modules/src/hooks.js';
 import { updateBundledModules } from 'lively.modules/src/module.js';
 import { Project } from 'lively.project/project.js';
 import { pathForBrowserHistory } from 'lively.morphic/helpers.js';
+import { installLinter } from 'lively.ide/js/linter.js';
+
 import untar from 'esm://cache/js-untar';
 import bowser from 'bowser';
 
@@ -231,6 +233,7 @@ function bootstrapLivelySystem (progress, fastLoad = query.fastLoad !== false ||
       $world.env.installSystemChangeHandlers();
 
       await loadViaScript(resource(baseURL).join('/lively.modules/systemjs-init.js').url);
+      installLinter(System);
       logInfo('Setup SystemJS:', Date.now() - ts + 'ms');
 
       // load packages

--- a/lively.ide/components/editor.js
+++ b/lively.ide/components/editor.js
@@ -3,7 +3,6 @@ import { ExpressionSerializer } from 'lively.serializer2';
 import { string, obj } from 'lively.lang';
 import module from 'lively.modules/src/module.js';
 import { withAllViewModelsDo } from 'lively.morphic/components/policy.js';
-import lint from '../js/linter.js';
 import { ComponentChangeTracker } from './change-tracker.js';
 import { findComponentDef, getComponentNode, scanForNamesInGenerator } from './helpers.js';
 import { replaceComponentDefinition, Reconciliation, createInitialComponentDefinition } from './reconciliation.js';
@@ -245,7 +244,7 @@ export class InteractiveComponentDescriptor extends ComponentDescriptor {
 
   getSourceCode () {
     this._cachedComponent = null; // ensure to recreate the component morph
-    return lint(createInitialComponentDefinition(this.getComponentMorph()))[0];
+    return System.lint(createInitialComponentDefinition(this.getComponentMorph()))[0];
   }
 
   makeDirty () {

--- a/lively.ide/components/helpers.js
+++ b/lively.ide/components/helpers.js
@@ -4,7 +4,6 @@ import { Icons } from 'lively.morphic/text/icons.js';
 import { arr, string, num, obj } from 'lively.lang';
 import { parse, query } from 'lively.ast';
 import { module } from 'lively.modules/index.js';
-import lint from '../js/linter.js';
 
 export const DEFAULT_SKIPPED_ATTRIBUTES = ['metadata', 'styleClasses', 'isComponent', 'viewModel', 'activeMark', 'positionOnCanvas', 'selectionMode', 'acceptsDrops'];
 export const COMPONENTS_CORE_MODULE = 'lively.morphic/components/core.js';
@@ -113,7 +112,7 @@ export function getTextAttributesExpr (textMorph) {
 function indentExpression (expr, depth) {
   const braceLength = 1;
   const indentLength = depth * 2;
-  return string.indent(lint(`(${expr})`)[0], '  ', depth)
+  return string.indent(System.lint(`(${expr})`)[0], '  ', depth)
     .slice(indentLength + braceLength, -braceLength - indentLength - 2);
 }
 

--- a/lively.ide/components/reconciliation.js
+++ b/lively.ide/components/reconciliation.js
@@ -28,7 +28,6 @@ import { undeclaredVariables } from '../js/import-helper.js';
 import { ImportInjector, ImportRemover } from 'lively.modules/src/import-modification.js';
 import module from 'lively.modules/src/module.js';
 import { parse, stringify, nodes, query } from 'lively.ast';
-import lint from '../js/linter.js';
 import { notYetImplemented } from 'lively.lang/function.js';
 import { isFoldableProp, getDefaultValueFor } from 'lively.morphic/helpers.js';
 import { resource } from 'lively.resources';
@@ -341,7 +340,7 @@ export async function insertComponentDefinition (protoMorph, entityName, mod) {
       specifiers: [...finalExports.specifiers, nodes.id(entityName)]
     };
 
-    return lint(fixUndeclaredVars(
+    return System.lint(fixUndeclaredVars(
       string.applyChanges(oldSource, [
         { action: 'replace', ...finalExports, lines: [decl, stringify(updatedExports)] }
       ]),
@@ -558,7 +557,7 @@ export function applyModuleChanges (reconciliation, scope, system, sourceEditor 
     }
 
     if (runLint) {
-      [updatedSource] = lint(updatedSource);
+      [updatedSource] = System.lint(updatedSource);
       if (patchTextMorph) {
         sourceEditor.textString = updatedSource;
       }

--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -32,8 +32,6 @@ import DefaultTheme from '../../themes/default.js';
 import { objectReplacementChar } from 'lively.morphic/text/document.js';
 import { serverInterfaceFor, localInterface } from 'lively-system-interface/index.js';
 
-import lint from '../linter.js';
-
 import { mdCompiler } from '../../md/compiler.js';
 import MarkdownEditorPlugin from '../../md/editor-plugin.js';
 
@@ -1951,7 +1949,7 @@ export class BrowserModel extends ViewModel {
           content = sourceEditor.textString;
         }
 
-        const linterOutput = await lint(content);
+        const linterOutput = await System.lint(content);
         content = linterOutput[0];
         warnings = linterOutput[1];
 

--- a/lively.ide/js/linter.js
+++ b/lively.ide/js/linter.js
@@ -127,3 +127,7 @@ export default function lint (code, customRules = {}) {
   const linterOutput = linter.verifyAndFix(code, { ...config, rules: { ...config.rules, ...customRules } });
   return [linterOutput.output, linterOutput.messages];
 }
+
+export function installLinter (System) {
+  System.lint = lint;
+}

--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -34,7 +34,6 @@ import { part } from 'lively.morphic';
 
 import worldCommands from './world-commands.js';
 import { CommentData } from 'lively.collab';
-import './js/linter.js';
 import { TopBar } from './studio/top-bar.cp.js';
 import { pathForBrowserHistory } from 'lively.morphic/helpers.js';
 import { Project } from 'lively.project';


### PR DESCRIPTION
I noticed that loading the eslint package either consumes a lot of time in the loading screen or when delayed, as soon as one opens the system browser, which is annoying. When loading from the bundle its super fast.

I suggest accessing the linter via a static function installed on the System object, which initially references the bundled eslint, which loads fast.

That way we can also benefit from fast eslint loading even in slow load.