### PR TITLE
Fix/disappearing drop

### DIFF
--- a/lively.morphic/components/policy.js
+++ b/lively.morphic/components/policy.js
@@ -1019,8 +1019,7 @@ export class StylePolicy {
       if (synthesized.layout) {
         synthesized.layout = synthesized.layout.copy();
         synthesized.layout.estimateSubmorphExtents(synthesized, extractBuildSpecs); // should be done before the submorph specs are synthesized
-        // however for submorphs which themselves are resized by layouts, the extent information is not yet determined
-        // estimate the container extent
+        // however for submorphs which themselves are resized by layouts, the extent information is not yet determined, instead estimate the container extent below
       }
 
       if (modelClass) synthesized.viewModel = new modelClass(modelParams);

--- a/lively.morphic/layout.js
+++ b/lively.morphic/layout.js
@@ -1431,9 +1431,14 @@ export class TilingLayout extends Layout {
     const policies = this.config.resizePolicies;
     if (!policies) return;
 
-    for (let m of containerSpec.submorphs) {
-      let match, fixedTotalExtent;
-      if (m.isPolicy) m = m.spec;
+    for (let i = 0; i < containerSpec.submorphs.length; i++) {
+      let match; let fixedTotalExtent; let m = containerSpec.submorphs[i];
+      if (m.isPolicy) {
+        m = containerSpec.submorphs[i] = m.copy();
+        m = m.spec;
+      } else {
+        m = containerSpec.submorphs[i] = { ...m };
+      }
       if (match = policies.find(([name, policy]) => name === m.name)) {
         const [_, policy] = match;
         if (policy.width === 'fill') {

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1664,11 +1664,6 @@ export class Morph {
       submorph.withAllSubmorphsDo(ea => {
         ea.onOwnerChanged(this);
       });
-
-      if (this.world() && !this.isText) {
-        this.env.forceUpdate(this);
-        this.withAllSubmorphsDo(m => m.makeDirty());
-      }
     });
 
     return submorph;


### PR DESCRIPTION
Fixes #1718.

Was due to an incomplete implementation of #1696 which was due to an oversight from my part: The full synthesization of the style properties of the entire morph hierarchy to be created from a component was faulty, since it ignores the effect of layout applications, which in the end leads to incorrect synthesization of style properties due to wrong breakpoints getting triggered.
This PR fixes that by performing a rough "pre-computation" of layouts on the level of style specs instead of morph, allowing us to avoid running into the issue described.