### PR TITLE
[codex] Pin Rust for SWC plugin builds

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: wasm32-wasip1
       - name: Install `sultan`

--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: wasm32-wasip1
       - name: Checkout repository

--- a/lively.freezer/swc-plugin/rust-toolchain.toml
+++ b/lively.freezer/swc-plugin/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# Updated to use stable for newer swc versions
-channel = "stable"
+# Pinned until the SWC plugin handles Rust 1.96+ Wasm linker changes.
+channel = "1.95.0"
 targets = [ "wasm32-wasip1", "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Pins the Rust toolchain used by the SWC plugin build to `1.95.0` in both CI workflows and `lively.freezer/swc-plugin/rust-toolchain.toml`.

## Root Cause

The daily check started failing after Rust stable advanced from `1.95.0` to `1.96.0` on May 28, 2026. The SWC plugin build leaves host-provided SWC symbols unresolved for the Wasm plugin runtime, and Rust `1.96.0` now rejects those undefined symbols during `rust-lld` linking.

Pinning restores the last known-good toolchain without adding `--allow-undefined`, which would broaden linker acceptance for this build.

## Validation

- Confirmed `dtolnay/rust-toolchain` has a `1.95.0` ref.
- Ran `git diff --check`.
- Ran `cargo build --release --target wasm32-wasip1 -p lively-swc-plugin` under `rustc 1.95.0` successfully.
