### PR TITLE
Fix daily docs coverage dependency conflict

### DIFF
--- a/.github/workflows/daily-ci-checks.yml
+++ b/.github/workflows/daily-ci-checks.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install `jsdoc` plugin for `eslint`
         run: npm install eslint-plugin-jsdoc
       - name: Install `eslint` parser for `babel`
-        run: npm install @babel/eslint-parser
+        run: npm install @babel/eslint-parser@7.29.7 # pin to Babel 7; Babel 8 requires eslint@9 or newer
       - name: Setup GitHub Action Summary
         run: |
           echo '' >> docs_output.md


### PR DESCRIPTION
## What changed

Pin `@babel/eslint-parser` to version 7.29.7 in the daily docs-coverage job.

## Why

The workflow pins ESLint 8 but installed the Babel ESLint parser without a version constraint. Since Babel parser 8 became the default release, npm resolves it with an ESLint 9/10 peer requirement and aborts with `ERESOLVE` before documentation linting starts.

This dependency conflict has made every scheduled daily run fail since June 17 even when the test job succeeds. The missing docs artifact also causes the downstream summary job to fail.

## Impact

The docs-coverage job can install its tooling and run again without migrating the repository's legacy ESLint configuration to ESLint 9.

## Validation

- Reproduced the workflow's three npm install commands in a clean archive of `main`
- Confirmed `@babel/eslint-parser@7.29.7`, `eslint@8.57.0`, and `eslint-plugin-jsdoc` install without peer conflicts
- Ran `npx eslint -c .eslintrc.js lively.*/*.js | grep '✖'` successfully
- Ran `git diff --check`
