### PR TITLE
🎨🧰: add `forceSceneGraphInclusion` property for `Morph`s

### DIFF
--- a/lively.ide/studio/interactive-tree.js
+++ b/lively.ide/studio/interactive-tree.js
@@ -522,9 +522,9 @@ export class SceneGraphTree extends InteractiveTree {
 
   ignoreMorph (m) {
     if (!m.isMorph) return false;
-    return m.isContainer || m.isWindow || m.getWindow() || m.isEpiMorph || m.isHand || m.isHaloItem || m.isCommentIndicator ||
+    return !m.forceSceneGraphInclusion && (m.isContainer || m.isWindow || m.getWindow() || m.isEpiMorph || m.isHand || m.isHaloItem || m.isCommentIndicator ||
       ['lively.halos'].includes(m.constructor[Symbol.for('lively-module-meta')].package.name) ||
-      ['Menu'].includes(m.constructor.name);
+      ['Menu'].includes(m.constructor.name));
   }
 
   onDropHoverOut (evt) {

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -852,6 +852,10 @@ export class Morph {
         defaultValue: false
       },
 
+      forceSceneGraphInclusion: {
+        defaultValue: false
+      },
+
       respondsToVisibleWindow: {
         group: 'interaction',
         doc: "Morphs will respond to changes to the visible browser window and a call will be made to the morph's relayout function, supplying the event generated",


### PR DESCRIPTION
This is mainly intended for @rickmcgeer's ease-of-life: It adds a property called `forceSceneGraphInclusion` which allows overriding the in-built criteria of the scene-graph. See #1452.