### PR TITLE
🧰: ensure ide world becomes visible if never animated

### DIFF
--- a/lively.ide/world.js
+++ b/lively.ide/world.js
@@ -425,6 +425,7 @@ export class LivelyWorld extends World {
     await localInterface.exportsOfModules({
       excludedPackages: config.ide.js.ignoredPackages
     });
+    this.opacity = 1;
   }
 
   async initializeTopBar () {


### PR DESCRIPTION
Fixes #1767.
Fixes #1763.
For cases where one decides to freeze an ide world, but wont utilize it alongside a bootstrapped module system.