### PR TITLE
🎛️: fix labels of project browser on landing-page

### DIFF
--- a/lively.components/widgets/mode-selector.cp.js
+++ b/lively.components/widgets/mode-selector.cp.js
@@ -118,7 +118,7 @@ class ModeSelectorModel extends ViewModel {
   createLabels () {
     this.view.submorphs = this.items.map((item) => {
       const label = part(this.labelMaster, {
-        textString: item.text,
+        textAndAttributes: [item.text, null],
         name: item.name,
         tooltip: item.tooltip
       });


### PR DESCRIPTION
I assume this is due to the recent changes to the component instantiation. I am inclined to call this a bug - what do you think, @merryman? 
I think its okay to do it like this in this scenario, but if it turned out to be the case that we would now need to utilize `textAndAttributes` instead of `textString` in all/more cases, that would mean severely worse ergonomics from a user-perspective building their own components.