### PR TITLE
Fix/docs pipeline

### DIFF
--- a/.github/workflows/check-deploy-docs.yml
+++ b/.github/workflows/check-deploy-docs.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         with:

--- a/.github/workflows/check-deploy-docs.yml
+++ b/.github/workflows/check-deploy-docs.yml
@@ -36,6 +36,7 @@ jobs:
         cp lively.morphic/assets/favicon.ico docs/favicon.ico
     - name: Upload Documentation Build
       uses: actions/upload-pages-artifact@v3
+      if: github.event_name == 'workflow_dispatch'
       with:
         name: docs
         path: docs/
@@ -51,7 +52,7 @@ jobs:
         with:
           artifact_name: docs
   cleanup:
-    if: ${{ always() }}
+    if: github.event_name == 'workflow_dispatch'
     needs: [build, deploy]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-deploy-docs.yml
+++ b/.github/workflows/check-deploy-docs.yml
@@ -51,12 +51,3 @@ jobs:
         uses: actions/deploy-pages@v4
         with:
           artifact_name: docs
-  cleanup:
-    if: github.event_name == 'workflow_dispatch'
-    needs: [build, deploy]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete uploaded Artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: docs


### PR DESCRIPTION
It is not entirely clear to me why the lookup of past artifacts began to fail all of a sudden. I think this might be something that changed on the site of github - the delete-artifact action we used it the only non-official one, and we also needed to use quite an old version of that, so this might be the culprit.

I changed the logic of the action to only upload the build when triggering the workflow manually (i.e., when triggering a deploy of the updated docs). Previously, we uploaded that build on every run. Because of this, we introduced the explicit deletion, as there is a limit on the amount of artifacts we can upload. However, artifacts are retained for 90d only per default. We would need to deploy *often* to hit this now with the improved logic.