### PR TITLE
fix: revert jspm generator env to browser

### DIFF
--- a/lively.server/plugins/lib-lookup.js
+++ b/lively.server/plugins/lib-lookup.js
@@ -68,7 +68,7 @@ async function findAvailableCDNVersion (name, failingVersion) {
 
 function createGenerator (inputMap, resolutions) {
   return new Generator({
-    env: ["browser", "module", "import"],
+    env: ["browser"],
     defaultProvider: 'jspm.io',
     inputMap,
     ...(Object.keys(resolutions).length ? { resolutions } : {})


### PR DESCRIPTION
## Summary
- Reverts env from `["browser", "module", "import"]` to `["browser"]` in jspm Generator config
- The expanded env caused PouchDB to resolve to `index-browser.es.js` (minified ESM) which has a top-level `var re` that gets scope-captured by lively.modules, breaking IndexedDB initialization
- Fixes lively.storage test failure on daily CI

## Test plan
- [x] Clean install with `env: ["browser"]` generates all import maps without failures
- [x] `lively.storage` tests pass (73/73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)