### PR TITLE
Preserve resolver metadata in package registry cache

### DIFF
--- a/lively.modules/src/packages/package.js
+++ b/lively.modules/src/packages/package.js
@@ -142,7 +142,12 @@ class Package {
     this.version = config.version;
     this.dependencies = config.dependencies || {};
     this.devDependencies = config.devDependencies || {};
+    this.optionalDependencies = config.optionalDependencies;
+    this.peerDependencies = config.peerDependencies;
+    this.peerDependenciesMeta = config.peerDependenciesMeta;
     this.main = config.main;
+    this.exports = config.exports;
+    this.imports = config.imports;
     this.systemjs = config.systemjs;
     this.lively = config.lively;
     this.author = config.author;
@@ -159,7 +164,12 @@ class Package {
       'map',
       'dependencies',
       'devDependencies',
+      'optionalDependencies',
+      'peerDependencies',
+      'peerDependenciesMeta',
       'main',
+      'exports',
+      'imports',
       'systemjs',
       'lively',
       'author',
@@ -179,6 +189,11 @@ class Package {
     this.main = jso.main;
     this.dependencies = jso.dependencies || {};
     this.devDependencies = jso.devDependencies || {};
+    this.optionalDependencies = jso.optionalDependencies;
+    this.peerDependencies = jso.peerDependencies;
+    this.peerDependenciesMeta = jso.peerDependenciesMeta;
+    this.exports = jso.exports;
+    this.imports = jso.imports;
     this.systemjs = jso.systemjs;
     this.description = jso.description;
     this.author = jso.author;
@@ -230,7 +245,10 @@ class Package {
       version,
       dependencies,
       devDependencies,
-      main, systemjs, lively
+      optionalDependencies,
+      peerDependencies,
+      peerDependenciesMeta,
+      main, exports, imports, systemjs, lively
     } = this;
     let config = {
       name: name,
@@ -239,6 +257,11 @@ class Package {
       devDependencies: devDependencies || {}
     };
     if (main) config.main = main;
+    if (optionalDependencies) config.optionalDependencies = optionalDependencies;
+    if (peerDependencies) config.peerDependencies = peerDependencies;
+    if (peerDependenciesMeta) config.peerDependenciesMeta = peerDependenciesMeta;
+    if (exports) config.exports = exports;
+    if (imports) config.imports = imports;
     if (systemjs) config.systemjs = systemjs;
     if (lively) config.lively = lively;
     return config;

--- a/lively.modules/tests/package-test.js
+++ b/lively.modules/tests/package-test.js
@@ -7,7 +7,7 @@ import { arr } from 'lively.lang';
 import { resource, createFiles } from 'lively.resources';
 import module from '../src/module.js';
 import { getSystem, removeSystem } from '../src/system.js';
-import { getPackage, ensurePackage, applyConfig, getPackageSpecs } from '../src/packages/package.js';
+import { getPackage, ensurePackage, applyConfig, getPackageSpecs, Package } from '../src/packages/package.js';
 import { PackageRegistry } from '../src/packages/package-registry.js';
 
 let testDir = System.decanonicalize('lively.modules/tests/package-tests-temp/');
@@ -161,6 +161,47 @@ describe('package loading', function () {
       registry.resetByURL();
 
       expect(await S.normalize('ws', encodedParent)).equals(ws.url + '/index.js');
+    });
+
+
+    it('preserves package metadata needed for cached resolver lookups', async () => {
+      if (!System.get('@system-env').node) return;
+      const registry = PackageRegistry.ofSystem(S);
+      const engineURL = 'file:///Users/robin.schreiber/Library/Application Support/lively.next/runtime-root/lively.next-node_modules/engine.io/6.6.8';
+      const wsURL = 'file:///Users/robin.schreiber/Library/Application Support/lively.next/runtime-root/lively.next-node_modules/ws/8.20.1';
+      const engine = new Package(S, engineURL, null, null, {
+        name: 'engine.io',
+        version: '6.6.8',
+        dependencies: { ws: '~8.20.1' }
+      });
+      const ws = new Package(S, wsURL, null, null, {
+        name: 'ws',
+        version: '8.20.1',
+        optionalDependencies: { bufferutil: '^4.0.1' },
+        peerDependenciesMeta: { 'utf-8-validate': { optional: true } },
+        exports: {
+          '.': {
+            browser: './browser.js',
+            import: './wrapper.mjs',
+            require: './index.js'
+          }
+        }
+      });
+      registry.packageMap = {
+        'engine.io': { latest: '6.6.8', versions: { '6.6.8': engine } },
+        ws: { latest: '8.20.1', versions: { '8.20.1': ws } }
+      };
+      registry.resetByURL();
+
+      const cached = registry.toJSON();
+      registry.packageMap = {};
+      registry.fromJSON(cached);
+
+      const encodedEngineParent = '/Users/robin.schreiber/Library/Application%20Support/lively.next/runtime-root/lively.next-node_modules/engine.io/6.6.8/build/server.js';
+      const encodedWsParent = '/Users/robin.schreiber/Library/Application%20Support/lively.next/runtime-root/lively.next-node_modules/ws/8.20.1/lib/buffer-util.js';
+      expect(await S.normalize('ws', encodedEngineParent)).equals(wsURL + '/index.js');
+      expect(await S.normalize('bufferutil', encodedWsParent)).equals('@empty');
+      expect(await S.normalize('utf-8-validate', encodedWsParent)).equals('@empty');
     });
 
     it('registers and loads a package', async () => {


### PR DESCRIPTION
## Summary
- Preserve package metadata that affects module resolution when serializing/deserializing the package registry cache.
- Round-trip optional dependency, optional peer metadata, imports, and exports fields so cached desktop starts can still map optional native ws addons to `@empty`.
- Add a regression test for the macOS `Application Support` cached-runtime path that triggered `bufferutil` resolution as a hard file lookup.

## Testing
- `git diff --check`
- Could not run `./scripts/test.sh lively.modules` in the Codex shell initially because `node` was not available on `PATH` there.