### PR TITLE
🧰: don't show test loading indicator when to package selected to load

### DIFF
--- a/lively.ide/test-runner.js
+++ b/lively.ide/test-runner.js
@@ -767,7 +767,7 @@ export default class TestRunner extends HTMLMorph {
         historyId: 'lively.morphic-test-runner-load-tests-pkg-hist'
       });
 
-    // if (!pkg) return null
+    if (!pkg) return null;
     const li = LoadingIndicator.open('Finding Testmodules in Package');
     const tests = await findTestModulesInPackage(sys, pkg.url);
     li.remove();


### PR DESCRIPTION
When using the "load tests" button the test runner and selecting no packages, the loading indicator would appear regardless, which was very annoying.