### PR TITLE
Fix erratic jump of shapes on drag right after creation.

### DIFF
--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -2263,13 +2263,14 @@ export default class Halo extends Morph {
 
   onDragStart (evt) {
     this.dragHalo().init();
-    this._lastDragPos = evt.startPosition;
+    this._lastDragPos = evt.position;
   }
 
   onDrag (evt) {
     if (!this.world()) return;
     this.dragHalo().update(evt.state.dragDelta);
     this.dragHalo().visible = false;
+    this._lastDragPos = evt.position;
   }
 
   onDragEnd (evt) {


### PR DESCRIPTION
Fixes an issue where after a very fast successive drag of a just created shape, it would randomly jump a huge amount for no reason.