### PR TITLE
🧰: fix search icon in component browser

### DIFF
--- a/lively.ide/studio/component-browser.cp.js
+++ b/lively.ide/studio/component-browser.cp.js
@@ -1600,11 +1600,11 @@ const ComponentBrowser = component({
     }), {
       type: Text,
       name: 'search clear button',
-      nativeCursor: 'pointer',
       visible: false,
+      nativeCursor: 'pointer',
       fontColor: Color.rgba(0, 0, 0, 0.5),
       fontSize: 25,
-      lineHeight: 2,
+      lineHeight: 1,
       padding: rect(1, 1, 9, 0),
       textAndAttributes: ['', {
         fontFamily: 'Font Awesome',


### PR DESCRIPTION
Fixes this eyesore: 
![misaligned-clear](https://github.com/user-attachments/assets/23a2f9a0-4e72-4884-919e-3a184ac1e7ad)
