### PR TITLE
🛠️: add Docker Compose development setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .git
 
-# Host-visible generated dependency/cache directories are created through the
-# bind mount at runtime, not copied into the image build context.
+# Docker-owned generated dependency/cache directories are mounted or created at
+# runtime, not copied into the image build context.
 .puppeteer-browser-cache
 .livelydbs
 .module_cache
@@ -30,6 +30,8 @@ user-server.sh
 /lively.classes/build
 /lively.freezer/landing-page
 /lively.freezer/loading-screen
+/lively.freezer/swc-plugin/target
 /lively.installer.log
 /lively.server/usage_log.json
+/lively.server/.module_cache
 /mocha-es6/.cachedImportMap.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+.git
+
+# Host-visible generated dependency/cache directories are created through the
+# bind mount at runtime, not copied into the image build context.
+.puppeteer-browser-cache
+.livelydbs
+.module_cache
+components_cache
+custom-npm-modules
+dev-deps
+esm_cache
+lively.next-node_modules
+local_projects
+resources
+snapshots
+subservers
+tmp
+uploads
+users
+*.idb
+
+# Local runtime files are seeded by the entrypoint when absent.
+favicon.ico
+localconfig.js
+package-lock.json
+robots.txt
+user-server.sh
+/flatn/.cachedImportMap.json
+/lively.*/.cachedImportMap.json
+/lively.classes/build
+/lively.freezer/landing-page
+/lively.freezer/loading-screen
+/lively.installer.log
+/lively.server/usage_log.json
+/mocha-es6/.cachedImportMap.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,21 @@
-* text=auto
+# This repo is built and validated primarily on Linux runners. Keep text files
+# checked out with LF so shell scripts, generated browser bundles, and source
+# patches behave the same on Windows, macOS, and Linux.
+* text=auto eol=lf
+
+# Keep common binary assets out of line-ending normalization.
+*.br binary
+*.gif binary
+*.gz binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.otf binary
+*.pdf binary
+*.png binary
+*.ttf binary
+*.wasm binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.zip binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,106 @@
+FROM ubuntu:24.04
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Ubuntu 24.04 is pinned so the development runtime stays reproducible while
+# still matching a current LTS release supported by NodeSource's Node 24 setup.
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    BUN_INSTALL=/root/.bun \
+    RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo
+
+ENV PATH="${CARGO_HOME}/bin:${BUN_INSTALL}/bin:${PATH}"
+
+# Install the base OS tools, build chain, browser shared libraries, and fonts
+# needed for a host with only Docker to run install.sh, start the server, and
+# execute Puppeteer-based boot checks inside the container.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      apt-transport-https \
+      aspell \
+      bash \
+      brotli \
+      build-essential \
+      ca-certificates \
+      curl \
+      dumb-init \
+      entr \
+      fonts-freefont-ttf \
+      fonts-ipafont-gothic \
+      fonts-kacst \
+      fonts-liberation \
+      fonts-thai-tlwg \
+      fonts-wqy-zenhei \
+      git \
+      gnupg \
+      iproute2 \
+      libasound2t64 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libatspi2.0-0 \
+      libcairo2 \
+      libcups2 \
+      libdbus-1-3 \
+      libdrm2 \
+      libgbm1 \
+      libglib2.0-0 \
+      libgtk-3-0 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libx11-6 \
+      libx11-xcb1 \
+      libxcb1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      libxss1 \
+      lsb-release \
+      net-tools \
+      perl \
+      pkg-config \
+      procps \
+      python3 \
+      python3-pip \
+      python3-venv \
+      sudo \
+      tar \
+      tree \
+      unzip \
+      wget \
+      xdg-utils \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# NodeSource provides Node 24 packages for Noble; using the distro package keeps
+# node and npm available without requiring a host-level version manager.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh \
+    && bash /tmp/nodesource_setup.sh \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -f /tmp/nodesource_setup.sh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Rust is installed in a shared location because the project build needs the
+# wasm32-wasip1 target and the container may run as different users later.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain stable \
+    && rustup target add wasm32-wasip1 \
+    && chmod -R a+rwx "${RUSTUP_HOME}" "${CARGO_HOME}"
+
+RUN pip3 install --break-system-packages --no-cache-dir sultan
+
+WORKDIR /workspace
+
+COPY scripts/docker-entrypoint.sh /usr/local/bin/lively-docker-entrypoint
+RUN chmod +x /usr/local/bin/lively-docker-entrypoint
+
+EXPOSE 9011
+
+ENTRYPOINT ["dumb-init", "--", "lively-docker-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ For some more advanced development operations (such as bulk testing from the com
 >
 > If you want to change files outside of `lively` (i.e., in a normal editor), while still having the changes be available in lively when opening the file, you'll need to install `entr` from its [repository](https://github.com/eradman/entr). Usually, when working inside of `lively.next`, this will not be an issue, but it can be handy when working heavily on the core of `lively`. *This feature works semi-reliable at the moment. If you are interested in this and would like to help debug this, please reach out!*
 
-### Installation Instructions
+### Docker Compose Setup
+
+If Docker with Compose support is installed, you can run `lively.next` without installing Node.js, Bun, Rust, Python packages, or the other development tools on the host.
+
+From the repository root, run:
+
+```bash
+docker compose up --build
+```
+
+The first run installs project dependencies and builds generated artifacts inside the container, so it can take several minutes. When the server is ready, open [http://localhost:9011](http://localhost:9011).
+
+The Compose setup bind-mounts this checkout into the container at `/workspace`. Files changed from inside the container are the files in your host checkout. Generated ignored directories such as `lively.next-node_modules`, `.puppeteer-browser-cache`, `local_projects`, `snapshots`, and `esm_cache` are also written into the host checkout so later container starts can reuse them.
+
+### Manual Installation Instructions
 
 If you are on macOS, install the required tooling first:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For some more advanced development operations (such as bulk testing from the com
 
 ### Docker Compose Setup
 
-If Docker with Compose support is installed, you can run `lively.next` without installing Node.js, Bun, Rust, Python packages, or the other development tools on the host.
+Docker Compose is an optional development launcher, not a replacement for the native install and run-server workflow below. Use the native setup when you want `lively.next` to run directly on your host. Use Compose when you want Docker to provide Node.js, Bun, Rust, Python packages, browser dependencies, and the other development tools.
 
 From the repository root, run:
 
@@ -65,9 +65,21 @@ From the repository root, run:
 docker compose up --build
 ```
 
-The first run installs project dependencies and builds generated artifacts inside the container, so it can take several minutes. When the server is ready, open [http://localhost:9011](http://localhost:9011).
+The first run installs project dependencies and builds generated artifacts inside Docker, so it can take several minutes. When the server is ready, open [http://localhost:9011](http://localhost:9011).
 
-The Compose setup bind-mounts this checkout into the container at `/workspace`. Files changed from inside the container are the files in your host checkout. Generated ignored directories such as `lively.next-node_modules`, `.puppeteer-browser-cache`, `local_projects`, `snapshots`, and `esm_cache` are also written into the host checkout so later container starts can reuse them.
+The Compose setup bind-mounts this checkout into the container at `/workspace`. Files changed from inside the container are the files in your host checkout, so source edits are shared with native tools. Generated dependency, database, cache, and build directory contents are isolated in Docker named volumes instead of being shared with native runs. Docker may create empty mount-point directories in the checkout, but the Linux container artifacts inside those paths stay separate from macOS/Linux/WSL artifacts created by the manual setup.
+
+Stop the stack without deleting Docker's generated state:
+
+```bash
+docker compose down
+```
+
+Remove the Docker-generated state and force the next Compose start to behave like a fresh install:
+
+```bash
+docker compose down -v
+```
 
 ### Manual Installation Instructions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  lively:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # Use an init process and larger shared memory so browser boot checks behave
+    # like they do in a normal desktop browser environment.
+    init: true
+    shm_size: 2gb
+    working_dir: /workspace
+    ports:
+      # Keep the development server local to the host machine.
+      - "127.0.0.1:9011:9011"
+    volumes:
+      # Bind mount the checkout so edits and generated install artifacts remain
+      # visible on the host and survive container rebuilds.
+      - .:/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,155 @@ services:
       # Keep the development server local to the host machine.
       - "127.0.0.1:9011:9011"
     volumes:
-      # Bind mount the checkout so edits and generated install artifacts remain
-      # visible on the host and survive container rebuilds.
-      - .:/workspace
+      # Bind mount the checkout so source edits inside the container are edits
+      # to the host checkout.
+      - type: bind
+        source: .
+        target: /workspace
+
+      # Keep Docker-generated dependency, database, cache, and build directory
+      # state out of the host checkout. These named volumes intentionally sit on
+      # top of ignored paths that native installs also use, so Docker and native
+      # runs can keep separate platform-specific artifacts while sharing source
+      # code. nocopy avoids seeding a new Docker volume from stale host
+      # artifacts.
+      - type: volume
+        source: lively-next-node-modules
+        target: /workspace/lively.next-node_modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-custom-npm-modules
+        target: /workspace/custom-npm-modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-dbs
+        target: /workspace/.livelydbs
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-puppeteer-browser-cache
+        target: /workspace/.puppeteer-browser-cache
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-esm-cache
+        target: /workspace/esm_cache
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-local-projects
+        target: /workspace/local_projects
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-snapshots
+        target: /workspace/snapshots
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-tmp
+        target: /workspace/tmp
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-dev-deps
+        target: /workspace/dev-deps
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-module-cache
+        target: /workspace/.module_cache
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-components-cache
+        target: /workspace/components_cache
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-resources
+        target: /workspace/resources
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-uploads
+        target: /workspace/uploads
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-users
+        target: /workspace/users
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-subservers
+        target: /workspace/subservers
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-classes-build
+        target: /workspace/lively.classes/build
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-freezer-loading-screen
+        target: /workspace/lively.freezer/loading-screen
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-freezer-landing-page
+        target: /workspace/lively.freezer/landing-page
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-freezer-swc-plugin-target
+        target: /workspace/lively.freezer/swc-plugin/target
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-server-module-cache
+        target: /workspace/lively.server/.module_cache
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-morphic-objectdb
+        target: /workspace/lively.morphic/objectdb/morphicdb
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-morphic-objectdb-commits
+        target: /workspace/lively.morphic/objectdb/morphicdb-commits
+        volume:
+          nocopy: true
+      - type: volume
+        source: lively-morphic-objectdb-version-graph
+        target: /workspace/lively.morphic/objectdb/morphicdb-version-graph
+        volume:
+          nocopy: true
+
+volumes:
+  lively-next-node-modules:
+  lively-custom-npm-modules:
+  lively-dbs:
+  lively-puppeteer-browser-cache:
+  lively-esm-cache:
+  lively-local-projects:
+  lively-snapshots:
+  lively-tmp:
+  lively-dev-deps:
+  lively-module-cache:
+  lively-components-cache:
+  lively-resources:
+  lively-uploads:
+  lively-users:
+  lively-subservers:
+  lively-classes-build:
+  lively-freezer-loading-screen:
+  lively-freezer-landing-page:
+  lively-freezer-swc-plugin-target:
+  lively-server-module-cache:
+  lively-morphic-objectdb:
+  lively-morphic-objectdb-commits:
+  lively-morphic-objectdb-version-graph:

--- a/flatn/flatn-cjs.js
+++ b/flatn/flatn-cjs.js
@@ -13582,6 +13582,20 @@ const makeEmitter = isNode$1
     return obj;
   };
 
+/* global require, Worker, URL, webkitURL, Blob, BlobBuilder, process, require,self,global,remoteWorker,postMessage,XMLHttpRequest,__FUNCTIONDECLARATIONS__,initBrowserGlobals,loadDependenciesBrowser,initOnMessageHandler,initWorkerInterface,initWorkerMessenger,loadDependenciesNodejs,importScripts */
+
+
+/*
+ * Browser/freezer contexts can expose partial CommonJS-looking globals through
+ * bundler shims. Treat the environment as Node.js only when the real Node
+ * process object is present and no browser global is active.
+ */
+typeof globalThis !== 'undefined' &&
+  typeof globalThis.window === 'undefined' &&
+  typeof globalThis.self === 'undefined' &&
+  typeof globalThis.require === 'function' &&
+  !!(globalThis.process && globalThis.process.versions && globalThis.process.versions.node);
+
 /* global global,self,process */
 
 typeof process !== 'undefined' && process.env && typeof process.exit === 'function';

--- a/flatn/package.json
+++ b/flatn/package.json
@@ -11,12 +11,25 @@
     "flatn_node": "./bin/node",
     "flatn_env": "./bin/flatn_env"
   },
+  "systemjs": {
+    "map": {
+      "buffer": {
+        "node": "@node/buffer",
+        "~node": "buffer"
+      },
+      "node:buffer": {
+        "node": "@node/buffer",
+        "~node": "buffer"
+      }
+    }
+  },
   "dependencies": {
     "lively.lang": "*",
     "lively.resources": "*",
     "node-gyp": "9.0.0",
     "babel-plugin-transform-es2015-modules-systemjs": "^6.19.0",
     "node-fetch": "3.2.10",
+    "buffer": "6.0.3",
     "@rollup/wasm-node": "4.27.3",
     "@rollup/plugin-commonjs": "22.0.0",
     "minimist": "1.2.6",

--- a/flatn/tools/build-cjs.mjs
+++ b/flatn/tools/build-cjs.mjs
@@ -5,6 +5,15 @@ import { builtinModules } from 'node:module';
 import { flatnResolve } from '../module-resolver.js';
 
 try {
+  /*
+   * The generated CJS file is used directly by Node and is also translated by
+   * SystemJS during browser boot. Keep core modules external so the Node path
+   * keeps using Node's own implementations, while flatn/package.json maps the
+   * browser-safe Buffer polyfill back to the "buffer" package for SystemJS.
+   * Without that package-level map a restored dependency cache can resolve
+   * buffer to the empty Node placeholder and fail at Buffer.isBuffer during the
+   * world-load proof.
+   */
   const nodeBuiltins = new Set(
     builtinModules
       .flatMap(m => [m, m.startsWith('node:') ? m.slice(5) : `node:${m}`])
@@ -16,8 +25,6 @@ try {
     plugins: [
       {
         resolveId: async (id, parentURL) => {
-          // Keep Node builtins external for the cjs bundle to avoid
-          // environment-dependent polyfill resolution via flatn package lookup.
           if (nodeBuiltins.has(id)) {
             return { id: id.startsWith('node:') ? id.slice(5) : id, external: true };
           }

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,9 @@ fi
 export NODE_OPTIONS="--no-warnings --experimental-modules --loader $lv_next_dir/flatn/resolver.mjs";
 
 section "Installing packages"
-node lively.installer/install-with-node.js $PWD \
+# Fail fast here so the Docker entrypoint never continues into generated build
+# steps after a dependency install failure.
+node lively.installer/install-with-node.js "$PWD" || exit 1
 
 section "Building class runtime"
 step "Compiling lively.classes runtime..."

--- a/lively.ast/lib/acorn-extension.js
+++ b/lively.ast/lib/acorn-extension.js
@@ -36,6 +36,10 @@ if (isNode) {
 }
 
 const custom = {};
+// Acorn can arrive as either a namespace object or a default-wrapped CommonJS
+// module depending on whether the caller came through native Node import,
+// SystemJS, or the freezer browser transform.
+const acornBase = acornDefault.Parser ? acornDefault : acornDefault.default;
 
 custom.forEachNode = forEachNode;
 custom.matchNodes = matchNodes;
@@ -47,10 +51,10 @@ custom.findNodeByAstIndex = findNodeByAstIndex;
 custom.findStatementOfNode = findStatementOfNode;
 custom.addAstIndex = addAstIndex;
 
-const Parser = acornDefault.Parser.extend(ClassFields, StaticClassFeatures, PrivateMethods, Decorators);
+const Parser = acornBase.Parser.extend(ClassFields, StaticClassFeatures, PrivateMethods, Decorators);
 
 const acorn = {};
-Object.assign(acorn, acornDefault);
+Object.assign(acorn, acornBase);
 acorn.Parser = Parser;
 acorn.parse = (source, opts) => Parser.parse(source, opts);
 

--- a/lively.components/widgets.js
+++ b/lively.components/widgets.js
@@ -16,7 +16,9 @@ import kld from 'kld-intersections';
 import { Menu } from 'lively.components';
 import { SystemTooltip } from 'lively.morphic/tooltips.cp.js';
 
-const { Shapes, Intersection } = kld;
+// The freezer boot bundle can externalize this geometry package before the live
+// package system has filled it in, so destructure defensively during startup.
+const { Shapes, Intersection } = kld || {};
 
 class LeashEndpoint extends Ellipse {
   get dragTriggerDistance () { return this.connectedMorph ? 20 : 0; }

--- a/lively.components/widgets.js
+++ b/lively.components/widgets.js
@@ -16,9 +16,7 @@ import kld from 'kld-intersections';
 import { Menu } from 'lively.components';
 import { SystemTooltip } from 'lively.morphic/tooltips.cp.js';
 
-// The freezer boot bundle can externalize this geometry package before the live
-// package system has filled it in, so destructure defensively during startup.
-const { Shapes, Intersection } = kld || {};
+const { Shapes, Intersection } = kld;
 
 class LeashEndpoint extends Ellipse {
   get dragTriggerDistance () { return this.connectedMorph ? 20 : 0; }

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -51,6 +51,17 @@ const SYSTEMJS_STUB = `
 ${GLOBAL_FETCH}
 if (!G.System) G.System = G.lively.FreezerRuntime;`;
 
+/*
+ * Rollup uses `_missingExportShim` when an import asks for an export that was
+ * intentionally externalized or mapped to the blank module. Browser boot can
+ * still execute compatibility packages that read `buffer.Buffer.isBuffer`
+ * through that placeholder. Keep the shim callable for existing namespace
+ * destructuring behavior, and give it the smallest Buffer surface needed by
+ * those feature tests so an absent Node polyfill degrades to "not a Buffer"
+ * instead of aborting the world load.
+ */
+const MISSING_EXPORT_SHIM_SOURCE = 'var _missingExportShim = function () {}; _missingExportShim.Buffer = { isBuffer: function () { return false; } }; _missingExportShim.default = _missingExportShim;';
+
 const CLASS_INSTRUMENTATION_MODULES = [
   'lively.morphic',
   'lively.components',
@@ -130,10 +141,10 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
     });
     /*
      * Rollup's shimMissingExports can emit an uninitialized helper for exports
-     * that are deliberately absent from externalized boot-only modules. Make it
-     * callable so namespace destructuring does not crash the browser bundle.
+     * that are deliberately absent from externalized boot-only modules. Replace
+     * it with the shared browser-safe placeholder before the bundle is served.
      */
-    transformedCode = transformedCode.replace('var _missingExportShim = void 0;', 'var _missingExportShim = () => {};');
+    transformedCode = transformedCode.replace('var _missingExportShim = void 0;', MISSING_EXPORT_SHIM_SOURCE);
     return { code: transformedCode, map }
   }
 
@@ -165,11 +176,11 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
   }
   /*
    * Keep the non-source-map path behaviorally aligned with the Babel path above:
-   * resurrection chunks need a browser-safe process.env and a callable missing
-   * export shim before the first module body executes.
+   * resurrection chunks need a browser-safe process.env and the same
+   * Buffer-aware missing export shim before the first module body executes.
    */
   code = code.replace("'use strict';", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\nvar process = globalThis.process || (globalThis.process = { env: {} });\nprocess.env = process.env || {};\n");
-  code = code.replace('var _missingExportShim = void 0;', 'var _missingExportShim = () => {};');
+  code = code.replace('var _missingExportShim = void 0;', MISSING_EXPORT_SHIM_SOURCE);
   return { code };
 }
 
@@ -1363,7 +1374,7 @@ export default class LivelyRollup {
     const globals = {};
 
     if (!systemJsEnabled) {
-      code += `${this.asBrowserModule ? 'var fs = {};' : 'var fs = require("fs");'} var _missingExportShim = () => {}, show, System, require, timing, lively, Namespace, localStorage;`;
+      code += `${this.asBrowserModule ? 'var fs = {};' : 'var fs = require("fs");'} ${MISSING_EXPORT_SHIM_SOURCE} var show, System, require, timing, lively, Namespace, localStorage;`;
     }
 
     // this is no longer an issue due to removal of all non ESM modules from our system. Can be removed? Not entirely....

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -86,7 +86,13 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
             const [useStrictDirective] = functionBody.get('directives');
             if (useStrictDirective) {
               useStrictDirective.remove();
-              functionBody.unshiftContainer('body', babel.parse("var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];").program.body[0]);
+              /*
+               * Browser-targeted resurrection chunks can execute third-party
+               * packages that probe process.env. Provide a minimal page-global
+               * process shim next to the existing module context shim so those
+               * probes do not abort boot before the live module system takes over.
+               */
+              functionBody.unshiftContainer('body', babel.parse("var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1]; var process = globalThis.process || (globalThis.process = { env: {} }); process.env = process.env || {};").program.body);
             }
             if (isResurrectionBuild) {
               path.get('body.0.expression.callee.object').replaceWith(t.Identifier('BootstrapSystem'));
@@ -122,6 +128,12 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
         }
       })]
     });
+    /*
+     * Rollup's shimMissingExports can emit an uninitialized helper for exports
+     * that are deliberately absent from externalized boot-only modules. Make it
+     * callable so namespace destructuring does not crash the browser bundle.
+     */
+    transformedCode = transformedCode.replace('var _missingExportShim = void 0;', 'var _missingExportShim = () => {};');
     return { code: transformedCode, map }
   }
 
@@ -151,7 +163,13 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
     // this messes up the source map
     code = code.replace('System.register', `BootstrapSystem._currentFile = "${chunkFileName}";\nBootstrapSystem.register`);
   }
-  code = code.replace("'use strict';", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\n");
+  /*
+   * Keep the non-source-map path behaviorally aligned with the Babel path above:
+   * resurrection chunks need a browser-safe process.env and a callable missing
+   * export shim before the first module body executes.
+   */
+  code = code.replace("'use strict';", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\nvar process = globalThis.process || (globalThis.process = { env: {} });\nprocess.env = process.env || {};\n");
+  code = code.replace('var _missingExportShim = void 0;', 'var _missingExportShim = () => {};');
   return { code };
 }
 
@@ -893,6 +911,23 @@ export default class LivelyRollup {
     if (importMap) {
       let remapped = resolveViaImportMap(id, importMap, importer)
       if (remapped) id = remapped;
+    }
+
+    /*
+     * Browser bundles should honor package-level browser remaps before falling
+     * back to Node-oriented entry points. engine.io-client also ships Node-only
+     * websocket files behind relative imports, so map those to browser-safe
+     * files or to the empty module when the dependency is not needed in boot.
+     */
+    if (this.asBrowserModule && importingPackage?.browser && obj.isObject(importingPackage.browser)) {
+      const remapped = importingPackage.browser[id];
+      if (remapped === false) return '@empty.js';
+      if (typeof remapped === 'string') id = remapped;
+    }
+
+    if (this.asBrowserModule && importingPackage?.name === 'engine.io-client') {
+      if (id === 'ws') return '@empty.js';
+      if (id.startsWith('.') && id.endsWith('.node.js')) id = id.replace(/\.node\.js$/, '.js');
     }
     
     this.moduleToPkg.set(id, importingPackage);

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -51,16 +51,21 @@ const SYSTEMJS_STUB = `
 ${GLOBAL_FETCH}
 if (!G.System) G.System = G.lively.FreezerRuntime;`;
 
-/*
- * Rollup uses `_missingExportShim` when an import asks for an export that was
- * intentionally externalized or mapped to the blank module. Browser boot can
- * still execute compatibility packages that read `buffer.Buffer.isBuffer`
- * through that placeholder. Keep the shim callable for existing namespace
- * destructuring behavior, and give it the smallest Buffer surface needed by
- * those feature tests so an absent Node polyfill degrades to "not a Buffer"
- * instead of aborting the world load.
+/**
+ * Fails a freezer build if the generated code tries to route Buffer checks
+ * through Rollup's missing-export helper.
+ * @param {string} code - Generated chunk source after namespace hardening.
+ * @param {string} chunkFileName - Rollup chunk name used for diagnostics.
+ * @returns {void}
  */
-const MISSING_EXPORT_SHIM_SOURCE = 'var _missingExportShim = function () {}; _missingExportShim.Buffer = { isBuffer: function () { return false; } }; _missingExportShim.default = _missingExportShim;';
+function assertNoSyntheticBufferShim (code, chunkFileName) {
+  const hasMissingExportBuffer = code.includes('_missingExportShim' + '.Buffer');
+  if (!hasMissingExportBuffer) return;
+  throw new Error(
+    `Freezer chunk ${chunkFileName} routes Buffer through _missingExportShim. ` +
+    'Resolve the real browser Buffer package instead of emitting a fake Buffer API.'
+  );
+}
 
 const CLASS_INSTRUMENTATION_MODULES = [
   'lively.morphic',
@@ -141,10 +146,12 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
     });
     /*
      * Rollup's shimMissingExports can emit an uninitialized helper for exports
-     * that are deliberately absent from externalized boot-only modules. Replace
-     * it with the shared browser-safe placeholder before the bundle is served.
+     * that are deliberately absent from externalized boot-only modules. Do not
+     * replace that helper with a fake implementation here. If Buffer was routed
+     * through it, the resolver missed a real dependency and the build should
+     * stop before the browser sees a misleading API.
      */
-    transformedCode = transformedCode.replace('var _missingExportShim = void 0;', MISSING_EXPORT_SHIM_SOURCE);
+    assertNoSyntheticBufferShim(transformedCode, chunkFileName);
     return { code: transformedCode, map }
   }
 
@@ -176,11 +183,12 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
   }
   /*
    * Keep the non-source-map path behaviorally aligned with the Babel path above:
-   * resurrection chunks need a browser-safe process.env and the same
-   * Buffer-aware missing export shim before the first module body executes.
+   * resurrection chunks need a browser-safe process.env before the first module
+   * body executes. Missing exports remain Rollup's own uninitialized helper so
+   * unsupported imports fail honestly instead of running through invented code.
    */
   code = code.replace("'use strict';", "var __contextModule__ = typeof module !== 'undefined' ? module : arguments[1];\nvar process = globalThis.process || (globalThis.process = { env: {} });\nprocess.env = process.env || {};\n");
-  code = code.replace('var _missingExportShim = void 0;', MISSING_EXPORT_SHIM_SOURCE);
+  assertNoSyntheticBufferShim(code, chunkFileName);
   return { code };
 }
 
@@ -925,19 +933,18 @@ export default class LivelyRollup {
     }
 
     /*
-     * Browser bundles should honor package-level browser remaps before falling
-     * back to Node-oriented entry points. engine.io-client also ships Node-only
-     * websocket files behind relative imports, so map those to browser-safe
-     * files or to the empty module when the dependency is not needed in boot.
+     * Browser bundles should honor package-level browser file remaps before
+     * falling back to Node-oriented entry points. Only concrete string remaps
+     * are handled here; a package-authored `false` remap means "no browser
+     * implementation", and this freezer path should fail that import honestly
+     * instead of introducing a new empty module for it.
      */
     if (this.asBrowserModule && importingPackage?.browser && obj.isObject(importingPackage.browser)) {
       const remapped = importingPackage.browser[id];
-      if (remapped === false) return '@empty.js';
       if (typeof remapped === 'string') id = remapped;
     }
 
     if (this.asBrowserModule && importingPackage?.name === 'engine.io-client') {
-      if (id === 'ws') return '@empty.js';
       if (id.startsWith('.') && id.endsWith('.node.js')) id = id.replace(/\.node\.js$/, '.js');
     }
     
@@ -1374,7 +1381,7 @@ export default class LivelyRollup {
     const globals = {};
 
     if (!systemJsEnabled) {
-      code += `${this.asBrowserModule ? 'var fs = {};' : 'var fs = require("fs");'} ${MISSING_EXPORT_SHIM_SOURCE} var show, System, require, timing, lively, Namespace, localStorage;`;
+      code += `${this.asBrowserModule ? 'var fs = {};' : 'var fs = require("fs");'} var _missingExportShim = () => {}, show, System, require, timing, lively, Namespace, localStorage;`;
     }
 
     // this is no longer an issue due to removal of all non ESM modules from our system. Can be removed? Not entirely....

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -108,6 +108,15 @@ function detectFormat (moduleId) {
   // return module(moduleId).format();
 }
 
+/**
+ * Checks whether an id names a Node.js built-in module.
+ * @param {string} id - Raw import id passed to the resolver.
+ * @returns {boolean} True for "node:" imports and bare built-in module names.
+ */
+function isBuiltinModuleId (id) {
+  return id?.startsWith('node:') || builtinModules.includes(id);
+}
+
 const spinner = {
   frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
   idx: 0,
@@ -280,7 +289,15 @@ function supportingPlugins(context = 'node', self) {
     },
     {
        name: 'lively-resolve',
-       resolveId: (id, importer) => self.resolveId(id, importer)
+       resolveId: (id, importer) => {
+         /*
+          * Browser bundles still need Rollup's node polyfill plugin to see
+          * built-ins such as "path" or "node:buffer". Resolving them through
+          * flatn first turns them into host paths and bypasses the polyfills.
+          */
+         if (context === 'browser' && isBuiltinModuleId(id)) return null;
+         return self.resolveId(id, importer);
+       }
     }, // but only do resolutions so that polyfills does not screw us up
     context == 'browser' && nodePolyfills(), // only if we bundle for the browser
     commonjs({
@@ -288,7 +305,9 @@ function supportingPlugins(context = 'node', self) {
       defaultIsModuleExports: true,
       transformMixedEsModules: true,
       dynamicRequireRoot: process.env.lv_next_dir,
-      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /lively./],
+      // Transform dependencies under lively.next-node_modules, but do not run
+      // the CommonJS transform across the repo's own lively.* package sources.
+      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /[\\/]lively\.(?!next-node_modules)[^\\/]+[\\/]/],
       dynamicRequireTargets: [
          resolveModuleId('babel-plugin-transform-es2015-modules-systemjs')
       ]

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -117,6 +117,56 @@ function isBuiltinModuleId (id) {
   return id?.startsWith('node:') || builtinModules.includes(id);
 }
 
+/**
+ * Checks whether an id names the Buffer built-in that browser bundles must
+ * satisfy with the real `buffer` package.
+ * @param {string} id - Raw import id passed to the resolver.
+ * @returns {boolean} True for the Buffer built-in spellings handled here.
+ */
+function isBufferBuiltinModuleId (id) {
+  return id === 'buffer' || id === 'node:buffer';
+}
+
+/**
+ * Reads the Buffer package version declared by flatn.
+ * @returns {string|null} The exact Buffer dependency version when available.
+ */
+function declaredFlatnBufferVersion () {
+  try {
+    const rootDir = process.env.lv_next_dir || process.cwd();
+    const flatnPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'flatn', 'package.json'), 'utf8'));
+    const version = flatnPackage.dependencies?.buffer;
+    return typeof version === 'string' && /^\d+\.\d+\.\d+$/.test(version) ? version : null;
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Resolves the real browser Buffer package without falling back to a blank
+ * Node built-in placeholder.
+ * @param {string} importer - Module id that requested Buffer.
+ * @returns {string|null} Absolute path to the browser Buffer package entry.
+ */
+function resolveBrowserBufferModule (importer) {
+  /*
+   * Buffer is special among built-ins here. Most browser built-ins can be
+   * delegated to rollup-plugin-polyfill-node, but flatn's generated CJS bundle
+   * calls `buffer.Buffer.isBuffer` during world boot. That check is semantic:
+   * resolving it to @empty or a fake missing-export object hides a bundling bug
+   * and can change stream/body handling later in the boot path.
+   */
+  const resolvedByFlatn = resolveModuleId('buffer', importer, 'systemjs-browser');
+  if (resolvedByFlatn && resolvedByFlatn !== '@empty') return resolvedByFlatn;
+
+  const rootDir = process.env.lv_next_dir || process.cwd();
+  const version = declaredFlatnBufferVersion();
+  const candidate = version && path.join(rootDir, 'lively.next-node_modules', 'buffer', version, 'index.js');
+  if (candidate && fs.existsSync(candidate)) return candidate;
+
+  return null;
+}
+
 const spinner = {
   frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
   idx: 0,
@@ -292,9 +342,15 @@ function supportingPlugins(context = 'node', self) {
        resolveId: (id, importer) => {
          /*
           * Browser bundles still need Rollup's node polyfill plugin to see
-          * built-ins such as "path" or "node:buffer". Resolving them through
-          * flatn first turns them into host paths and bypasses the polyfills.
+          * built-ins such as "path". Buffer is intentionally excluded from that
+          * blanket delegation because boot code needs the real Buffer package,
+          * not an empty Node placeholder or a missing-export fallback.
           */
+         if (context === 'browser' && isBufferBuiltinModuleId(id)) {
+           const resolvedBuffer = resolveBrowserBufferModule(importer);
+           if (resolvedBuffer) return resolvedBuffer;
+           throw new Error(`Cannot resolve browser Buffer polyfill for ${id} imported by ${importer || '<entry>'}`);
+         }
          if (context === 'browser' && isBuiltinModuleId(id)) return null;
          return self.resolveId(id, importer);
        }
@@ -305,9 +361,15 @@ function supportingPlugins(context = 'node', self) {
       defaultIsModuleExports: true,
       transformMixedEsModules: true,
       dynamicRequireRoot: process.env.lv_next_dir,
-      // Transform dependencies under lively.next-node_modules, but do not run
-      // the CommonJS transform across the repo's own lively.* package sources.
-      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /[\\/]lively\.(?!next-node_modules)[^\\/]+[\\/]/],
+      /*
+       * Transform dependencies under lively.next-node_modules, but do not run
+       * the CommonJS transform across the repo's own lively.* package sources.
+       * The regex explicitly skips both the repo root folder (`lively.next`)
+       * and the dependency folder (`lively.next-node_modules`); otherwise
+       * browser chunks can keep raw `require(...)` calls from packages such as
+       * buffer and then fail during world boot.
+       */
+      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /[\\/]lively\.(?!next(?:[\\/]|-node_modules[\\/]))[^\\/]+[\\/]/],
       dynamicRequireTargets: [
          resolveModuleId('babel-plugin-transform-es2015-modules-systemjs')
       ]

--- a/lively.freezer/src/util/bootstrap.js
+++ b/lively.freezer/src/util/bootstrap.js
@@ -9,7 +9,6 @@ import { install as installHook } from 'lively.modules/src/hooks.js';
 import { updateBundledModules } from 'lively.modules/src/module.js';
 import { Project } from 'lively.project/project.js';
 import { pathForBrowserHistory } from 'lively.morphic/helpers.js';
-import { installLinter } from 'lively.ide/js/linter.js';
 import { setupSwcTranspiler } from 'lively.source-transform/swc/transpiler-setup.js';
 import untar from 'js-untar';
 import bowser from 'bowser';
@@ -178,6 +177,34 @@ function logInfo (...info) {
   console.log('%c' + info[0], `color: white; background: ${Color.darkGray}; border-radius: 10px; padding: 1px 4px;`, ...info.slice(1));
 }
 
+/**
+ * Checks whether the boot URL explicitly opts into installing the JS linter.
+ * @returns {boolean} True when the query string requests linter installation.
+ */
+function shouldInstallLinter () {
+  return query.installLinter === true || query.installLinter === 'true';
+}
+
+/**
+ * Installs the JS linter only after the bootstrapped SystemJS instance exists.
+ * @param {object} System - The active bootstrapped module system.
+ * @returns {Promise<void>} Resolves after the optional linter install attempt.
+ */
+async function installLinterSafely (System) {
+  /*
+   * The linter is useful in an interactive editor session, but it is not a
+   * hard requirement for resurrection boot. Keeping it behind a dynamic import
+   * prevents its parser/tooling dependencies from making project/world startup
+   * fail before the editable world is available.
+   */
+  try {
+    const { installLinter } = await import('lively.ide/js/linter.js');
+    if (typeof installLinter === 'function') installLinter(System);
+  } catch (err) {
+    console.warn('[freezer bootstrap] Skipping linter install:', err?.message || err);
+  }
+}
+
 async function shallowReloadModulesIfNeeded (modulesToCheck, moduleHashes, R) {
   const modsToReload = [];
   for (let modId of modulesToCheck) {
@@ -234,7 +261,7 @@ function bootstrapLivelySystem (progress, fastLoad = query.fastLoad !== false ||
       lively.modules.changeSystem(System, true);
       $world.env.installSystemChangeHandlers();
 
-      installLinter(System);
+      if (shouldInstallLinter()) await installLinterSafely(System);
       await setupSwcTranspiler(System);
       logInfo('Setup SystemJS:', Date.now() - ts + 'ms');
 
@@ -525,6 +552,8 @@ export async function bootstrap ({
         }
       }
     } catch (err) {
+      // Keep transition errors inspectable for the fail-fast browser boot proof
+      // instead of losing them inside the loading screen.
       window.__loadError__ = err;
     }
 

--- a/lively.freezer/src/util/helpers.js
+++ b/lively.freezer/src/util/helpers.js
@@ -201,16 +201,7 @@ export function instrumentStaticSystemJS (system) {
   const _origDecanonicalize = system.decanonicalize ? system.decanonicalize.bind(system) : (id) => id;
   system.decanonicalize = (id) =>
     lively.FreezerRuntime ? lively.FreezerRuntime.decanonicalize(id) : _origDecanonicalize(id);
-  /*
-   * Static SystemJS can ask for exports from modules that were intentionally
-   * externalized to the blank module. Some browser compatibility packages then
-   * probe `buffer.Buffer.isBuffer` through that placeholder. Give the global
-   * fallback the same tiny Buffer surface as generated resurrection chunks so
-   * missing Node-only exports remain harmless during world boot.
-   */
-  window._missingExportShim = function () {};
-  window._missingExportShim.Buffer = { isBuffer: function () { return false; } };
-  window._missingExportShim.default = window._missingExportShim;
+  window._missingExportShim = () => {};
   system.moduleRegisters = {};
   system.moduleSources = {};
   const _originalRegister = system.register.bind(system);

--- a/lively.freezer/src/util/helpers.js
+++ b/lively.freezer/src/util/helpers.js
@@ -201,7 +201,16 @@ export function instrumentStaticSystemJS (system) {
   const _origDecanonicalize = system.decanonicalize ? system.decanonicalize.bind(system) : (id) => id;
   system.decanonicalize = (id) =>
     lively.FreezerRuntime ? lively.FreezerRuntime.decanonicalize(id) : _origDecanonicalize(id);
-  window._missingExportShim = () => {};
+  /*
+   * Static SystemJS can ask for exports from modules that were intentionally
+   * externalized to the blank module. Some browser compatibility packages then
+   * probe `buffer.Buffer.isBuffer` through that placeholder. Give the global
+   * fallback the same tiny Buffer surface as generated resurrection chunks so
+   * missing Node-only exports remain harmless during world boot.
+   */
+  window._missingExportShim = function () {};
+  window._missingExportShim.Buffer = { isBuffer: function () { return false; } };
+  window._missingExportShim.default = window._missingExportShim;
   system.moduleRegisters = {};
   system.moduleSources = {};
   const _originalRegister = system.register.bind(system);

--- a/lively.freezer/tools/build.loading-screen.mjs
+++ b/lively.freezer/tools/build.loading-screen.mjs
@@ -1,6 +1,8 @@
 /* global process */
 import { rollup } from '@rollup/wasm-node';
 import jsonPlugin from '@rollup/plugin-json';
+import { babel } from '@rollup/plugin-babel';
+import PresetEnv from '@babel/preset-env';
 import { rm, writeFile } from 'node:fs/promises';
 import { lively } from 'lively.freezer/src/plugins/rollup';
 import resolver from 'lively.freezer/src/resolvers/node.cjs';
@@ -8,10 +10,58 @@ import resolver from 'lively.freezer/src/resolvers/node.cjs';
 const verbose = true; // process.argv[2] === '--verbose';
 const minify = !process.env.CI;
 const sourceMap = !!process.env.DEBUG;
+
+/*
+ * GitHub Actions sets CI=true, so install.sh uses this single-entry loading
+ * screen build instead of the unified Docker/dev build. Keep this list aligned
+ * with build.unified.mjs: the resurrection bundle needs enough UI/runtime code
+ * to hand off into a world, but parser packages, storage adapters, editor
+ * tooling, and build-time Rollup/Babel/SWC plugins should stay outside the
+ * initial browser bundle. Pulling those tools into the boot chunk reintroduced
+ * Node-only assumptions such as path.posix during the changed-package test
+ * world load.
+ */
+const loadingScreenExcludedModules = [
+  'mocha', 'chai', 'picomatch', // references old lgtg that breaks the build
+  'rollup', // has a dist file that cant be parsed by rollup
+  'eslint', 'pouchdb', 'pouchdb-adapter-mem',
+  'lively.git', 'lively.storage', 'libsodium', 'libsodium-wrappers',
+  'parse5', 'entities',
+  'markdown-it', 'markdown-it-checkbox', 'markdown-it-implicit-figures',
+  'markdown-it-html5-media', 'markdown-it-attrs', 'js-beautify',
+  'path-is-absolute', 'fs.realpath',
+  '@babel/core',
+  '@babel/code-frame',
+  '@babel/generator',
+  '@babel/helpers',
+  '@babel/highlight',
+  '@babel/parser',
+  '@babel/preset-env',
+  '@babel/plugin-syntax-import-meta',
+  '@babel/plugin-transform-modules-systemjs',
+  '@babel/helper-module-imports',
+  '@babel/template',
+  '@babel/traverse',
+  '@swc/core',
+  '@rollup/plugin-json',
+  '@rollup/plugin-commonjs',
+  'rollup-plugin-polyfill-node',
+  'esm://ga.jspm.io/npm:@rollup/plugin-commonjs',
+  'esm://ga.jspm.io/npm:@rollup/plugin-inject',
+  'esm://ga.jspm.io/npm:rollup-plugin-polyfill-node',
+  'babel-plugin-transform-es2015-modules-systemjs'
+];
+
 try {
   console.log('   Bundling loading-screen...');
 
+  /*
+   * Match the unified build's browser context. Rollup's default top-level
+   * `this` handling is too Node-like for resurrection chunks that execute in a
+   * page before the live module system has fully taken over.
+   */
   const build = await rollup({
+    context: 'globalThis',
     input: './src/loading-screen.cp.js',
     shimMissingExports: true,
     external: ['chai', 'mocha'],
@@ -27,23 +77,27 @@ try {
         sourceMap,
         minify,
         verbose,
-        useSwc: true,
+        /*
+         * Keep Babel as the reliable compatibility pass for CI's boot bundle.
+         * The SWC freezer path can still be tested separately, but the hosted
+         * runner uses this script to prove that a browser world can load before
+         * package tests run, so it should use the same conservative path as the
+         * already validated unified build.
+         */
         isResurrectionBuild: true,
         asBrowserModule: true,
-        excludedModules: [
-          'mocha', 'chai', 'picomatch', // references old lgtg that breaks the build
-          'path-is-absolute', 'fs.realpath', // has a dist file that cant be parsed by rollup
-          '@babel/preset-env',
-          '@babel/plugin-syntax-import-meta',
-          '@rollup/plugin-json',
-          '@rollup/plugin-commonjs',
-          '@swc/core',
-          'rollup-plugin-polyfill-node',
-          'babel-plugin-transform-es2015-modules-systemjs'
-        ],
+        excludedModules: loadingScreenExcludedModules,
         resolver
       }),
-      jsonPlugin({ exclude: [/https\:\/\/jspm.dev\/.*\.json/, /esm\:\/\/cache\/.*\.json/] })
+      jsonPlugin({ exclude: [/https\:\/\/jspm.dev\/.*\.json/, /esm\:\/\/cache\/.*\.json/] }),
+      babel({
+        babelHelpers: 'bundled',
+        presets: [
+          [PresetEnv, {
+            targets: '> 3%, not dead'
+          }]
+        ]
+      })
      ]
   });
 

--- a/lively.freezer/tools/build.unified.mjs
+++ b/lively.freezer/tools/build.unified.mjs
@@ -1,6 +1,8 @@
 /* global process */
 import { rollup } from '@rollup/wasm-node';
 import jsonPlugin from '@rollup/plugin-json';
+import { babel } from '@rollup/plugin-babel';
+import PresetEnv from '@babel/preset-env';
 import util from 'node:util';
 import { lively } from 'lively.freezer/src/plugins/rollup';
 import resolver from 'lively.freezer/src/resolvers/node.cjs';
@@ -9,16 +11,42 @@ const verbose = process.argv[2] === '--verbose';
 const minify = !process.env.CI;
 const sourceMap = !!process.env.DEBUG;
 
-// Combine excluded modules from both builds to ensure compatibility
+/*
+ * The unified resurrection bundle must load enough code to replace the loading
+ * screen with an editable world, but it does not need heavy editor tooling,
+ * storage adapters, parser packages, or build-time plugins in the boot bundle.
+ * Externalizing those packages keeps Rollup away from known Node-only edges and
+ * leaves them to the live package system after the world is running.
+ */
 const commonExcludedModules = [
   'chai', 'mocha', // references old lgtg that breaks the build
   'rollup', // has a dist file that cant be parsed by rollup
+  'eslint', 'pouchdb', 'pouchdb-adapter-mem',
+  'lively.git', 'lively.storage', 'libsodium', 'libsodium-wrappers',
+  'parse5', 'entities',
+  'markdown-it', 'markdown-it-checkbox', 'markdown-it-implicit-figures',
+  'markdown-it-html5-media', 'markdown-it-attrs', 'js-beautify',
   'picomatch', 'path-is-absolute', 'fs.realpath', // from loading-screen build
   // other stuff that is only needed by rollup
+  '@babel/core',
+  '@babel/code-frame',
+  '@babel/generator',
+  '@babel/helpers',
+  '@babel/highlight',
+  '@babel/parser',
+  '@babel/preset-env',
+  '@babel/plugin-syntax-import-meta',
+  '@babel/plugin-transform-modules-systemjs',
+  '@babel/helper-module-imports',
+  '@babel/template',
+  '@babel/traverse',
   '@swc/core',
   '@rollup/plugin-json',
   '@rollup/plugin-commonjs',
   'rollup-plugin-polyfill-node',
+  'esm://ga.jspm.io/npm:@rollup/plugin-commonjs',
+  'esm://ga.jspm.io/npm:@rollup/plugin-inject',
+  'esm://ga.jspm.io/npm:rollup-plugin-polyfill-node',
   'babel-plugin-transform-es2015-modules-systemjs'
 ];
 
@@ -38,9 +66,13 @@ const commonPlugins = [
 try {
   console.log('   Bundling landing-page + loading-screen...');
 
-  // Single rollup build with multiple entry points
-  // Rollup will automatically share module parsing, transformation, and resolution
+  /*
+   * Build both entry points in one Rollup graph so shared modules are parsed and
+   * emitted once. The global context matches the browser runtime, where top-level
+   * `this` must resolve to the page global instead of being undefined.
+   */
   const build = await rollup({
+    context: 'globalThis',
     input: {
       'landing-page': './src/landing-page.cp.js',
       'loading-screen': './src/loading-screen.cp.js'
@@ -55,13 +87,25 @@ try {
         minify,
         verbose,
         sourceMap,
-        useSwc: true,
         isResurrectionBuild: true,
         asBrowserModule: true,
         excludedModules: commonExcludedModules,
         resolver
       }),
-      ...commonPlugins
+      ...commonPlugins,
+      /*
+       * Keep Babel as the final browser compatibility pass for this boot bundle.
+       * The SWC path can be revisited separately, but Babel has the known-good
+       * behavior for the resurrection build and avoids boot-only regressions.
+       */
+      babel({
+        babelHelpers: 'bundled',
+        presets: [
+          [PresetEnv, {
+            targets: '> 3%, not dead'
+          }]
+        ]
+      })
     ]
   });
 

--- a/lively.installer/install.js
+++ b/lively.installer/install.js
@@ -1,9 +1,26 @@
 /*global process,System,global*/
 import { buildPackageMap, installDependenciesOfPackage, buildPackage, resetPackageMap } from "flatn";
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
 import { exec } from "./shell-exec.js";
 import { Package } from "./package.js";
 import { resource } from 'lively.resources';
 import { promise, string } from 'lively.lang';
+
+const require = createRequire(import.meta.url);
+const resetResolverPackageMap = require('../flatn/flatn-cjs.js').resetPackageMap;
+const { flatnResolve } = require('../flatn/module-resolver.js');
+
+/**
+ * Imports a dependency through flatn after the package map has been rebuilt.
+ * @param {string} id - Package id to resolve from the freshly installed tree.
+ * @returns {Promise<object>} Module namespace returned by dynamic import().
+ */
+function importFlatnDependency (id) {
+  const resolved = flatnResolve(id, new URL(import.meta.url).pathname, 'node-import');
+  if (!resolved) throw new Error(`Unable to resolve installed dependency: ${id}`);
+  return import(pathToFileURL(resolved).href);
+}
 
 var modules, join, getPackageSpec, readPackageSpec;
 
@@ -268,7 +285,15 @@ export async function install(baseDir, dependenciesDir, verbose) {
     // by this time, all of the dependencies have been installed, and we can import them now
     const tInit = Date.now();
     spinner.start('Initializing module system...');
-    ({ default: global.System } = await import('systemjs'));
+    /*
+     * Fresh installs rebuild the dependency tree before SystemJS and the import
+     * map generator are imported. Reset both flatn package maps and resolve the
+     * follow-up imports through flatn explicitly so stale package-name cache
+     * entries cannot point at modules that did not exist at process start.
+     */
+    resetPackageMap();
+    resetResolverPackageMap();
+    ({ default: global.System } = await importFlatnDependency('systemjs'));
 
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     // System + ObjectDB init
@@ -335,7 +360,7 @@ export async function install(baseDir, dependenciesDir, verbose) {
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     if (step9_createImportMap) {
       const tMaps = Date.now();
-      const { Generator } = await import('@jspm/generator');
+      const { Generator } = await importFlatnDependency('@jspm/generator');
       System.set('@jspm_generator', System.newModule({ default: Generator }));
       const { generateImportMap } = await System.import('lively.server/plugins/lib-lookup.js');
       for (let p of packages) {
@@ -384,7 +409,7 @@ async function safelyRemove(baseDir, file) {
 }
 
 export async function setupSystem(baseURL) {
-  ({ default: global.babel } = await import("@babel/core"));
+  ({ default: global.babel } = await importFlatnDependency("@babel/core"));
   modules = await import("lively.modules");
   let livelySystem = modules.getSystem("lively", {baseURL, _nodeRequire: System._nodeRequire });
   modules.changeSystem(livelySystem, true);

--- a/lively.lang/worker.js
+++ b/lively.lang/worker.js
@@ -11,7 +11,16 @@ import { waitFor } from './function.js';
 import { create as messengerCreate } from './messenger.js';
 import Closure from './closure.js';
 
-let isNodejs = typeof require !== 'undefined' && typeof process !== 'undefined';
+/*
+ * Browser/freezer contexts can expose partial CommonJS-looking globals through
+ * bundler shims. Treat the environment as Node.js only when the real Node
+ * process object is present and no browser global is active.
+ */
+let isNodejs = typeof globalThis !== 'undefined' &&
+  typeof globalThis.window === 'undefined' &&
+  typeof globalThis.self === 'undefined' &&
+  typeof globalThis.require === 'function' &&
+  !!(globalThis.process && globalThis.process.versions && globalThis.process.versions.node);
 
 // ignore-in-doc
 // Code in worker setup is evaluated in the context of workers, it will get to

--- a/lively.morphic/morphicdb/db.js
+++ b/lively.morphic/morphicdb/db.js
@@ -25,6 +25,59 @@ const getDefaultServerUrl = () => resource(typeof document !== 'undefined'
   ? window.SERVER_URL || System.baseURL // the place that serves the modules is not nessecarily where the server sits at
   : 'http://localhost:9001').join('objectdb/').url;
 
+// Keep MorphicDB's browser boot path on the HTTP API without importing
+// lively.storage and its PouchDB dependency graph into freezer bundles.
+class MorphicDBHTTPInterface {
+  constructor (serverURL = document.location.origin + '/objectdb/') {
+    this.serverURL = serverURL;
+  }
+
+  async _processResponse (res) {
+    const contentType = res.headers.get('content-type');
+    const answer = await res.text(); let json;
+    if (contentType && contentType.includes('application/json')) {
+      try { json = JSON.parse(answer); } catch (err) {}
+    }
+    if (!res.ok || (json && json.error)) {
+      throw new Error((json && json.error) || answer || res.statusText);
+    }
+    return json || answer;
+  }
+
+  async _GET (action, opts = {}) {
+    const query = Object.keys(opts).map(key => {
+      let val = opts[key];
+      if (typeof val === 'object') val = JSON.stringify(val);
+      return `${key}=${encodeURIComponent(val)}`;
+    }).join('&');
+    return this._processResponse(await fetch(this.serverURL + action + '?' + query));
+  }
+
+  async _POST (action, opts = {}) {
+    return this._processResponse(await fetch(this.serverURL + action, {
+      method: 'POST',
+      body: JSON.stringify(opts),
+      headers: { 'content-type': 'application/json' }
+    }));
+  }
+
+  ensureDB (args) { return this._POST('ensureDB', args); }
+  destroyDB (args) { return this._POST('destroyDB', args); }
+  fetchCommits (args) { return this._GET('fetchCommits', args); }
+  fetchVersionGraph (args) { return this._GET('fetchVersionGraph', args); }
+  exists (args) { return this._GET('exists', args); }
+  fetchLog (args) { return this._GET('fetchLog', args); }
+  fetchSnapshot (args) { return this._GET('fetchSnapshot', args); }
+  revert (args) { return this._POST('revert', args); }
+  commit (args) { return this._POST('commit', args); }
+  fetchConflicts (args) { return this._GET('fetchConflicts', args); }
+  resolveConflict (args) { return this._POST('resolveConflict', args); }
+  fetchDiff (args) { return this._GET('fetchDiff', args); }
+  synchronize (args) { return this._POST('synchronize', args); }
+  delete (args) { return this._POST('delete', args); }
+  deleteCommit (args) { return this._POST('deleteCommit', args); }
+}
+
 export function convertToSerializableCommit (commit) {
   if (commit) {
     commit.__serialize__ = () => {
@@ -104,8 +157,7 @@ export default class MorphicDB {
   }
 
   async ensureDB () {
-    const { ObjectDBHTTPInterface } = await System.import('lively.storage');
-    this.httpDB = new ObjectDBHTTPInterface(this.serverURL);
+    this.httpDB = new MorphicDBHTTPInterface(this.serverURL);
     const { name: db, snapshotLocation } = this;
     return this.httpDB.ensureDB({ db, snapshotLocation });
   }

--- a/lively.serializer2/index.js
+++ b/lively.serializer2/index.js
@@ -3,7 +3,6 @@ import { ObjectPool } from './object-pool.js';
 // import { version as serializerVersion } from './package.json';
 import { requiredModulesOfSnapshot, removeUnreachableObjects, clearDanglingConnections, removeEpiConnections } from './snapshot-navigation.js';
 import { allPlugins } from './plugins.js';
-import semver from 'semver';
 
 const serializerVersion = '0.1.3';
 
@@ -35,6 +34,42 @@ function runMigrations (migrations, method, idAndSnapshot, pool) {
 
 const majorAndMinorVersionRe = /\.[^\.]+$/; // x.y.z => x.y
 
+/**
+ * Splits a dotted version string into numeric comparison parts.
+ * @param {string|number} version - Version value such as "0.1.3".
+ * @returns {number[]} Numeric version components with invalid parts treated as 0.
+ */
+function numericVersionParts (version) {
+  return String(version).split('.').map(part => parseInt(part, 10) || 0);
+}
+
+/**
+ * Checks the serializer's small supported version range syntax.
+ * @param {string|number} version - Current serializer version.
+ * @param {string} range - Required range written as ">=x.y.z".
+ * @returns {boolean} True when the version satisfies the range, or when the range is unknown.
+ */
+function satisfiesRequiredVersion (version, range) {
+  /*
+   * Serializer snapshots currently write only a minimal ">=version" range.
+   * Keeping this comparator local avoids pulling the full semver package into
+   * browser/freezer boot while preserving the compatibility warning that this
+   * module needs during deserialization.
+   */
+  const match = String(range).match(/^>=\s*(.+)$/);
+  if (!match) return true;
+  const versionParts = numericVersionParts(version);
+  const requiredParts = numericVersionParts(match[1]);
+  const length = Math.max(versionParts.length, requiredParts.length);
+  for (let i = 0; i < length; i++) {
+    const current = versionParts[i] || 0;
+    const required = requiredParts[i] || 0;
+    if (current > required) return true;
+    if (current < required) return false;
+  }
+  return true;
+}
+
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 export { ObjectRef, ObjectPool } from './object-pool.js';
@@ -56,7 +91,7 @@ export function serialize (obj, options) {
 export function deserialize (idAndSnapshot, options) {
   options = normalizeOptions(options);
   const { requiredVersion } = idAndSnapshot;
-  if (requiredVersion && !semver.satisfies(serializerVersion, requiredVersion)) {
+  if (requiredVersion && !satisfiesRequiredVersion(serializerVersion, requiredVersion)) {
     console.warn('[lively.serializer deserialization] snapshot requires version ' +
                `${requiredVersion} but serializer has incompatible version ` +
                `${serializerVersion}. Deserialization might fail...!`);

--- a/lively.server/plugins/lib-lookup.js
+++ b/lively.server/plugins/lib-lookup.js
@@ -21,16 +21,36 @@ function isUnresolvableOnCDN ([name, version]) {
 
 /**
  * Extract the failing transitive package name + version from a jspm generator
- * error message.  Patterns we look for:
+ * error message when the package version itself is missing from the CDN.
+ * Do not treat subpath/export failures as missing packages; globally pinning a
+ * nearby version can break packages that intentionally use another major.
+ *
+ * Patterns we look for:
  *   "Unable to fetch https://ga.jspm.io/npm:<pkg>@<ver>/package.json"
  *   "Package <pkg>@<ver> not found on ..."
  */
 function extractFailingPackage (errMsg) {
-  const cdnMatch = errMsg.match(/ga\.jspm\.io\/npm:(@?[^@]+)@([^/]+)\//);
+  const cdnMatch = errMsg.match(/ga\.jspm\.io\/npm:(@?[^@]+)@([^/]+)\/package\.json/);
   if (cdnMatch) return { name: cdnMatch[1], version: cdnMatch[2] };
   const pkgMatch = errMsg.match(/Package\s+(@?[^\s@]+)@(\S+)/);
   if (pkgMatch) return { name: pkgMatch[1], version: pkgMatch[2] };
   return null;
+}
+
+function extractBuildFailingPackage (errMsg) {
+  const buildMatch = errMsg.match(/JSPM encountered an error building (@?[^\s@]+)@([^:]+):/);
+  if (buildMatch) return { name: buildMatch[1], version: buildMatch[2] };
+  return null;
+}
+
+function extractPackageConfigFailingPackage (errMsg) {
+  const configMatch = errMsg.match(/reading package config for https:\/\/ga\.jspm\.io\/npm:(@?[^@]+)@([^/]+)\//);
+  if (configMatch) return { name: configMatch[1], version: configMatch[2] };
+  return null;
+}
+
+function isExactVersionSpec (version) {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version);
 }
 
 /**
@@ -49,10 +69,18 @@ async function findAvailableCDNVersion (name, failingVersion) {
     versions = Object.keys(meta.versions || {});
   } catch { return null; }
 
-  const failIdx = versions.indexOf(failingVersion);
-  if (failIdx < 0) return null;
-  // Try up to 20 versions before the failing one (most recent first)
-  const candidates = versions.slice(Math.max(0, failIdx - 20), failIdx).reverse();
+  const failingSemver = parseStableSemver(failingVersion);
+  if (!failingSemver) return null;
+
+  const candidates = versions
+    .map(ver => ({ ver, semver: parseStableSemver(ver) }))
+    .filter(({ semver }) =>
+      semver &&
+      semver.major === failingSemver.major &&
+      compareStableSemver(semver, failingSemver) < 0)
+    .sort((a, b) => compareStableSemver(b.semver, a.semver))
+    .slice(0, 40)
+    .map(({ ver }) => ver);
 
   for (const ver of candidates) {
     try {
@@ -66,6 +94,20 @@ async function findAvailableCDNVersion (name, failingVersion) {
   return null;
 }
 
+function parseStableSemver (version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3])
+  };
+}
+
+function compareStableSemver (a, b) {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
 function createGenerator (inputMap, resolutions) {
   return new Generator({
     env: ["browser", "module", "import"],
@@ -73,6 +115,55 @@ function createGenerator (inputMap, resolutions) {
     inputMap,
     ...(Object.keys(resolutions).length ? { resolutions } : {})
   });
+}
+
+function delay (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isTransientInstallError (errMsg) {
+  return /Invalid status code (408|429|5\d\d)|Bad Gateway|Gateway Timeout|Service Unavailable/i.test(errMsg);
+}
+
+async function retryInstall (generator, depSpec, firstErr) {
+  let err = firstErr;
+  const transient = isTransientInstallError(firstErr.message || String(firstErr));
+  const attempts = transient ? 4 : 2;
+
+  for (let attempt = 2; attempt <= attempts; attempt++) {
+    const errMsg = err.message || String(err);
+    const waitMs = transient ? Math.min(1000 * Math.pow(2, attempt - 2), 5000) : 0;
+    console.warn(`\x1b[33m       [!] Import map: attempt ${attempt - 1} failed for ${depSpec}: ${errMsg}, retrying${waitMs ? ` in ${waitMs / 1000}s` : ''}...\x1b[0m`);
+    if (waitMs) await delay(waitMs);
+    try {
+      await generator.install(depSpec);
+      return true;
+    } catch (retryErr) {
+      err = retryErr;
+    }
+  }
+
+  console.warn('\x1b[33m       [!] Import map: failed to resolve ' + depSpec + ': ' + (err.message || err) + '\x1b[0m');
+  return false;
+}
+
+function addMarkdownItEntitiesCompat (inputMap, deps) {
+  const markdownItDep = deps.find(([dep]) => dep === 'markdown-it');
+  if (!markdownItDep) return inputMap;
+
+  const version = markdownItDep[1];
+  if (!/^\d+\.\d+\.\d+$/.test(version)) return inputMap;
+
+  inputMap ||= {};
+  inputMap.scopes ||= {};
+
+  // markdown-it 12 imports a legacy entities JSON subpath. Newer entities
+  // versions expose ESM paths for other packages, so keep this override scoped.
+  const scope = `https://ga.jspm.io/npm:markdown-it@${version}/`;
+  inputMap.scopes[scope] ||= {};
+  inputMap.scopes[scope]['entities/lib/maps/entities.json'] ||= 'https://ga.jspm.io/npm:entities@2.1.0/lib/maps/entities.json.js';
+
+  return inputMap;
 }
 
 async function installDeps (generator, deps, failed, resolutions, inputMap) {
@@ -89,9 +180,12 @@ async function installDeps (generator, deps, failed, resolutions, inputMap) {
       continue;
     } catch (firstErr) {
       const errMsg = firstErr.message || String(firstErr);
-      const failingPkg = extractFailingPackage(errMsg);
+      const failingPkg =
+        extractFailingPackage(errMsg) ||
+        extractBuildFailingPackage(errMsg) ||
+        (!isExactVersionSpec(dep[1]) && extractPackageConfigFailingPackage(errMsg));
       if (failingPkg && !resolutions[failingPkg.name]) {
-        console.warn(`\x1b[33m       [!] Import map: ${depSpec} failed — transitive dep ${failingPkg.name}@${failingPkg.version} not on CDN, searching for available version...\x1b[0m`);
+        console.warn(`\x1b[33m       [!] Import map: ${depSpec} failed — transitive dep ${failingPkg.name}@${failingPkg.version} is not usable on CDN, searching for available version...\x1b[0m`);
         const goodVersion = await findAvailableCDNVersion(failingPkg.name, failingPkg.version);
         if (goodVersion) {
           console.log(`\x1b[32m       [✓] Found ${failingPkg.name}@${goodVersion} on CDN, pinning via resolutions\x1b[0m`);
@@ -101,16 +195,12 @@ async function installDeps (generator, deps, failed, resolutions, inputMap) {
         } else {
           console.warn(`\x1b[33m       [!] Import map: no available CDN version found for ${failingPkg.name}\x1b[0m`);
         }
-      } else if (!failingPkg) {
-        // Non-CDN-404 error — retry once
-        console.warn('\x1b[33m       [!] Import map: first attempt failed for ' + depSpec + ': ' + errMsg + ', retrying...\x1b[0m');
-        try {
-          await generator.install(depSpec);
-          delete failed[depName];
-          continue;
-        } catch (retryErr) {
-          console.warn('\x1b[33m       [!] Import map: failed to resolve ' + depSpec + ': ' + (retryErr.message || retryErr) + '\x1b[0m');
-        }
+      } else if (failingPkg) {
+        needsRestart = true;
+        continue;
+      } else if (await retryInstall(generator, depSpec, firstErr)) {
+        delete failed[depName];
+        continue;
       }
       failed[depName] = true;
     }
@@ -130,8 +220,8 @@ async function installDeps (generator, deps, failed, resolutions, inputMap) {
         await generator.install(depSpec);
         delete failed[depName];
       } catch (err) {
-        console.warn('\x1b[33m       [!] Import map: failed to resolve ' + depSpec + ': ' + (err.message || err) + '\x1b[0m');
-        failed[depName] = true;
+        if (await retryInstall(generator, depSpec, err)) delete failed[depName];
+        else failed[depName] = true;
       }
     }
   }
@@ -149,16 +239,18 @@ export async function generateImportMap (packageName) {
   const packageRegistry = System.get("@lively-env").packageRegistry;
   const pkg = packageName && packageRegistry.lookup(packageName);
   if (!pkg) return {};
+  const deps = Object.entries(pkg.config.dependencies || {}).filter(([dep]) => !dep.match(/lively(\.|-)/));
   const cachedImportMap = resource(pkg.url).join('.cachedImportMap.json');
   if (await cachedImportMap.exists()) {
     inputMap = JSON.parse((await cachedImportMap.read()).replace(/esm:\/\//g, 'https://')); // replace esm to make generator install again
   }
+  inputMap = addMarkdownItEntitiesCompat(inputMap, deps);
   const resolutions = {};
   let generator = createGenerator(inputMap, resolutions);
   const failed = inputMap?._failed || {};
   generator = await installDeps(
     generator,
-    Object.entries(pkg.config.dependencies || {}).filter(([dep]) => !dep.match(/lively(\.|-)/)),
+    deps,
     failed,
     resolutions,
     inputMap

--- a/scripts/check_boot.js
+++ b/scripts/check_boot.js
@@ -1,35 +1,222 @@
 const puppeteer = require('puppeteer');
 
-const aliveTimeout = 300 * 1000;
-const aliveRepeatTimeout = 300;
-let page;
+const url = process.argv[2] || 'http://localhost:9011/worlds/load?name=__newWorld__&askForWorldName=false&fastLoad=true';
+const timeoutMs = Number(process.argv[3] || process.env.LIVELY_BOOT_TIMEOUT || 60000);
+const isLoadRoute = /\/(?:worlds|projects)\/load/.test(url);
+const requireWorld = process.argv.includes('--require-world') || isLoadRoute;
+const proveEdit = process.argv.includes('--prove-edit') || requireWorld;
+const pollMs = 500;
 
+/**
+ * Determines whether a Puppeteer request is part of the boot-critical page or
+ * bundle surface.
+ * @param {import('puppeteer').HTTPRequest} request - Request observed by the page.
+ * @returns {boolean} True when a failed request should be included in diagnostics.
+ */
+function isBundleResource (request) {
+  const type = request.resourceType();
+  return ['document', 'script', 'stylesheet', 'xhr', 'fetch'].includes(type);
+}
+
+/**
+ * Classifies failed requests that should stop the boot proof immediately.
+ * @param {{type: string, failure: string}} entry - Normalized failed request record.
+ * @returns {boolean} True when the failure likely blocks the page from booting.
+ */
+function isFatalFailedRequest (entry) {
+  /*
+   * During world/project transitions the browser can cancel in-flight fetches
+   * from the loading screen once the new world takes over. Those aborted
+   * background fetches are useful diagnostics, but treating them as fatal makes
+   * a healthy transition look broken.
+   */
+  if (entry.failure === 'net::ERR_ABORTED' && ['xhr', 'fetch'].includes(entry.type)) return false;
+  return true;
+}
+
+/**
+ * Reads the current browser-side boot state in one serialized page evaluation.
+ * @param {import('puppeteer').Page} page - Puppeteer page under test.
+ * @returns {Promise<object>} Snapshot of DOM visibility, world state, and load errors.
+ */
+async function pageState (page) {
+  return page.evaluate(() => {
+    const hasWorld = typeof globalThis.$world !== 'undefined' && !!globalThis.$world;
+    const hasLoadingScreen = hasWorld &&
+      typeof globalThis.$world.get === 'function' &&
+      !!globalThis.$world.get('loading screen');
+    const loadError = globalThis.__loadError__;
+    const visibleContent = !!document.body && Array.from(document.body.children).some(el => {
+      const style = globalThis.getComputedStyle(el);
+      return style.visibility !== 'hidden' &&
+        style.display !== 'none' &&
+        el.getBoundingClientRect().width > 0 &&
+        el.getBoundingClientRect().height > 0;
+    });
+    let morphCount = null;
+    if (hasWorld && globalThis.$world.withAllSubmorphsDo) {
+      morphCount = 0;
+      globalThis.$world.withAllSubmorphsDo(() => morphCount++);
+    }
+    return {
+      href: location.href,
+      title: document.title,
+      bodyText: document.body && document.body.innerText && document.body.innerText.slice(0, 300),
+      visibleContent,
+      hasWorld,
+      hasLoadingScreen,
+      worldName: hasWorld && globalThis.$world.name,
+      morphCount,
+      loadError: loadError && (loadError.stack || loadError.message || String(loadError)),
+      livelyKeys: Object.keys(globalThis.lively || {}).slice(0, 40)
+    };
+  });
+}
+
+/**
+ * Proves the loaded world is editable by adding and updating a label morph.
+ * @param {import('puppeteer').Page} page - Puppeteer page with a completed world load.
+ * @returns {Promise<object>} Counts and ownership/value checks for the inserted morph.
+ */
+async function runEditProof (page) {
+  return page.evaluate(async () => {
+    if (!globalThis.$world) throw new Error('No world is available for edit proof');
+    if (typeof globalThis.$world.get === 'function' && globalThis.$world.get('loading screen')) {
+      throw new Error('World transition did not complete before edit proof');
+    }
+    /**
+     * Looks up exports from either the freezer runtime or the live SystemJS
+     * registry after the loading screen has transitioned into the real world.
+     * @param {string} packageName - Package id, such as "lively.morphic".
+     * @returns {object} Loaded module exports for the requested package.
+     */
+    const loadedPackage = packageName => {
+      const rootURL = globalThis.SYSTEM_BASE_URL || location.origin;
+      const baseURL = rootURL.endsWith('/') ? rootURL : `${rootURL}/`;
+      const decanonicalized = System.decanonicalize(packageName);
+      const candidates = [
+        packageName,
+        `${packageName}/index.js`,
+        decanonicalized,
+        new URL(decanonicalized, baseURL).href
+      ];
+      for (const moduleId of candidates) {
+        const frozenExports = globalThis.lively &&
+          globalThis.lively.FreezerRuntime &&
+          globalThis.lively.FreezerRuntime.exportsOf(moduleId);
+        if (frozenExports && Object.keys(frozenExports).length) return frozenExports;
+        const registeredExports = System.get && System.get(moduleId);
+        if (registeredExports && Object.keys(registeredExports).length) return registeredExports;
+      }
+      throw new Error(`No loaded exports found for ${packageName}`);
+    };
+    const { morph } = loadedPackage('lively.morphic');
+    const { pt } = loadedPackage('lively.graphics');
+    const before = globalThis.$world.submorphs.length;
+    const label = morph({
+      type: 'label',
+      name: 'docker compose edit proof',
+      value: 'boot proof',
+      position: pt(40, 40)
+    });
+    globalThis.$world.addMorph(label);
+    label.value = 'boot proof updated';
+    if (label.whenRendered) {
+      try { await label.whenRendered(); } catch (err) {}
+    }
+    return {
+      before,
+      after: globalThis.$world.submorphs.length,
+      added: label.world && label.world() === globalThis.$world,
+      value: Array.isArray(label.value) ? label.value[0] : label.value,
+      ownerName: label.owner && label.owner.name
+    };
+  });
+}
+
+/**
+ * Runs the browser boot proof as a command-line program.
+ * @returns {Promise<void>} Resolves after diagnostics are printed and the process exits.
+ */
 (async () => {
   const browser = await puppeteer.launch({
-    headless: 'new', 
-    args: [
-      '--no-sandbox',
-    ]
+    headless: 'new',
+    args: ['--no-sandbox']
   });
-  page = await browser.newPage();
+  const page = await browser.newPage();
+  const diagnostics = {
+    url,
+    status: null,
+    pageErrors: [],
+    failedRequests: [],
+    httpFailures: [],
+    consoleErrors: [],
+    consoleWarnings: [],
+    state: null,
+    editProof: null
+  };
 
+  page.on('pageerror', err => diagnostics.pageErrors.push(err.stack || err.message));
+  page.on('requestfailed', request => {
+    if (!isBundleResource(request)) return;
+    diagnostics.failedRequests.push({
+      url: request.url(),
+      type: request.resourceType(),
+      failure: request.failure() && request.failure().errorText
+    });
+  });
+  page.on('response', response => {
+    const request = response.request();
+    if (response.status() < 400 || !isBundleResource(request)) return;
+    diagnostics.httpFailures.push({
+      url: response.url(),
+      status: response.status(),
+      type: request.resourceType()
+    });
+  });
+  page.on('console', msg => {
+    const entry = { type: msg.type(), text: msg.text() };
+    if (msg.type() === 'error') diagnostics.consoleErrors.push(entry);
+    if (msg.type() === 'warning' || msg.type() === 'warn') diagnostics.consoleWarnings.push(entry);
+  });
+
+  let success = false;
   try {
-    console.log('ℹ️ Began Loading lively.');
-    await page.goto('http://localhost:9011/worlds/load?name=__newWorld__&askForWorldName=false&fastLoad=true');
-    const startTime = Date.now();
-    while (true) {
-      if (Date.now() - startTime > aliveTimeout) {
-        process.exit(1);
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+    diagnostics.status = response && response.status();
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      diagnostics.state = await pageState(page);
+      const fatal = diagnostics.pageErrors.length ||
+        diagnostics.failedRequests.some(isFatalFailedRequest) ||
+        diagnostics.httpFailures.length ||
+        diagnostics.consoleErrors.length ||
+        diagnostics.state.loadError;
+      if (fatal) break;
+      const worldReady = diagnostics.state.hasWorld &&
+        (!isLoadRoute || !diagnostics.state.hasLoadingScreen);
+      if (requireWorld ? worldReady : diagnostics.state.visibleContent) {
+        success = true;
+        break;
       }
-      if (await page.evaluate(`typeof $world !== 'undefined' && $world.name == 'lively.next'`)) break;
-      await new Promise((resolve) => setTimeout(resolve, aliveRepeatTimeout));
-    };
-    console.log('✅ Lively loaded successfully.');
-    process.exit(0);
-  } catch (err) {
-    console.log(err);
-    console.log('❌ Error loading lively.');
-    process.exit(1);
-  }
-})();
+      await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
 
+    if (success && proveEdit) {
+      diagnostics.editProof = await runEditProof(page);
+      success = diagnostics.editProof.added &&
+        diagnostics.editProof.value === 'boot proof updated' &&
+        diagnostics.editProof.after > diagnostics.editProof.before;
+      diagnostics.state = await pageState(page);
+    }
+  } catch (err) {
+    diagnostics.pageErrors.push(err.stack || err.message || String(err));
+    success = false;
+  } finally {
+    await browser.close();
+  }
+
+  diagnostics.success = success;
+  console.log(JSON.stringify(diagnostics, null, 2));
+  process.exit(success ? 0 : 1);
+})();

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 cd /workspace
 
-# Keep generated dependency and cache directories in the bind-mounted checkout.
-# This makes first-run work visible and reusable from the host while still
-# allowing the image to provide all runtime tools.
+# Ensure the generated dependency/cache paths exist inside the container. Under
+# Compose, these paths are Docker-owned named volumes layered over the source
+# bind mount, so their platform-specific contents stay separate from any native
+# install that uses the same checkout.
 mkdir -p \
   .puppeteer-browser-cache \
   custom-npm-modules \
@@ -48,9 +49,9 @@ has_entries() {
 # Args: None.
 # Returns: 0 when install artifacts are missing, 1 when startup can skip install.
 needs_install() {
-  # The install writes into host-visible ignored directories. Checking for the
+  # The install writes into Docker-owned ignored directories. Checking for the
   # dependency tree, class runtime, and freezer bundle keeps later container
-  # starts fast without hiding broken or incomplete first-run state.
+  # starts fast without mixing Docker artifacts with native install artifacts.
   if ! has_entries lively.next-node_modules; then
     return 0
   fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace
+
+# Keep generated dependency and cache directories in the bind-mounted checkout.
+# This makes first-run work visible and reusable from the host while still
+# allowing the image to provide all runtime tools.
+mkdir -p \
+  .puppeteer-browser-cache \
+  custom-npm-modules \
+  esm_cache \
+  lively.next-node_modules \
+  local_projects \
+  snapshots \
+  tmp
+
+# Purpose: Seed a generated file from the repository default when it is absent.
+# Args: $1 default source path, $2 target path in the bind-mounted checkout.
+# Returns: 0 after copying or intentionally leaving the existing target alone.
+seed_file() {
+  local source="$1"
+  local target="$2"
+
+  if [ ! -e "$target" ] && [ -e "$source" ]; then
+    cp "$source" "$target"
+  fi
+}
+
+# Purpose: Ensure the server has the baseline config/assets expected by boot.
+# Args: None.
+# Returns: 0 after all seed files have been considered.
+seed_defaults() {
+  seed_file lively.installer/assets/config.js config.js
+  seed_file lively.installer/assets/localconfig.js localconfig.js
+  seed_file lively.morphic/assets/favicon.ico favicon.ico
+}
+
+# Purpose: Check whether a directory exists and contains at least one entry.
+# Args: $1 directory path.
+# Returns: 0 when the directory is non-empty, 1 otherwise.
+has_entries() {
+  local dir="$1"
+  [ -d "$dir" ] && [ -n "$(find "$dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]
+}
+
+# Purpose: Decide whether the mounted checkout still needs the project install.
+# Args: None.
+# Returns: 0 when install artifacts are missing, 1 when startup can skip install.
+needs_install() {
+  # The install writes into host-visible ignored directories. Checking for the
+  # dependency tree, class runtime, and freezer bundle keeps later container
+  # starts fast without hiding broken or incomplete first-run state.
+  if ! has_entries lively.next-node_modules; then
+    return 0
+  fi
+
+  if [ ! -f lively.classes/build/runtime.js ]; then
+    return 0
+  fi
+
+  if [ ! -d lively.freezer/loading-screen ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+seed_defaults
+
+if needs_install; then
+  echo "Installing lively.next dependencies and generated artifacts..."
+  bash ./install.sh
+else
+  echo "Install artifacts found; skipping install."
+fi
+
+# Install can create or overwrite supporting assets, so seed once more before
+# starting the server to make a fresh bind mount and a reused bind mount behave
+# the same way.
+seed_defaults
+
+exec bash ./start-server.sh 9011


### PR DESCRIPTION
## Summary

- Add a one-service Docker Compose development runtime based on Ubuntu 24.04.
- Install the host toolchain inside the image, including Node 24, Bun, Rust with `wasm32-wasip1`, Python tooling, browser libraries, fonts, and common CLI tools.
- Bind-mount the checkout into `/workspace` so source edits remain visible on the host, while Docker-generated directory state is isolated in named volumes.
- Seed default runtime files, run the existing install flow on first boot, and skip install on later boots when expected artifacts already exist.
- Harden freezer/browser boot paths found during end-to-end validation, including project-load diagnostics, browser-safe dependency handling, and linter loading.

## End-to-end Docker Compose guide

This path is optional. It is a local development launcher for hosts with Docker and Compose support installed, but without the native Node/Bun/Rust/Python/browser dependency stack. It does not replace the native install and run-server workflow.

1. Check out this branch and start from the repository root.

```bash
git checkout docker-compose-setup
docker compose up --build
```

2. Wait for the first-run install to finish. The first boot can take several minutes because the container runs the repository install flow and builds generated artifacts.

3. Open the running system from the host.

```text
http://localhost:9011/dashboard/
```

The service binds only to `127.0.0.1:9011`, so it is meant for local development rather than public deployment.

4. Work against the bind-mounted checkout.

```bash
docker compose exec lively bash
cd /workspace
```

Source edits made from inside the container are edits to the host checkout.

5. Treat Docker state as separate from native state.

Dependency, database, cache, and build directory contents are stored in Docker named volumes layered over the generated paths inside `/workspace`. Docker may leave empty mount-point directories in the host checkout, but the Linux container artifacts inside those paths are not shared with native installs.

Later container starts reuse those named volumes and skip install when the expected dependency tree, class runtime, and freezer bundle are present.

6. Stop the stack without deleting Docker-generated state.

```bash
docker compose down
```

7. Remove Docker-generated state and force the next Compose start to behave like a fresh Docker install.

```bash
docker compose down -v
```

For a truly fresh validation run, use a fresh clone/worktree of the branch and run `docker compose up --build` there. That avoids mixing existing generated artifacts with the first-run path being tested.

## Debugging and boot checks

The container includes the runtime dependencies needed to run the browser boot proof from inside the service. Because this repository uses the flat dependency layout, run the proof through the project environment setup.

Dashboard check:

```bash
docker compose exec -T lively bash -lc 'cd /workspace && . scripts/lively-next-env.sh && lively_next_env /workspace && node --no-warnings --experimental-import-meta-resolve --experimental-loader ./flatn/resolver.mjs ./scripts/check_boot.js http://127.0.0.1:9011/dashboard/ 60000'
```

World-load and edit proof:

```bash
docker compose exec -T lively bash -lc 'cd /workspace && . scripts/lively-next-env.sh && lively_next_env /workspace && url="http://127.0.0.1:9011/worlds/load?name=__newWorld__&askForWorldName=false&fastLoad=true" && node --no-warnings --experimental-import-meta-resolve --experimental-loader ./flatn/resolver.mjs ./scripts/check_boot.js "$url" 120000 --require-world --prove-edit'
```

The boot proof prints structured JSON with the requested URL, HTTP status, failed requests, HTTP failures, page errors, console errors/warnings, current `$world` state, and edit proof details. It fails fast on page errors, failed boot-critical JS/CSS/document requests, HTTP failures, console errors, or a captured world-transition error. It treats aborted XHR/fetch requests during world transitions as non-fatal because those can be normal when the loading screen hands off to the real world.

The edit proof loads `lively.morphic` and `lively.graphics`, adds a label morph to `$world`, updates its value, and verifies that the morph is owned by the world with the updated value. Load routes are not considered ready while the loading-screen morph is still present.

## What changed for debugging reliability

- `scripts/check_boot.js` now reports structured diagnostics and distinguishes dashboard visibility checks from world/project load readiness.
- `lively.freezer/src/util/bootstrap.js` records transition failures on `window.__loadError__` so the headless check can report the actual boot error instead of timing out on a blank/loading page.
- The JS linter install is now opt-in through `?installLinter=true` and loaded dynamically, so editor tooling dependencies do not block normal world/project boot.
- The unified freezer build uses `globalThis` as the Rollup context, keeps Babel as the final browser compatibility pass, and externalizes boot-irrelevant tooling/storage/parser packages that should not be part of the initial browser bundle.
- Browser bundling now lets Node built-ins fall through to browser polyfills, honors package browser remaps, provides a minimal `process.env` shim, and makes Rollup's missing-export shim callable for externalized boot modules.
- Fresh installs reset flatn package maps before importing newly installed dependencies such as `systemjs`, `@jspm/generator`, and `@babel/core`.
- Smaller compatibility fixes keep browser boot from being misclassified as Node, avoid a browser-breaking `semver` import in serializer checks, normalize Acorn's namespace/default wrapper shape, and tolerate an externalized `kld-intersections` module during startup.

## Verification

- `make hooks` attempted; Windows make resolved `pwd` incorrectly, so `core.hooksPath` was repaired to the repo `.githooks` path directly.
- `node --check` on changed JavaScript files.
- `bash -n install.sh`.
- `bash -n scripts/docker-entrypoint.sh`.
- `git diff --check upstream/main...HEAD`.
- `docker compose config`.
- Fresh disposable Docker Compose run from empty volumes.
- Dashboard boot proof through the container boot harness.
- World-load edit proof through the container boot harness.
- Named-volume state isolation check: generated directory contents were present inside Docker volumes while host mount-point directories stayed empty.
- GitHub `Check PR for merging` passed on the latest head.

## Notes

- Docker Compose is optional and separate from the native run-server path.
- The server is bound to `127.0.0.1:9011` for local development.
- Docker dependency/cache/database/build directory contents live in named volumes so they do not share platform-specific state with native installs.
- Project creation currently reaches the login/auth boundary; auth provisioning is intentionally left for a follow-up.