### PR TITLE
🎨: fix attr based sizeFor() measurement in font metric

### DIFF
--- a/lively.morphic/rendering/font-metric.js
+++ b/lively.morphic/rendering/font-metric.js
@@ -147,7 +147,7 @@ export default class FontMetric {
       const spanH = doc.createElement('span');
       spanH.className = 'line';
       spanH.style.whiteSpace = 'pre';
-      if (attr.fontFamily) spanH.style = `font-family: ${attr.fontFamily};`;
+      spanH.style = `font-family: ${attr.fontFamily || fontFamily}; font-size: ${attr.fontSize || fontSize}px;`;
       spanH.textContent = text;
       el.replaceChildren(spanH);
     } else {


### PR DESCRIPTION
Fixes an issue with #1717. Among other things, it cause the buttons in the properties side panel to look squashed:
![screenshot-measure-bug](https://github.com/user-attachments/assets/1d73aafe-1260-45f6-be4e-c75a66a1b74f)

