### PR TITLE
🧰: fix initial layout of zoom indicator

### DIFF
--- a/lively.ide/studio/zoom-indicator.cp.js
+++ b/lively.ide/studio/zoom-indicator.cp.js
@@ -1,5 +1,5 @@
-import { component, part, Morph, Text, ViewModel, Icon, TilingLayout } from 'lively.morphic';
-import { Color, pt } from 'lively.graphics';
+import { component, Text, ViewModel, Icon, TilingLayout } from 'lively.morphic';
+import { Color, rect, pt } from 'lively.graphics';
 
 class WorldZoomIndicatorModel extends ViewModel {
   static get properties () {
@@ -27,7 +27,7 @@ class WorldZoomIndicatorModel extends ViewModel {
     return true;
   }
 
-  onMouseDown (evt) {
+  onMouseDown () {
     $world.resetScaleFactor();
   }
 
@@ -42,54 +42,67 @@ class WorldZoomIndicatorModel extends ViewModel {
     let miniMapOffset = 0;
     if (miniMap) miniMapOffset = miniMap.width + 10;
 
-    if ($world.activeSideBars.includes('properties panel')) view.position = pt($world.get('properties panel').left - 10 - view.width - miniMapOffset, $world.extent.y - 10 - view.height);
-    else this.view.position = pt($world.extent.x - view.width - 10 - miniMapOffset, $world.extent.y - view.height - 10);
+    if ($world.activeSideBars.includes('properties panel')) view.position = pt($world.get('properties panel').left - view.width - miniMapOffset, $world.extent.y - view.height);
+    else this.view.position = pt($world.extent.x - view.width - miniMapOffset, $world.extent.y - view.height);
   }
 }
 
 export const WorldZoomIndicator = component({
+  name: 'zoom indicator wrapper',
   defaultViewModel: WorldZoomIndicatorModel,
-  name: 'zoom indicator',
-  borderColor: Color.rgb(23, 160, 251),
-  borderRadius: 5,
-  extent: pt(65, 27),
-  fill: Color.rgba(0, 0, 0, 0.6),
-  hasFixedPosition: true,
-  halosEnabled: false,
+  fill: Color.transparent,
+  extent: pt(100, 100),
   layout: new TilingLayout({
-    axisAlign: 'center',
-    align: 'center',
-    orderByIndex: true,
-    hugContentsHorizontally: true,
-    hugContentsVertically: true,
-    padding: {
-      height: 0,
-      width: 0,
-      x: 5,
-      y: 5
-    },
-    reactToSubmorphAnimations: false,
-    resizeSubmorphs: false,
-    spacing: 5
+    align: 'right',
+    axisAlign: 'right',
+    padding: rect(0, 0, 10, 10)
   }),
-  nativeCursor: 'pointer',
-  position: pt(535, 438.4),
-  submorphs: [
-    {
-      type: Text,
-      name: 'zoom icon label',
-      fontSize: 14,
-      fontColor: Color.white,
-      nativeCursor: 'pointer',
-      halosEnabled: false,
-      textAndAttributes: Icon.textAttribute('magnifying-glass')
+  reactsToPointer: false,
+  submorphs: [{
+    name: 'zoom indicator',
+    borderColor: Color.rgb(23, 160, 251),
+    borderRadius: 5,
+    extent: pt(65, 27),
+    fill: Color.rgba(0, 0, 0, 0.6),
+    hasFixedPosition: true,
+    halosEnabled: false,
+    layout: new TilingLayout({
+      axisAlign: 'center',
+      align: 'center',
+      orderByIndex: true,
+      hugContentsHorizontally: true,
+      hugContentsVertically: true,
+      padding: {
+        height: 0,
+        width: 0,
+        x: 5,
+        y: 5
+      },
+      reactToSubmorphAnimations: false,
+      resizeSubmorphs: false,
+      spacing: 5
+    }),
+    nativeCursor: 'pointer',
+    position: pt(535, 438.4),
+    submorphs: [
+      {
+        type: Text,
+        name: 'zoom icon label',
+        fontSize: 14,
+        fontColor: Color.white,
+        nativeCursor: 'pointer',
+        halosEnabled: false,
+        textAndAttributes: Icon.textAttribute('magnifying-glass')
 
-    }, {
-      type: Text,
-      name: 'zoom factor label',
-      fontColor: Color.rgb(253, 254, 254),
-      nativeCursor: 'pointer',
-      halosEnabled: false,
-      textAndAttributes: ['100 %', null]
-    }]
-});
+      }, {
+        type: Text,
+        name: 'zoom factor label',
+        fontColor: Color.rgb(253, 254, 254),
+        nativeCursor: 'pointer',
+        halosEnabled: false,
+        textAndAttributes: ['100 %', null]
+      }]
+  }
+  ]
+}
+);


### PR DESCRIPTION
![cutoff-zoom-indicator](https://github.com/user-attachments/assets/0cbd61ac-b0c4-4d17-843d-00b5dee6823f)

Fixes this, with the same trick applied in #1689.