### PR TITLE
🧰: fix crash on opening module in browser

### DIFF
--- a/lively.ide/js/browser/index.js
+++ b/lively.ide/js/browser/index.js
@@ -1278,7 +1278,7 @@ export class BrowserModel extends ViewModel {
       }
 
       if (url) {
-        if (this.alreadySelectedModule(m.url)) return;
+        if (this.alreadySelectedModule(url)) return;
         this.state.selectedModule = { url };
         const td = columnView.treeData;
         await columnView.setExpandedPath(node => {


### PR DESCRIPTION
Fixes an issue where the browser would crash when we open a module via browser + select.