### PR TITLE
🤕: increase `protocolTimeout`

### DIFF
--- a/lively.headless/index.js
+++ b/lively.headless/index.js
@@ -61,7 +61,9 @@ export class HeadlessSession {
           // However, removing this option lead to instant crashes of chromium on some of our machines and in CI.
           // Wo do not know why that is, since the flag was not necessary previous to the introduction of the docker setup.
           "--no-sandbox",
-         ]
+         ],
+        // Set to 120s as lively.lang tests began to time-out reliably and mysterously in CI
+        protocolTimeout: 120_000
        }));
        return this.constructor.browser || newBrowser;
   }


### PR DESCRIPTION
Pretty strait-forward solution to the continuous timeout we have recently seen for the daily test runs.
120s might be higher than necessary, but for our use-case I honestly can't think of any downsides. Some breathing room won't hurt I guess...

@merryman, merging this, then rebasing #1773 should make your PR green as well - if not, this is not as good of a fix as I think. I ran multiple CI runs to check that the lively.lang tests succeed.