### PR TITLE
🛠️: stabilize CDN loading, L2L reconnects, and installer failures

### DIFF
--- a/flatn/flatn-cjs.js
+++ b/flatn/flatn-cjs.js
@@ -14391,11 +14391,13 @@ const requestMap = {};
 
 class ESMResource extends Resource {
   static normalize (esmUrl) {
-    const id = esmUrl.replaceAll(/esm:\/\/([^\/]*)\//g, '');
+    const match = esmUrl.match(/^esm:\/\/([^\/]*)\/(.*)$/);
+    const domain = match?.[1];
+    const id = match?.[2] || esmUrl;
 
     let pathStructure = id.split('/').filter(Boolean);
 
-    // jspm servers both the entry point into a package as well as subcontent from package@version/
+    // ESM CDNs serve both the entry point into a package and package subcontent.
     // differentiate these cases by introducing an index.js which will automatically be served by systemJS
     if (pathStructure.length === 1 ||
         !pathStructure[pathStructure.length - 1].endsWith('+esm') &&
@@ -14421,6 +14423,9 @@ class ESMResource extends Resource {
       pathStructure[pathStructure.length - 1] = pathStructure[pathStructure.length - 1].replace('!cjs', '.cjs');
     }
 
+    // The provider is part of the cache identity. Different CDNs can use the
+    // same path for different transformed source.
+    if (domain) pathStructure.unshift(domain);
     return pathStructure;
   }
 
@@ -14434,7 +14439,7 @@ class ESMResource extends Resource {
     const id = this.url.replace(/esm:\/\/([^\/]*)\//g, '');
     const esmURL = this.getEsmURL();
 
-    let pathStructure = ESMResource.normalize(id);
+    let pathStructure = ESMResource.normalize(this.url);
 
     const [res, created] = await this.findOrCreatePathStructure(pathStructure);
 
@@ -14444,7 +14449,7 @@ class ESMResource extends Resource {
       module = await res.read();
     } else {
       module = await resource((esmURL + id)).read();
-      res.write(module);
+      await res.write(module);
     }
     return module;
   }
@@ -14650,8 +14655,29 @@ function x (cmd, opts = {}) {
         ? reject(new Error(`Command ${cmd} failed: ${code}\n${stdout}${stderr}`))
         : resolve(stdout));
     if (opts.verbose) {
-      p.stdout.pipe(process.stdout);
-      p.stderr.pipe(process.stderr);
+      const useProgress = process.stdout.isTTY &&
+        typeof globalThis.__flatnProgress === 'function';
+      if (!useProgress) {
+        p.stdout.pipe(process.stdout);
+        p.stderr.pipe(process.stderr);
+        return;
+      }
+
+      const report = (stream, reportLine) => {
+        let pending = '';
+        stream.setEncoding('utf8');
+        stream.on('data', chunk => {
+          const lines = `${pending}${chunk}`.split(/\r\n|\n|\r/);
+          pending = lines.pop() || '';
+          lines.filter(line => line.trim()).forEach(reportLine);
+        });
+        stream.on('end', () => {
+          if (pending.trim()) reportLine(pending);
+        });
+      };
+
+      report(p.stdout, line => globalThis.__flatnProgress(line));
+      report(p.stderr, line => console.error(line));
     }
   });
 }
@@ -15773,11 +15799,8 @@ function resolveImportMapping(name, mapping, context) {
 function equivalentImportMapScopesFor (url) {
   if (!url || typeof url !== 'string') return [];
   const urls = [url];
-  if (url.startsWith('https://ga.jspm.io/')) {
-    urls.push(url.replace('https://ga.jspm.io/', 'esm://ga.jspm.io/'));
-  } else if (url.startsWith('esm://ga.jspm.io/')) {
-    urls.push(url.replace('esm://ga.jspm.io/', 'https://ga.jspm.io/'));
-  }
+  if (url.startsWith('https://')) urls.push(url.replace(/^https:/, 'esm:'));
+  else if (url.startsWith('esm://')) urls.push(url.replace(/^esm:/, 'https:'));
   return urls;
 }
 

--- a/flatn/flatn-cjs.js
+++ b/flatn/flatn-cjs.js
@@ -14389,6 +14389,40 @@ var resourceExtension$1 = {
 
 const requestMap = {};
 
+function adaptEsmShExportsForJspmInterop (source, url) {
+  if (!url.startsWith('esm://esm.sh/')) return source;
+
+  source = source.replace(
+    /(\b[$A-Z_a-z][$\w]*)=([$A-Z_a-z][$\w]*)=>Object\.assign\(\{__esModule:true\},\2\)/g,
+    '$1=$2=>Object.create($2,{__esModule:{value:true}})'
+  );
+
+  return source.replace(
+    /export\s*\*\s*from\s*["']([^"']+)["'];?\s*export\s*\{\s*default\s*\}\s*from\s*["']\1["'];?/,
+    `import * as __livelyEsmShModule from "$1";
+export * from "$1";
+const __livelyEsmShDefault = __livelyEsmShModule.default;
+if (__livelyEsmShModule.__esModule && __livelyEsmShDefault &&
+    (typeof __livelyEsmShDefault === "object" || typeof __livelyEsmShDefault === "function")) {
+  for (const __livelyEsmShKey of Object.keys(__livelyEsmShModule)) {
+    if (!(__livelyEsmShKey in __livelyEsmShDefault)) {
+      Object.defineProperty(__livelyEsmShDefault, __livelyEsmShKey, {
+        enumerable: true,
+        get: () => __livelyEsmShModule[__livelyEsmShKey]
+      });
+    }
+  }
+  if (!("default" in __livelyEsmShDefault)) {
+    Object.defineProperty(__livelyEsmShDefault, "default", {
+      enumerable: true,
+      value: __livelyEsmShDefault
+    });
+  }
+}
+export { __livelyEsmShDefault as default };`
+  );
+}
+
 class ESMResource extends Resource {
   static normalize (esmUrl) {
     const match = esmUrl.match(/^esm:\/\/([^\/]*)\/(.*)$/);
@@ -14445,13 +14479,14 @@ class ESMResource extends Resource {
 
     if (!created) {
       let hit; let shortName = res.url.replace(this.getBaseURL(), '');
-      if (typeof lively !== 'undefined' && (hit = lively.memory_esm?.get(shortName))) return await hit.blob.text();
-      module = await res.read();
+      module = typeof lively !== 'undefined' && (hit = lively.memory_esm?.get(shortName))
+        ? await hit.blob.text()
+        : await res.read();
     } else {
       module = await resource((esmURL + id)).read();
       await res.write(module);
     }
-    return module;
+    return adaptEsmShExportsForJspmInterop(module, this.url);
   }
 
   getBaseURL () {

--- a/flatn/helpers.mjs
+++ b/flatn/helpers.mjs
@@ -46,11 +46,8 @@ export function resolveImportMapping(name, mapping, context) {
 function equivalentImportMapScopesFor (url) {
   if (!url || typeof url !== 'string') return [];
   const urls = [url];
-  if (url.startsWith('https://ga.jspm.io/')) {
-    urls.push(url.replace('https://ga.jspm.io/', 'esm://ga.jspm.io/'));
-  } else if (url.startsWith('esm://ga.jspm.io/')) {
-    urls.push(url.replace('esm://ga.jspm.io/', 'https://ga.jspm.io/'));
-  }
+  if (url.startsWith('https://')) urls.push(url.replace(/^https:/, 'esm:'));
+  else if (url.startsWith('esm://')) urls.push(url.replace(/^esm:/, 'https:'));
   return urls;
 }
 

--- a/flatn/module-resolver.js
+++ b/flatn/module-resolver.js
@@ -10,11 +10,8 @@ const moduleUrlToConfig = new Map();
 function equivalentModuleUrls (url) {
   if (!url || typeof url !== 'string') return [];
   const urls = [url];
-  if (url.startsWith('https://ga.jspm.io/')) {
-    urls.push(url.replace('https://ga.jspm.io/', 'esm://ga.jspm.io/'));
-  } else if (url.startsWith('esm://ga.jspm.io/')) {
-    urls.push(url.replace('esm://ga.jspm.io/', 'https://ga.jspm.io/'));
-  }
+  if (url.startsWith('https://')) urls.push(url.replace(/^https:/, 'esm:'));
+  else if (url.startsWith('esm://')) urls.push(url.replace(/^esm:/, 'https:'));
   return urls;
 }
 

--- a/flatn/tests/test.js
+++ b/flatn/tests/test.js
@@ -16,6 +16,7 @@ import {
 
 import { PackageSpec } from "flatn/package-map.js"
 import { bunInstall } from "flatn/bun-install.js"
+import { resolveViaImportMap } from "flatn/helpers.mjs"
 
 
 /*
@@ -26,6 +27,24 @@ import { bunInstall } from "flatn/bun-install.js"
 
 
 let baseDir = resource(`file://${tmpdir()}/lively.node-packages-test/`);
+
+describe("import maps", () => {
+  it("matches HTTPS importers against equivalent ESM CDN scopes", () => {
+    const importMap = {
+      scopes: {
+        "esm://esm.sh/example@1.0.0/": {
+          dependency: "esm://esm.sh/dependency@2.0.0"
+        }
+      }
+    };
+
+    expect(resolveViaImportMap(
+      "dependency",
+      importMap,
+      "https://esm.sh/example@1.0.0/index.js"
+    )).equals("esm://esm.sh/dependency@2.0.0");
+  });
+});
 
 
 describe("flat packages", function() {

--- a/flatn/util.js
+++ b/flatn/util.js
@@ -102,8 +102,29 @@ function x (cmd, opts = {}) {
         ? reject(new Error(`Command ${cmd} failed: ${code}\n${stdout}${stderr}`))
         : resolve(stdout));
     if (opts.verbose) {
-      p.stdout.pipe(process.stdout);
-      p.stderr.pipe(process.stderr);
+      const useProgress = process.stdout.isTTY &&
+        typeof globalThis.__flatnProgress === 'function';
+      if (!useProgress) {
+        p.stdout.pipe(process.stdout);
+        p.stderr.pipe(process.stderr);
+        return;
+      }
+
+      const report = (stream, reportLine) => {
+        let pending = '';
+        stream.setEncoding('utf8');
+        stream.on('data', chunk => {
+          const lines = `${pending}${chunk}`.split(/\r\n|\n|\r/);
+          pending = lines.pop() || '';
+          lines.filter(line => line.trim()).forEach(reportLine);
+        });
+        stream.on('end', () => {
+          if (pending.trim()) reportLine(pending);
+        });
+      };
+
+      report(p.stdout, line => globalThis.__flatnProgress(line));
+      report(p.stderr, line => console.error(line));
     }
   });
 }

--- a/install.sh
+++ b/install.sh
@@ -105,11 +105,17 @@ fi
 export NODE_OPTIONS="--no-warnings --experimental-modules --loader $lv_next_dir/flatn/resolver.mjs";
 
 section "Installing packages"
-node lively.installer/install-with-node.js $PWD \
+if ! node lively.installer/install-with-node.js "$PWD"; then
+  error "Package installation failed"
+  exit 1
+fi
 
 section "Building class runtime"
 step "Compiling lively.classes runtime..."
-env CI=true npm --silent --prefix $lv_next_dir/lively.classes/ run build
+if ! env CI=true npm --silent --prefix "$lv_next_dir/lively.classes/" run build; then
+  error "Class runtime build failed"
+  exit 1
+fi
 step "Class runtime built"
 
 if [ "$1" = "--freezer-only" ];
@@ -129,10 +135,16 @@ step "SWC plugin built"
 section "Building freezer bundles"
 if [ -z "${CI}" ]; then
   step "Building unified bundle (landing page + loading screen)..."
-  env CI=true npm --silent --prefix $lv_next_dir/lively.freezer/ run build-unified
+  if ! env CI=true npm --silent --prefix "$lv_next_dir/lively.freezer/" run build-unified; then
+    error "Freezer bundle build failed"
+    exit 1
+  fi
 else
   step "Building loading screen..."
-  env CI=true npm --silent --prefix $lv_next_dir/lively.freezer/ run build-loading-screen
+  if ! env CI=true npm --silent --prefix "$lv_next_dir/lively.freezer/" run build-loading-screen; then
+    error "Loading screen build failed"
+    exit 1
+  fi
 fi
 
 if [ -d "$lv_next_dir/lively.app" ] && [ "$1" != "--no-desktop" ]; then

--- a/lively.2lively/client.js
+++ b/lively.2lively/client.js
@@ -145,17 +145,18 @@ export default class L2LClient extends L2LConnection {
     this.trackerId = null;
     this._socketioClient = null;
 
-    // not socket.io already does auto reconnect when network fails but if the
-    // socket.io server disconnects a socket, it won't retry by itself. We want
-    // that behavior for l2l, however
+    // Socket.IO reconnects after transport failures. L2L only needs to
+    // re-register once the socket is connected again and explicitly reconnect
+    // after a server-initiated namespace disconnect.
     this._reconnectState = {
       closed: false,
       autoReconnect: true,
-      isReconnecting: false,
-      isReconnectingViaSocketio: false,
       registerAttempt: 0,
       registerProcess: null,
-      isOpening: false
+      registerRetry: null,
+      openProcess: null,
+      reconnecting: false,
+      generation: 0
     };
 
     Object.keys(defaultActions).forEach(name =>
@@ -178,113 +179,71 @@ export default class L2LClient extends L2LConnection {
   async open () {
     if (this.isOnline()) return this;
 
-    if (this._reconnectState.isOpening) return this;
+    const state = this._reconnectState;
+    if (state.openProcess) return state.openProcess;
 
-    await this.close();
+    state.closed = false;
+    const generation = state.generation;
+    const openProcess = (async () => {
+      let socket = this.socket;
+      if (!socket) {
+        const url = urlHelper.join(this.origin, this.namespace);
+        const opts = { path: this.path, transports: ['websocket', 'polling'] };
+        socket = this._socketioClient = ioClient(url, opts);
 
-    this._reconnectState.closed = false;
+        if (this.debug) console.log(`[${this}] connecting`);
 
-    const url = urlHelper.join(this.origin, this.namespace);
-    const opts = { path: this.path, transports: ['websocket', 'polling'] };
-    const socket = this._socketioClient = ioClient(url, opts);
+        socket.on('connect_error', err => this.debug && console.log(`[${this}] connection error: ${err}`));
 
-    if (this.debug) console.log(`[${this}] connecting`);
+        socket.on('connect', () => {
+          if (socket !== this.socket || generation !== state.generation) return;
+          this.debug && console.log(`[${this}] connected`);
+          this.emit('connected', this);
 
-    socket.on('error', (err) => {
-      this._reconnectState.isOpening = false;
-      this.debug && console.log(`[${this}] errored: ${err}`);
-    });
-    socket.on('close', (reason) => this.debug && console.log(`[${this}] closed: ${reason}`));
-    socket.on('reconnect_failed', () => this.debug && console.log(`[${this}] could not reconnect`));
-    socket.on('reconnect_error', (err) => this.debug && console.log(`[${this}] reconnect error ${err}`));
+          if (state.reconnecting) {
+            state.reconnecting = false;
+            this.register();
+          }
+        });
 
-    socket.on('connect', () => {
-      this.debug && console.log(`[${this}] connected`);
-      this.emit('connected', this);
-      this._reconnectState.isOpening = false;
-      this._reconnectState.isReconnecting = false;
-      this._reconnectState.isReconnectingViaSocketio = false;
-    });
+        socket.on('disconnect', reason => {
+          if (socket !== this.socket || generation !== state.generation) return;
 
-    socket.on('disconnect', () => {
-      this._reconnectState.isOpening = false;
+          this.debug && console.log(`[${this}] disconnected: ${reason}`);
+          this.emit('disconnected', this);
 
-      this.debug && console.log(`[${this}] disconnected`);
-      this.emit('disconnected', this);
+          if (this.trackerId && this.trackerId !== 'tracker') {
+            // Preserve message sequence numbers while the tracker is offline.
+            this.renameTarget(this.trackerId, 'tracker');
+          }
+          this.trackerId = null;
 
-      if (!this.trackerId) {
-        this.debug && console.log(`[${this}] disconnect: don't have a tracker id, won't try reconnect`);
-        this.trackerId = 'tracker';
-        return;
+          if (state.closed || !state.autoReconnect) return;
+
+          state.reconnecting = true;
+          this.emit('reconnecting', this);
+
+          // Socket.IO reconnects transport failures itself, but deliberately
+          // does not reconnect a namespace disconnected by the server.
+          if (reason === 'io server disconnect') socket.connect();
+        });
+
+        this.installEventToMessageTranslator(socket);
+      } else if (!socket.active) {
+        socket.connect();
       }
 
-      if (this.trackerId !== 'tracker') {
-        // for maintaining seq nos.
-        this.renameTarget(this.trackerId, 'tracker');
-        this.trackerId = null;
-      }
+      if (socket.connected) return this;
+      await new Promise(resolve => socket.once('connect', resolve));
+      return this;
+    })();
 
-      if (this._reconnectState.closed) {
-        this.debug && console.log(`[${this}] won't reconnect b/c client is marked as closed`);
-        return;
-      }
-
-      if (!this._reconnectState.autoReconnect) {
-        this.debug && console.log(`[${this}] won't reconnect b/c client has reconnection disabled`);
-        return;
-      }
-
-      this._reconnectState.isReconnecting = true;
-
-      setTimeout(() => {
-        // if socket.io isn't auto reconnecting we are doing it manually
-
-        if (this._reconnectState.closed) {
-          this.debug && console.log(`[${this}] won't reconnect b/c client is marked as closed 2`);
-          return;
-        }
-        if (this._reconnectState.isReconnectingViaSocketio) {
-          this.debug && console.log(`[${this}] won't reconnect again, client already reconnecting`);
-          return;
-        }
-
-        this.debug && console.log(`[${this}] initiating reconnection to tracker`);
-        this.register();
-      }, 20);
-    });
-
-    socket.on('reconnecting', () => {
-      this.debug && console.log(`[${this}] reconnecting`, this._reconnectState);
-      this.emit('reconnecting', this);
-      if (this._reconnectState.closed) {
-        this._reconnectState.isReconnecting = false;
-        this._reconnectState.isReconnectingViaSocketio = false;
-        socket.close();
-        this.close();
-      } else {
-        this._reconnectState.isReconnecting = true;
-        this._reconnectState.isReconnectingViaSocketio = true;
-      }
-    });
-
-    socket.on('reconnect', () => {
-      this.debug && console.log(`[${this}] reconnected`);
-      this._reconnectState.isReconnecting = false;
-      this._reconnectState.isReconnectingViaSocketio = false;
-      this.register();
-      if (this.onReconnect && typeof (this.onReconnect) === 'function') {
-        this.onReconnect();
-      }
-    });
-
-    this.installEventToMessageTranslator(socket);
-
-    this._reconnectState.isOpening = true;
-
-    return new Promise((resolve, reject) => {
-      socket.once('error', reject);
-      socket.once('connect', resolve);
-    }).then(() => this);
+    state.openProcess = openProcess;
+    try {
+      return await openProcess;
+    } finally {
+      if (state.openProcess === openProcess) state.openProcess = null;
+    }
   }
 
   async onReconnect () {
@@ -293,46 +252,27 @@ export default class L2LClient extends L2LConnection {
   }
 
   async close () {
-    this._reconnectState.closed = true;
+    const state = this._reconnectState;
+    state.closed = true;
+    state.reconnecting = false;
+    state.generation++;
+
+    if (state.registerRetry) clearTimeout(state.registerRetry);
+    state.registerRetry = null;
+    state.registerProcess = null;
+    state.openProcess = null;
 
     const socket = this.socket;
-    // this._socketioClient = null;
-
-    if (socket) {
-      socket.removeAllListeners('reconnect');
-      socket.removeAllListeners('reconnecting');
-      socket.removeAllListeners('disconnect');
-      socket.removeAllListeners('connect');
-      socket.removeAllListeners('reconnect_error');
-      socket.removeAllListeners('reconnect_failed');
-      socket.removeAllListeners('close');
-      socket.removeAllListeners('error');
-      socket.close();
-    }
-
-    this.debug && console.log(`[${this}] closing...`);
+    if (!socket) return this;
 
     if (this.isRegistered()) await this.unregister();
-    if (!this.isOnline() && !this.socket) {
-      if (this.debug) {
-        const reason = !this.isOnline() ? 'not online' : 'no socket';
-        this.debug && console.log(`[${this}] cannot close: ${reason}`);
-      }
-      return this;
-    }
 
-    if (socket && !socket.connected) {
-      this.debug && console.log(`[${this}] socket not connected, considering client closed`);
-      return this;
-    }
-
-    return Promise.race([
-      promise.delay(2000).then(() => socket.removeAllListeners('disconnect')),
-      new Promise(resolve => socket.once('disconnect', resolve))
-    ]).then(() => {
-      this.debug && console.log(`[${this}] closed`);
-      return this;
-    });
+    this.debug && console.log(`[${this}] closing...`);
+    socket.removeAllListeners();
+    socket.close();
+    this._socketioClient = null;
+    this.debug && console.log(`[${this}] closed`);
+    return this;
   }
 
   remove () {
@@ -343,59 +283,78 @@ export default class L2LClient extends L2LConnection {
   }
 
   async register () {
-    if (this.isRegistered()) return;
+    if (this.isRegistered()) return this;
 
-    if (this._reconnectState.closed) {
+    const state = this._reconnectState;
+    if (state.closed) {
       this.debug && console.log(`[${this}] not registering this b/c closed`);
-      this._reconnectState.registerAttempt = 0;
-      return;
+      state.registerAttempt = 0;
+      return this;
     }
 
-    if (this._reconnectState.registerProcess) {
+    if (state.registerProcess) {
       this.debug && console.log(`[${this}] not registering this b/c register process exists`);
-      return;
+      return state.registerProcess;
     }
 
+    const generation = state.generation;
+    const registerProcess = (async () => {
+      try {
+        if (!this.isOnline()) await this.open();
+        if (state.closed || generation !== state.generation) return this;
+
+        this.debug && console.log(`[${this}] register`);
+
+        const answer = await this.sendToAndWait('tracker', 'register', {
+          userName: 'unknown',
+          type: 'l2l ' + (isNode ? 'node' : 'browser'),
+          location: determineLocation(),
+          ...this.info
+        });
+
+        if (!answer.data) {
+          const err = new Error('Register answer is empty!');
+          this.emit('error', err);
+          throw err;
+        }
+
+        if (answer.data.isError) {
+          const err = new Error(answer.data.error);
+          this.emit('error', err);
+          throw err;
+        }
+
+        if (state.closed || generation !== state.generation) return this;
+
+        state.registerAttempt = 0;
+        if (state.registerRetry) clearTimeout(state.registerRetry);
+        state.registerRetry = null;
+        const { data: { trackerId, messageNumber } } = answer;
+        this.trackerId = trackerId;
+        this._incomingOrderNumberingBySenders.set(trackerId, messageNumber || 0);
+        this.emit('registered', { trackerId });
+        if (this.onReconnect && typeof (this.onReconnect) === 'function') {
+          this.onReconnect();
+        }
+      } catch (e) {
+        if (state.closed || generation !== state.generation) return this;
+
+        console.error(`Error in register request of ${this}: ${e}`);
+        const attempt = state.registerAttempt++;
+        const timeout = num.backoff(attempt, 4/* base */, 5 * 60 * 1000/* max */);
+        state.registerRetry = setTimeout(() => {
+          state.registerRetry = null;
+          this.register();
+        }, timeout);
+      }
+      return this;
+    })();
+
+    state.registerProcess = registerProcess;
     try {
-      if (!this.isOnline()) { await this.open(); }
-
-      this.debug && console.log(`[${this}] register`);
-
-      const answer = await this.sendToAndWait('tracker', 'register', {
-        userName: 'unknown',
-        type: 'l2l ' + (isNode ? 'node' : 'browser'),
-        location: determineLocation(),
-        ...this.info
-      });
-
-      if (!answer.data) {
-        const err = new Error('Register answer is empty!');
-        this.emit('error', err);
-        throw err;
-      }
-
-      if (answer.data.isError) {
-        const err = new Error(answer.data.error);
-        this.emit('error', err);
-        throw err;
-      }
-
-      this._reconnectState.registerAttempt = 0;
-      const { data: { trackerId, messageNumber } } = answer;
-      this.trackerId = trackerId;
-      this._incomingOrderNumberingBySenders.set(trackerId, messageNumber || 0);
-      this.emit('registered', { trackerId });
-      if (this.onReconnect && typeof (this.onReconnect) === 'function') {
-        this.onReconnect();
-      }
-    } catch (e) {
-      console.error(`Error in register request of ${this}: ${e}`);
-      const attempt = this._reconnectState.registerAttempt++;
-      const timeout = num.backoff(attempt, 4/* base */, 5 * 60 * 1000/* max */);
-      this._reconnectState.registerProcess = setTimeout(() => {
-        this._reconnectState.registerProcess = null;
-        this.register();
-      }, timeout);
+      return await registerProcess;
+    } finally {
+      if (state.registerProcess === registerProcess) state.registerProcess = null;
     }
   }
 

--- a/lively.2lively/tests/l2l-test.js
+++ b/lively.2lively/tests/l2l-test.js
@@ -109,6 +109,42 @@ describe('l2l', function () {
       await promise.waitFor(4000, () => connectedAgain);
     });
 
+    it('coalesces concurrent registration requests', async () => {
+      client2 = L2LClient.create({ url, namespace, autoOpen: false });
+      let connections = 0;
+      const countConnection = () => connections++;
+      tracker.ioNamespace.on('connection', countConnection);
+
+      try {
+        await Promise.all(Array.from({ length: 20 }, () => client2.register()));
+        await client2.whenRegistered(1000);
+        await promise.delay(50);
+      } finally {
+        tracker.ioNamespace.removeListener('connection', countConnection);
+      }
+
+      expect(connections).equals(1, 'concurrent registration opened multiple sockets');
+    });
+
+    it('re-registers once after a server disconnect', async () => {
+      const oldSocketId = client1.socketId;
+      let connections = 0;
+      const countConnection = () => connections++;
+      tracker.ioNamespace.on('connection', countConnection);
+
+      try {
+        tracker.getSocketForClientId(client1.id).disconnect(true);
+        await promise.waitFor(2000, () =>
+          client1.isRegistered() && client1.socketId !== oldSocketId);
+        await promise.delay(50);
+      } finally {
+        tracker.ioNamespace.removeListener('connection', countConnection);
+      }
+
+      expect(connections).equals(1, 'server disconnect opened multiple replacement sockets');
+      expect(tracker.clients.get(client1.id).socketId).equals(client1.socketId);
+    });
+
     it('client unregisters', async () => {
       expect(client1.isRegistered()).equals(true, 1);
       await client1.unregister();

--- a/lively.2lively/tracker.js
+++ b/lively.2lively/tracker.js
@@ -137,7 +137,7 @@ export default class L2LTracker extends L2LConnection {
 
     socket.on('error', (err) => this.onError(err));
     socket.on('connect', () => this.onConnect(socket));
-    socket.on('disconnect', () => this.onDisconnect(socket));
+    socket.on('disconnect', reason => this.onDisconnect(socket, reason));
 
     this.installEventToMessageTranslator(socket);
   }
@@ -146,8 +146,12 @@ export default class L2LTracker extends L2LConnection {
     if (this.debug) console.log(`[l2l] ${this} connected to ${socket.id}`);
   }
 
-  onDisconnect (socket) {
-    if (this.debug) console.log(`[l2l] ${this} disconnected from ${socket.id}`);
+  onDisconnect (socket, reason) {
+    if (this.debug) {
+      const clientId = this.getClientIdForSocketId(socket.id);
+      const info = clientId && this.clients.get(clientId)?.info;
+      console.log(`[l2l] ${this} disconnected from ${socket.id}: ${reason}`, info || 'unregistered');
+    }
   }
 
   registerClient ({ sender, data }, answerFn, socket) {

--- a/lively.freezer/src/bundler.js
+++ b/lively.freezer/src/bundler.js
@@ -63,7 +63,7 @@ const CLASS_INSTRUMENTATION_MODULES = [
   'https://jspm.dev/npm:rollup@2.28.2' // this contains a bunch of class definitions which right now screws up the closure compiler
 ];
 
-const ESM_CDNS = [/esm:\/\/([^\/]*)\//, /https:\/\/ga\.jspm\.io\//];
+const ESM_CDNS = [/^esm:\/\/([^\/]*)\//, /^https:\/\/(?:ga\.jspm\.io|esm\.sh)\//];
 
 // fixme: Why is a blacklist nessecary if there is a whitelist?
 const CLASS_INSTRUMENTATION_MODULES_EXCLUSION = ['lively.lang'];
@@ -133,10 +133,11 @@ export function bulletProofNamespaces (code, chunkFileName, isResurrectionBuild,
       if (node.type === 'VariableDeclaration') {
         const matchingComment = pureComments.find(c => node.start < c.start && c.end > node.end);
         if (!matchingComment) return node;
-        const matchingGetter = node.declarations[0]?.init?.arguments?.[0]?.properties?.find(prop => prop.key.name === 'default' && prop.kind === 'get');
+        const matchingGetter = node.declarations[0]?.init?.arguments?.[0]?.properties?.find(prop => prop?.key?.name === 'default' && prop.kind === 'get');
         if (!matchingGetter) return node;
         const getterBody = matchingGetter.value.body;
         const [returnStmt] = getterBody.body;
+        if (returnStmt?.type !== 'ReturnStatement' || returnStmt.argument?.type !== 'Identifier') return node;
         rewrites.push([getterBody, `\nif (typeof ${returnStmt.argument.name} === 'undefined') throw new Error('Module not yet initialized!');\n`]);
       }
       return node;
@@ -203,11 +204,8 @@ function resolutionId (id, importer) {
 function equivalentCdnModuleIds (id) {
   if (!id || typeof id !== 'string') return [];
   const ids = [id];
-  if (id.startsWith('https://ga.jspm.io/')) {
-    ids.push(id.replace('https://ga.jspm.io/', 'esm://ga.jspm.io/'));
-  } else if (id.startsWith('esm://ga.jspm.io/')) {
-    ids.push(id.replace('esm://ga.jspm.io/', 'https://ga.jspm.io/'));
-  }
+  if (id.startsWith('https://')) ids.push(id.replace(/^https:/, 'esm:'));
+  else if (id.startsWith('esm://')) ids.push(id.replace(/^esm:/, 'https:'));
   return ids;
 }
 
@@ -220,11 +218,38 @@ function equivalentCdnModuleIds (id) {
  * @returns { boolean } Wether or not the module was served from an ESM CDN.
  */
 function isCdnImport (id, importer, resolver) {
-  if (ESM_CDNS.find(cdn => id.match(cdn) || importer.match(cdn)) && importer && importer !== ROOT_ID) {
+  if (importer && importer !== ROOT_ID && ESM_CDNS.find(cdn => id.match(cdn) || importer.match(cdn))) {
     const { url } = resource(resolver.ensureFileFormat(importer)).root(); // get the cdn host root
     return ESM_CDNS.find(cdn => url.match(cdn));
   }
   return false;
+}
+
+/**
+ * esm.sh rewrites Node built-ins to private `/node/*.mjs` URLs. Translate
+ * those URLs back to standard `node:*` specifiers so the project's browser
+ * import map can choose one consistent polyfill implementation.
+ */
+export function resolveEsmShNodeBuiltin (id, importer, importMap) {
+  if (!id || !importer || !importMap ||
+      !/^(?:esm|https):\/\/esm\.sh\//.test(importer)) return null;
+
+  const match = id.match(/^\/node\/(.+)\.mjs$/) ||
+    id.match(/^(?:esm|https):\/\/esm\.sh\/node\/(.+)\.mjs$/);
+  if (!match) return null;
+
+  const builtinName = match[1];
+  const importers = [
+    importer,
+    ...Object.keys(importMap.scopes || {}).filter(scope => scope.includes('ga.jspm.io/'))
+  ];
+  for (const resolutionImporter of importers) {
+    for (const builtinId of [`node:${builtinName}`, builtinName]) {
+      const remapped = resolveViaImportMap(builtinId, importMap, resolutionImporter);
+      if (remapped && remapped !== builtinId) return remapped;
+    }
+  }
+  return null;
 }
 
 export default class LivelyRollup {
@@ -346,7 +371,7 @@ export default class LivelyRollup {
     if (!id || id === ROOT_ID || id.startsWith('__rootModule__:') ||
         id.startsWith('.') || id.startsWith('/') || id.startsWith('\0') || id.includes(':')) return null;
     const importMap = this.defaultImportMapForCdnImports();
-    const remapped = importMap && resolveViaImportMap(id, importMap, 'esm://ga.jspm.io/');
+    const remapped = importMap && resolveViaImportMap(id, importMap, '');
     if (remapped && remapped !== id) return remapped;
     try {
       const fallbackImporter = this.resolver.normalizeFileName('lively.freezer/index.js');
@@ -917,8 +942,17 @@ export default class LivelyRollup {
     // handle standalone
     if (!importer) return this.resolver.resolveModuleId(id, importer, this.getResolutionContext());
 
-    // handle ESM CDN imports
-    if (isCdnImport(id, importer, this.resolver)) {
+    const importingPackage = this.modulePackageFor(importer);
+    // honor the systemjs options within the package config
+    let { map: mapping, importMap } = importingPackage?.systemjs || {};
+    if (!importMap && this.wasFetchedFromEsmCdn(importer)) {
+      importMap = this.defaultImportMapForCdnImports();
+    }
+
+    const builtinRemapping = resolveEsmShNodeBuiltin(id, importer, importMap);
+    if (builtinRemapping) {
+      id = builtinRemapping;
+    } else if (isCdnImport(id, importer, this.resolver)) {
       if (id.startsWith('.')) {
         id = resource(importer).parent().join(id).withRelativePartsResolved().url;
       } else if (id.startsWith('/')) {
@@ -926,12 +960,6 @@ export default class LivelyRollup {
       }
     }
 
-    const importingPackage = this.modulePackageFor(importer);
-    // honor the systemjs options within the package config
-    let { map: mapping, importMap } = importingPackage?.systemjs || {};
-    if (!importMap && this.wasFetchedFromEsmCdn(importer)) {
-      importMap = this.defaultImportMapForCdnImports();
-    }
     if (mapping) {
       let remapped = mapping[id];
       if (remapped) {

--- a/lively.freezer/src/plugins/rollup.js
+++ b/lively.freezer/src/plugins/rollup.js
@@ -148,9 +148,6 @@ export function lively (args) {
     },
     async generateBundle (options, bundle, isWrite) {
       await bundler.generateBundle(this, bundle, depsCode, importMap, options);
-    },
-    renderError() {
-      process.exit(1);
     }
   };
 }

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -237,6 +237,12 @@ async function load(url) {
 }
 
 function supportingPlugins(context = 'node', self) {
+  const livelyPackageRoot = path.resolve(process.env.lv_next_dir || process.cwd())
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const livelyPackage = new RegExp(
+    `^${livelyPackageRoot}/lively\\.(?!next-node_modules(?:/|$))[^/]+/`
+  );
+
   return [
     context == 'node' && {
       name: 'system-require-handler',
@@ -290,7 +296,7 @@ function supportingPlugins(context = 'node', self) {
       defaultIsModuleExports: true,
       transformMixedEsModules: true,
       dynamicRequireRoot: process.env.lv_next_dir,
-      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', /lively./],
+      exclude: ['../**/base/0.11.1/utils.js', '../**/use/2.0.0/utils.js', livelyPackage],
       dynamicRequireTargets: [
          resolveModuleId('babel-plugin-transform-es2015-modules-systemjs')
       ]

--- a/lively.freezer/src/resolvers/node.cjs
+++ b/lively.freezer/src/resolvers/node.cjs
@@ -43,9 +43,10 @@ async function availableFonts(fontCSSFile) {
 }
 
 function isCdnImport(url) {
-   return  url.includes('jspm.dev') ||
-   url.includes('ga.jspm.io') ||
-   url.includes('esm://');
+   return url.startsWith('https://jspm.dev/') ||
+   url.startsWith('https://ga.jspm.io/') ||
+   url.startsWith('https://esm.sh/') ||
+   url.startsWith('esm://');
 }
 
 function isAlreadyResolved(url) {

--- a/lively.freezer/tests/cdn-resolution-test.js
+++ b/lively.freezer/tests/cdn-resolution-test.js
@@ -1,0 +1,29 @@
+/* global describe, it */
+
+import { expect } from 'mocha-es6';
+import { resolveEsmShNodeBuiltin } from '../src/bundler.js';
+
+describe('freezer CDN resolution', () => {
+  it('resolves esm.sh Node shims through the browser import map', () => {
+    const importMap = {
+      scopes: {
+        'esm://ga.jspm.io/': {
+          events: 'esm://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/events.js',
+          'node:fs/promises': 'esm://ga.jspm.io/npm:@jspm/core@2.1.0/nodelibs/browser/fs/promises.js'
+        }
+      }
+    };
+    const importer = 'esm://esm.sh/example@1.0.0/es2022/example.mjs';
+
+    expect(resolveEsmShNodeBuiltin('/node/events.mjs', importer, importMap))
+      .equals(importMap.scopes['esm://ga.jspm.io/'].events);
+    expect(resolveEsmShNodeBuiltin('/node/fs/promises.mjs', importer, importMap))
+      .equals(importMap.scopes['esm://ga.jspm.io/']['node:fs/promises']);
+  });
+
+  it('leaves provider modules alone when the import map has no replacement', () => {
+    const importer = 'esm://esm.sh/example@1.0.0/es2022/example.mjs';
+    expect(resolveEsmShNodeBuiltin('/node/events.mjs', importer, {})).equals(null);
+    expect(resolveEsmShNodeBuiltin('/node/events.mjs', 'esm://ga.jspm.io/example.js', {})).equals(null);
+  });
+});

--- a/lively.ide/package.json
+++ b/lively.ide/package.json
@@ -44,12 +44,5 @@
   },
   "scripts": {
     "test": "mocha-es6 tests/{,diff/,js/,shell/}*-test.js"
-  },
-  "systemjs": {
-    "map": {
-      "highlight.js/lib/core": "https://ga.jspm.io/npm:highlight.js@11.11.1/es/core.js",
-      "highlight.js/lib/languages/javascript": "https://ga.jspm.io/npm:highlight.js@11.11.1/es/languages/javascript.js",
-      "highlight.js/lib/languages/shell": "https://ga.jspm.io/npm:highlight.js@11.11.1/es/languages/shell.js"
-    }
   }
 }

--- a/lively.modules/src/system.js
+++ b/lively.modules/src/system.js
@@ -472,6 +472,9 @@ function preNormalize (System, name, parent) {
       importMap = !isNode && systemjs?.importMap; // only works in the browser
       mappedObject = map?.[name] || isNode && System.map[name]; // only consider the global map if no local importMap
     }
+    if (!importMap && !isNode && parent) {
+      importMap = System.importMapCache.get(parent);
+    }
 
     if (mappedObject) {
       if (typeof mappedObject === 'object') {
@@ -615,6 +618,14 @@ async function finalizeNormalization (System, name, normalized) {
   return normalized;
 }
 
+export function propagateImportMapCache (System, sourceId, ...normalizedIds) {
+  const importMap = System.importMapCache.get(sourceId);
+  if (!importMap) return;
+  for (const id of normalizedIds) {
+    if (id) System.importMapCache.set(id, importMap);
+  }
+}
+
 async function normalizeHook (proceed, name, parent, parentAddress) {
   const System = this;
   if (!isLivelyTranspiler(System.transpiler)) return await proceed(name, parent, true);
@@ -632,6 +643,7 @@ async function normalizeHook (proceed, name, parent, parentAddress) {
   const stage2 = await proceed(stage1, parent, true);
   let stage3 = postNormalize(System, stage2 || stage1, false);
   stage3 = await finalizeNormalization(System, name, stage3);
+  propagateImportMapCache(System, stage1, stage2, stage3);
   System.debug && console.log(`[normalize] ${name} => ${stage3}`);
 
   if (System.METADATA[stage2] && !System.METADATA[stage3]) {

--- a/lively.modules/tests/hook-test.js
+++ b/lively.modules/tests/hook-test.js
@@ -1,7 +1,7 @@
 /* global beforeEach, afterEach, describe, it */
 import { expect } from 'mocha-es6';
 
-import { getSystem, removeSystem } from '../src/system.js';
+import { getSystem, propagateImportMapCache, removeSystem } from '../src/system.js';
 import { install as installHook, remove as removeHook, isInstalled as isHookInstalled } from '../src/hooks.js';
 
 describe('hooks', () => {
@@ -35,5 +35,19 @@ describe('hooks', () => {
     function hook (proceed, name, parent) { return proceed(name, parent); }
     installHook(System, 'normalize', hook);
     expect(isHookInstalled(System, 'normalize', 'hook')).to.equal(true);
+  });
+
+  it('preserves import maps across module ID normalization', () => {
+    const importMap = { imports: { dependency: 'esm://cdn.example/dependency.js' } };
+    System.importMapCache.set('esm://cdn.example/entry.js', importMap);
+
+    propagateImportMapCache(
+      System,
+      'esm://cdn.example/entry.js',
+      'http://localhost:9011/esm_cache/cdn.example/entry.js'
+    );
+
+    expect(System.importMapCache.get('http://localhost:9011/esm_cache/cdn.example/entry.js'))
+      .equals(importMap);
   });
 });

--- a/lively.morphic/package.json
+++ b/lively.morphic/package.json
@@ -44,10 +44,7 @@
     "uglify-es": "^3.3.9"
   },
   "systemjs": {
-    "main": "index.js",
-    "map": {
-      "yoga-layout/load": "https://ga.jspm.io/npm:yoga-layout@3.2.1/dist/src/load.js"
-    }
+    "main": "index.js"
   },
   "scripts": {
     "build": "node tools/build.js",

--- a/lively.morphic/package.json
+++ b/lively.morphic/package.json
@@ -44,7 +44,10 @@
     "uglify-es": "^3.3.9"
   },
   "systemjs": {
-    "main": "index.js"
+    "main": "index.js",
+    "map": {
+      "yoga-layout/load": "https://ga.jspm.io/npm:yoga-layout@3.2.0/dist/src/load.js"
+    }
   },
   "scripts": {
     "build": "node tools/build.js",

--- a/lively.resources/src/esm-resource.js
+++ b/lively.resources/src/esm-resource.js
@@ -7,11 +7,13 @@ const requestMap = {};
 
 export class ESMResource extends Resource {
   static normalize (esmUrl) {
-    const id = esmUrl.replaceAll(/esm:\/\/([^\/]*)\//g, '');
+    const match = esmUrl.match(/^esm:\/\/([^\/]*)\/(.*)$/);
+    const domain = match?.[1];
+    const id = match?.[2] || esmUrl;
 
     let pathStructure = id.split('/').filter(Boolean);
 
-    // jspm servers both the entry point into a package as well as subcontent from package@version/
+    // ESM CDNs serve both the entry point into a package and package subcontent.
     // differentiate these cases by introducing an index.js which will automatically be served by systemJS
     if (pathStructure.length === 1 ||
         !pathStructure[pathStructure.length - 1].endsWith('+esm') &&
@@ -37,6 +39,9 @@ export class ESMResource extends Resource {
       pathStructure[pathStructure.length - 1] = pathStructure[pathStructure.length - 1].replace('!cjs', '.cjs');
     }
 
+    // The provider is part of the cache identity. Different CDNs can use the
+    // same path for different transformed source.
+    if (domain) pathStructure.unshift(domain);
     return pathStructure;
   }
 
@@ -50,7 +55,7 @@ export class ESMResource extends Resource {
     const id = this.url.replace(/esm:\/\/([^\/]*)\//g, '');
     const esmURL = this.getEsmURL();
 
-    let pathStructure = ESMResource.normalize(id);
+    let pathStructure = ESMResource.normalize(this.url);
 
     const [res, created] = await this.findOrCreatePathStructure(pathStructure);
 
@@ -60,7 +65,7 @@ export class ESMResource extends Resource {
       module = await res.read();
     } else {
       module = await resource((esmURL + id)).read();
-      res.write(module);
+      await res.write(module);
     }
     return module;
   }

--- a/lively.resources/src/esm-resource.js
+++ b/lively.resources/src/esm-resource.js
@@ -5,6 +5,40 @@ import { string } from 'lively.lang';
 
 const requestMap = {};
 
+export function adaptEsmShExportsForJspmInterop (source, url) {
+  if (!url.startsWith('esm://esm.sh/')) return source;
+
+  source = source.replace(
+    /(\b[$A-Z_a-z][$\w]*)=([$A-Z_a-z][$\w]*)=>Object\.assign\(\{__esModule:true\},\2\)/g,
+    '$1=$2=>Object.create($2,{__esModule:{value:true}})'
+  );
+
+  return source.replace(
+    /export\s*\*\s*from\s*["']([^"']+)["'];?\s*export\s*\{\s*default\s*\}\s*from\s*["']\1["'];?/,
+    `import * as __livelyEsmShModule from "$1";
+export * from "$1";
+const __livelyEsmShDefault = __livelyEsmShModule.default;
+if (__livelyEsmShModule.__esModule && __livelyEsmShDefault &&
+    (typeof __livelyEsmShDefault === "object" || typeof __livelyEsmShDefault === "function")) {
+  for (const __livelyEsmShKey of Object.keys(__livelyEsmShModule)) {
+    if (!(__livelyEsmShKey in __livelyEsmShDefault)) {
+      Object.defineProperty(__livelyEsmShDefault, __livelyEsmShKey, {
+        enumerable: true,
+        get: () => __livelyEsmShModule[__livelyEsmShKey]
+      });
+    }
+  }
+  if (!("default" in __livelyEsmShDefault)) {
+    Object.defineProperty(__livelyEsmShDefault, "default", {
+      enumerable: true,
+      value: __livelyEsmShDefault
+    });
+  }
+}
+export { __livelyEsmShDefault as default };`
+  );
+}
+
 export class ESMResource extends Resource {
   static normalize (esmUrl) {
     const match = esmUrl.match(/^esm:\/\/([^\/]*)\/(.*)$/);
@@ -61,13 +95,14 @@ export class ESMResource extends Resource {
 
     if (!created) {
       let hit; let shortName = res.url.replace(this.getBaseURL(), '');
-      if (typeof lively !== 'undefined' && (hit = lively.memory_esm?.get(shortName))) return await hit.blob.text();
-      module = await res.read();
+      module = typeof lively !== 'undefined' && (hit = lively.memory_esm?.get(shortName))
+        ? await hit.blob.text()
+        : await res.read();
     } else {
       module = await resource((esmURL + id)).read();
       await res.write(module);
     }
-    return module;
+    return adaptEsmShExportsForJspmInterop(module, this.url);
   }
 
   getBaseURL () {

--- a/lively.resources/tests/esm-resource-test.js
+++ b/lively.resources/tests/esm-resource-test.js
@@ -1,7 +1,7 @@
 /* global describe, it */
 
 import { expect } from 'mocha-es6';
-import { ESMResource } from '../src/esm-resource.js';
+import { adaptEsmShExportsForJspmInterop, ESMResource } from '../src/esm-resource.js';
 
 describe('ESM resource', () => {
   it('keeps providers isolated in the on-disk cache', () => {
@@ -10,5 +10,45 @@ describe('ESM resource', () => {
 
     expect(jspmPath).deep.equals(['ga.jspm.io', 'npm:example@1.0.0', 'index.js']);
     expect(esmShPath).deep.equals(['esm.sh', 'npm:example@1.0.0', 'index.js']);
+  });
+
+  it('preserves JSPM CommonJS default semantics for esm.sh entry modules', () => {
+    const source = `/* esm.sh - @babel/template */
+export * from "/@babel/template/es2022/template.mjs";
+export { default } from "/@babel/template/es2022/template.mjs";`;
+
+    expect(adaptEsmShExportsForJspmInterop(source, 'esm://esm.sh/@babel/template/lib/index.js')).equals(`/* esm.sh - @babel/template */
+import * as __livelyEsmShModule from "/@babel/template/es2022/template.mjs";
+export * from "/@babel/template/es2022/template.mjs";
+const __livelyEsmShDefault = __livelyEsmShModule.default;
+if (__livelyEsmShModule.__esModule && __livelyEsmShDefault &&
+    (typeof __livelyEsmShDefault === "object" || typeof __livelyEsmShDefault === "function")) {
+  for (const __livelyEsmShKey of Object.keys(__livelyEsmShModule)) {
+    if (!(__livelyEsmShKey in __livelyEsmShDefault)) {
+      Object.defineProperty(__livelyEsmShDefault, __livelyEsmShKey, {
+        enumerable: true,
+        get: () => __livelyEsmShModule[__livelyEsmShKey]
+      });
+    }
+  }
+  if (!("default" in __livelyEsmShDefault)) {
+    Object.defineProperty(__livelyEsmShDefault, "default", {
+      enumerable: true,
+      value: __livelyEsmShDefault
+    });
+  }
+}
+export { __livelyEsmShDefault as default };`);
+  });
+
+  it('keeps ESM namespace access lazy across CommonJS cycles', () => {
+    const source = 'const c=m=>Object.assign({__esModule:true},m);';
+    expect(adaptEsmShExportsForJspmInterop(source, 'esm://esm.sh/package/es2022/package.mjs'))
+      .equals('const c=m=>Object.create(m,{__esModule:{value:true}});');
+  });
+
+  it('does not adapt modules from other providers', () => {
+    const source = 'export { default } from "./module.js";';
+    expect(adaptEsmShExportsForJspmInterop(source, 'esm://ga.jspm.io/module.js')).equals(source);
   });
 });

--- a/lively.resources/tests/esm-resource-test.js
+++ b/lively.resources/tests/esm-resource-test.js
@@ -1,0 +1,14 @@
+/* global describe, it */
+
+import { expect } from 'mocha-es6';
+import { ESMResource } from '../src/esm-resource.js';
+
+describe('ESM resource', () => {
+  it('keeps providers isolated in the on-disk cache', () => {
+    const jspmPath = ESMResource.normalize('esm://ga.jspm.io/npm:example@1.0.0/index.js');
+    const esmShPath = ESMResource.normalize('esm://esm.sh/npm:example@1.0.0/index.js');
+
+    expect(jspmPath).deep.equals(['ga.jspm.io', 'npm:example@1.0.0', 'index.js']);
+    expect(esmShPath).deep.equals(['esm.sh', 'npm:example@1.0.0', 'index.js']);
+  });
+});

--- a/lively.server/plugins/lib-lookup.js
+++ b/lively.server/plugins/lib-lookup.js
@@ -6,6 +6,8 @@ import { resource } from "lively.resources";
 import { parseQuery } from "lively.resources";
 import { arr, obj } from "lively.lang";
 const Generator = System.get('@jspm_generator').default;
+const jspmAvailabilityCache = new Map();
+const JSPM_AVAILABILITY_TTL = 60 * 1000;
 
 // Deps that cannot be resolved via jspm.io CDN:
 // - native binary packages (platform-specific compiled addons)
@@ -16,6 +18,7 @@ function isUnresolvableOnCDN ([name, version]) {
   if (/^@rollup\/rollup-/.test(name)) return true;
   if (/^@swc\/core(-|$)/.test(name)) return true;
   if (name === '@jspm/generator') return true;
+  if (name === 'nw') return true;
   if (name === 'puppeteer' || name === 'puppeteer-core') return true;
   return false;
 }
@@ -34,46 +37,77 @@ function extractFailingPackage (errMsg) {
   return null;
 }
 
-/**
- * Given a package name and failing version, find a nearby version that
- * actually exists on the jspm.io CDN by walking backwards from the failing
- * version through the npm registry's version list.
- */
-async function findAvailableCDNVersion (name, failingVersion) {
-  let versions;
-  try {
-    const res = await fetch(`https://registry.npmjs.org/${name}`, {
-      headers: { Accept: 'application/vnd.npm.install-v1+json' }
-    });
-    if (!res.ok) return null;
-    const meta = await res.json();
-    versions = Object.keys(meta.versions || {});
-  } catch { return null; }
-
-  const failIdx = versions.indexOf(failingVersion);
-  if (failIdx < 0) return null;
-  // Try up to 20 versions before the failing one (most recent first)
-  const candidates = versions.slice(Math.max(0, failIdx - 20), failIdx).reverse();
-
-  for (const ver of candidates) {
-    try {
-      const probe = await fetch(
-        `https://ga.jspm.io/npm:${name}@${ver}/package.json`,
-        { method: 'HEAD' }
-      );
-      if (probe.ok) return ver;
-    } catch { continue; }
-  }
-  return null;
-}
-
-function createGenerator (inputMap, resolutions) {
+function createGenerator (inputMap, providers) {
   return new Generator({
     env: ["browser", "module", "import"],
     defaultProvider: 'jspm.io',
     inputMap,
-    ...(Object.keys(resolutions).length ? { resolutions } : {})
+    ...(Object.keys(providers).length ? { providers } : {})
   });
+}
+
+function moduleUrlsIn (value, urls = new Set()) {
+  if (typeof value === 'string') {
+    if (value.startsWith('https://ga.jspm.io/npm:') && !value.endsWith('/')) urls.add(value);
+  } else if (value && typeof value === 'object') {
+    for (const nested of Object.values(value)) moduleUrlsIn(nested, urls);
+  }
+  return urls;
+}
+
+async function isUnavailableOnJspm (url, fetchModule, availabilityCache) {
+  let cached = availabilityCache.get(url);
+  if (!cached || Date.now() - cached.checkedAt > JSPM_AVAILABILITY_TTL) {
+    cached = {
+      checkedAt: Date.now(),
+      result: (async () => {
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            const response = await fetchModule(url, { method: 'HEAD' });
+            if (response.status < 500) return response.status === 404 || response.status === 410;
+          } catch {}
+        }
+        return false;
+      })()
+    };
+    availabilityCache.set(url, cached);
+  }
+  return await cached.result;
+}
+
+export async function findUnavailableJspmPackages (
+  importMap,
+  fetchModule = fetch,
+  availabilityCache = jspmAvailabilityCache
+) {
+  const urls = [...moduleUrlsIn(importMap)];
+  const unavailable = new Set();
+  let next = 0;
+
+  async function checkNext () {
+    while (next < urls.length) {
+      const url = urls[next++];
+      if (!await isUnavailableOnJspm(url, fetchModule, availabilityCache)) continue;
+      const failingPackage = extractFailingPackage(url);
+      if (failingPackage) unavailable.add(failingPackage.name);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(20, urls.length) }, checkNext));
+  return [...unavailable].sort();
+}
+
+function esmShPackagesIn (value, packageNames = new Set()) {
+  if (typeof value === 'string') {
+    const match = value.match(/^https:\/\/esm\.sh\/(?:v\d+\/)?\*?((?:@[^/@]+\/)?[^/@]+)@/);
+    if (match) packageNames.add(match[1]);
+  } else if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      esmShPackagesIn(key, packageNames);
+      esmShPackagesIn(nested, packageNames);
+    }
+  }
+  return packageNames;
 }
 
 function fileURLPath (url) {
@@ -109,34 +143,36 @@ function clientRelativePackageRegistryJSON (value) {
   return value;
 }
 
-async function installDeps (generator, deps, failed, resolutions, inputMap) {
+export async function installDeps (
+  generator,
+  deps,
+  failed,
+  providers,
+  newGenerator = createGenerator,
+  findUnavailablePackages = findUnavailableJspmPackages
+) {
   const depNames = deps.map(([name]) => name);
-  let needsRestart = false;
+  while (true) {
+    let needsRestart = false;
 
-  for (let dep of deps) {
-    if (dep[0] == 'tar-fs' || isUnresolvableOnCDN(dep) || !!generator.map.imports[dep[0]]) continue;
-    const depName = dep[0];
-    const depSpec = dep.join('@');
-    try {
-      await generator.install(depSpec);
-      delete failed[depName];
-      continue;
-    } catch (firstErr) {
-      const errMsg = firstErr.message || String(firstErr);
-      const failingPkg = extractFailingPackage(errMsg);
-      if (failingPkg && !resolutions[failingPkg.name]) {
-        console.warn(`\x1b[33m       [!] Import map: ${depSpec} failed — transitive dep ${failingPkg.name}@${failingPkg.version} not on CDN, searching for available version...\x1b[0m`);
-        const goodVersion = await findAvailableCDNVersion(failingPkg.name, failingPkg.version);
-        if (goodVersion) {
-          console.log(`\x1b[32m       [✓] Found ${failingPkg.name}@${goodVersion} on CDN, pinning via resolutions\x1b[0m`);
-          resolutions[failingPkg.name] = goodVersion;
+    for (let dep of deps) {
+      if (dep[0] == 'tar-fs' || isUnresolvableOnCDN(dep) || !!generator.map.imports[dep[0]]) continue;
+      const depName = dep[0];
+      const depSpec = dep.join('@');
+      try {
+        await generator.install(depSpec);
+        delete failed[depName];
+      } catch (firstErr) {
+        const errMsg = firstErr.message || String(firstErr);
+        const failingPkg = extractFailingPackage(errMsg);
+        if (failingPkg && !providers[failingPkg.name]) {
+          console.warn(`\x1b[33m       [!] Import map: ${depSpec} failed — ${failingPkg.name}@${failingPkg.version} is unavailable from jspm.io; retrying the same version via esm.sh\x1b[0m`);
+          providers[failingPkg.name] = 'esm.sh';
           needsRestart = true;
-          continue; // don't mark as failed — will be retried in second pass
-        } else {
-          console.warn(`\x1b[33m       [!] Import map: no available CDN version found for ${failingPkg.name}\x1b[0m`);
+          break;
         }
-      } else if (!failingPkg) {
-        // Non-CDN-404 error — retry once
+
+        // Retry transient failures once before leaving the direct dependency unresolved.
         console.warn('\x1b[33m       [!] Import map: first attempt failed for ' + depSpec + ': ' + errMsg + ', retrying...\x1b[0m');
         try {
           await generator.install(depSpec);
@@ -145,29 +181,25 @@ async function installDeps (generator, deps, failed, resolutions, inputMap) {
         } catch (retryErr) {
           console.warn('\x1b[33m       [!] Import map: failed to resolve ' + depSpec + ': ' + (retryErr.message || retryErr) + '\x1b[0m');
         }
-      }
-      failed[depName] = true;
-    }
-  }
-
-  // If we discovered new resolution pins, recreate the generator and
-  // redo the entire install so all deps benefit from the pins.
-  if (needsRestart) {
-    console.log(`\x1b[36m       [↻] Restarting import map resolution with ${Object.keys(resolutions).length} pinned resolution(s)...\x1b[0m`);
-    generator = createGenerator(inputMap, resolutions);
-    for (const key of Object.keys(failed)) delete failed[key];
-    for (let dep of deps) {
-      if (dep[0] == 'tar-fs' || isUnresolvableOnCDN(dep) || !!generator.map.imports[dep[0]]) continue;
-      const depName = dep[0];
-      const depSpec = dep.join('@');
-      try {
-        await generator.install(depSpec);
-        delete failed[depName];
-      } catch (err) {
-        console.warn('\x1b[33m       [!] Import map: failed to resolve ' + depSpec + ': ' + (err.message || err) + '\x1b[0m');
         failed[depName] = true;
       }
     }
+
+    if (!needsRestart) {
+      const unavailablePackages = await findUnavailablePackages(generator.getMap());
+      const newFallbacks = unavailablePackages.filter(name => !providers[name]);
+      for (const name of newFallbacks) providers[name] = 'esm.sh';
+      if (newFallbacks.length) {
+        console.warn(`\x1b[33m       [!] Import map: ${newFallbacks.length} generated jspm.io package artifact(s) returned 404; retrying them via esm.sh\x1b[0m`);
+        needsRestart = true;
+      }
+    }
+    if (!needsRestart) break;
+    console.log(`\x1b[36m       [↻] Restarting import map resolution with ${Object.keys(providers).length} esm.sh package fallback(s)...\x1b[0m`);
+    // Existing locks still point at the failed provider. Rebuild the map so
+    // the package-level provider overrides apply throughout the dependency graph.
+    generator = newGenerator(false, providers);
+    for (const key of Object.keys(failed)) delete failed[key];
   }
 
   for (const failedDep of Object.keys(failed)) {
@@ -187,19 +219,31 @@ export async function generateImportMap (packageName) {
   if (await cachedImportMap.exists()) {
     inputMap = JSON.parse((await cachedImportMap.read()).replace(/esm:\/\//g, 'https://')); // replace esm to make generator install again
   }
-  const resolutions = {};
-  let generator = createGenerator(inputMap, resolutions);
+  const providers = inputMap?._providers || {};
+  // Old maps may contain silent transitive downgrades. Maps with provider
+  // overrides also need rebuilding because their existing URL locks take
+  // precedence over those overrides.
+  if (inputMap?._resolutions || inputMap?._providers) inputMap = false;
   const failed = inputMap?._failed || {};
+  if (inputMap) {
+    delete inputMap._failed;
+    delete inputMap._providers;
+  }
+  let generator = createGenerator(inputMap, providers);
   generator = await installDeps(
     generator,
     Object.entries(pkg.config.dependencies || {}).filter(([dep]) => !dep.match(/lively(\.|-)/)),
     failed,
-    resolutions,
-    inputMap
+    providers
   );
-  const importMap = JSON.parse(JSON.stringify(generator.getMap()).replace(/https:\/\//g, 'esm://'))
+  const generatedMap = generator.getMap();
+  const usedEsmShPackages = esmShPackagesIn(generatedMap);
+  for (const [name, provider] of Object.entries(providers)) {
+    if (provider === 'esm.sh' && !usedEsmShPackages.has(name)) delete providers[name];
+  }
+  const importMap = JSON.parse(JSON.stringify(generatedMap).replace(/https:\/\//g, 'esm://'))
   if (!obj.isEmpty(failed)) importMap._failed = failed;
-  if (!obj.isEmpty(resolutions)) importMap._resolutions = resolutions;
+  if (!obj.isEmpty(providers)) importMap._providers = providers;
   if (!obj.isEmpty(importMap)) await cachedImportMap.writeJson(importMap);
   else if (inputMap) { await cachedImportMap.remove() }
   return importMap;

--- a/lively.server/tests/lib-lookup-test.js
+++ b/lively.server/tests/lib-lookup-test.js
@@ -1,0 +1,124 @@
+/* global describe, it */
+
+import { expect } from 'mocha-es6';
+import { findUnavailableJspmPackages, installDeps } from '../plugins/lib-lookup.js';
+
+class FakeGenerator {
+  constructor (failure) {
+    this.failure = failure;
+    this.installs = [];
+    this.map = { imports: {} };
+  }
+
+  async install (spec) {
+    this.installs.push(spec);
+    if (this.failure) throw new Error(this.failure);
+    this.map.imports[spec.slice(0, spec.lastIndexOf('@'))] = 'resolved';
+  }
+
+  async uninstall () {}
+
+  getMap () { return this.map; }
+}
+
+describe('import map generation', () => {
+  it('retries unavailable JSPM packages on esm.sh without changing versions', async () => {
+    const firstGenerator = new FakeGenerator(
+      'Unable to fetch https://ga.jspm.io/npm:ajv@6.15.0/package.json'
+    );
+    const fallbackGenerator = new FakeGenerator();
+    const providers = {};
+    const createdWith = [];
+
+    const result = await installDeps(
+      firstGenerator,
+      [['eslint', '7.32.0']],
+      {},
+      providers,
+      (inputMap, providerOverrides) => {
+        createdWith.push({ inputMap, providerOverrides: { ...providerOverrides } });
+        return fallbackGenerator;
+      }
+    );
+
+    expect(result).equals(fallbackGenerator);
+    expect(providers).deep.equals({ ajv: 'esm.sh' });
+    expect(createdWith).deep.equals([{
+      inputMap: false,
+      providerOverrides: { ajv: 'esm.sh' }
+    }]);
+    expect(firstGenerator.installs).deep.equals(['eslint@7.32.0']);
+    expect(fallbackGenerator.installs).deep.equals(['eslint@7.32.0']);
+  });
+
+  it('can discover multiple unavailable transitive packages', async () => {
+    const generators = [
+      new FakeGenerator('Unable to fetch https://ga.jspm.io/npm:ajv@6.15.0/package.json'),
+      new FakeGenerator('Unable to fetch https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.29.7/package.json'),
+      new FakeGenerator()
+    ];
+    const providers = {};
+
+    const result = await installDeps(
+      generators.shift(),
+      [['eslint', '7.32.0']],
+      {},
+      providers,
+      () => generators.shift()
+    );
+
+    expect(result.installs).deep.equals(['eslint@7.32.0']);
+    expect(providers).deep.equals({
+      ajv: 'esm.sh',
+      '@babel/helper-plugin-utils': 'esm.sh'
+    });
+  });
+
+  it('checks generated module artifacts instead of trusting package metadata', async () => {
+    const importMap = {
+      imports: {
+        available: 'https://ga.jspm.io/npm:available@1.0.0/index.js',
+        missing: 'https://ga.jspm.io/npm:@scope/missing@2.0.0/index.js',
+        fallback: 'https://esm.sh/*already-on-fallback@3.0.0/index.js'
+      }
+    };
+    const requested = [];
+
+    const unavailable = await findUnavailableJspmPackages(
+      importMap,
+      async (url, options) => {
+        requested.push({ url, options });
+        return { status: url.includes('/missing@') ? 404 : 200 };
+      },
+      new Map()
+    );
+
+    expect(unavailable).deep.equals(['@scope/missing']);
+    expect(requested).length(2);
+    expect(requested.every(({ options }) => options.method === 'HEAD')).equals(true);
+  });
+
+  it('rebuilds a map when validation finds a generated 404', async () => {
+    const firstGenerator = new FakeGenerator();
+    const fallbackGenerator = new FakeGenerator();
+    const providers = {};
+    const inputMaps = [];
+    let validation = 0;
+
+    const result = await installDeps(
+      firstGenerator,
+      [['package', '1.0.0']],
+      {},
+      providers,
+      (inputMap) => {
+        inputMaps.push(inputMap);
+        return fallbackGenerator;
+      },
+      async () => validation++ === 0 ? ['transitive'] : []
+    );
+
+    expect(result).equals(fallbackGenerator);
+    expect(providers).deep.equals({ transitive: 'esm.sh' });
+    expect(inputMaps).deep.equals([false]);
+  });
+});

--- a/lively.shell/bin/commandline2lively.js
+++ b/lively.shell/bin/commandline2lively.js
@@ -1,4 +1,4 @@
-/* global process, require, __dirname, module */
+/* global process, require */
 
 /*
  * This script conforms to and can be used as SSH_ASKPASS / GIT_ASKPASS tool.
@@ -7,12 +7,10 @@
  * protocol and prompt the query. The prompt input will be written to stdout.
  */
 
-import path from 'path';
-import util from 'util';
 import io from 'socket.io-client';
 let debug = false;
 let debugOut = debug && require('fs').createWriteStream(process.env.HOME + '/.commandline2lively-debug.log');
-let env = process.env;
+let env = typeof process !== 'undefined' ? process.env : {};
 
 function log (/* args */) {
   if (!debug) return;
@@ -22,14 +20,20 @@ function log (/* args */) {
   // console.log.apply(console, arguments);
 }
 
-function createConnection (thenDo) {
+function createConnection (thenDo, connect) {
   let url = env.L2L_SESSIONTRACKER_SERVER || 'http://localhost:9001';
-  var ioPath = env.L2L_SESSIONTRACKER_PATH || '/lively-socket.io';
-  var ioPath = ioPath.startsWith('/') ? ioPath : '/' + ioPath;
+  let ioPath = env.L2L_SESSIONTRACKER_PATH || '/lively-socket.io';
+  ioPath = ioPath.startsWith('/') ? ioPath : '/' + ioPath;
   let ns = env.L2L_SESSIONTRACKER_NS || 'l2l';
   let auth = env.L2L_ASKPASS_AUTH_HEADER;
   let ioURL = url.replace(/\/$/, '') + ns.replace(/^\/?/, '/');
-  let ioOpts = { path: ioPath, transports: ['websocket', 'polling'] };
+  let ioOpts = {
+    path: ioPath,
+    transports: ['websocket', 'polling'],
+    autoConnect: false,
+    reconnection: false,
+    timeout: 5000
+  };
   let secure = !!url.match(/https:/);
 
   if (!url) { thenDo(new Error('No L2L_SESSIONTRACKER_SERVER provided for creating connection from shell to Lively!')); }
@@ -52,48 +56,59 @@ function createConnection (thenDo) {
   
     log('Creating %ssocket.io connection to %s', secure ? 'secure ' : '', ioURL);
 
-    thenDo(null, io(ioURL, ioOpts));
+    thenDo(null, connect(ioURL, ioOpts));
   } catch (e) { thenDo(e); }
 }
 
-export default function queryLively (msg, thenDo) {
+export default function queryLively (msg, thenDo, connect = io) {
   // lively-2-lively session id to be used to ask for password:
   let clientSessionId = env.L2L_EDITOR_SESSIONID || env.ASKPASS_SESSIONID;
   if (clientSessionId && !msg.target) msg.target = clientSessionId;
   if (!msg.n) msg.n = 0;
   if (!msg.ackTimeout) msg.ackTimeout = 0;
   if (!msg.sender) msg.sender = 'OS shell';
+  if (!msg.action) {
+    thenDo(new Error('Cannot send an L2L message without an action'));
+    return;
+  }
 
   log('Sending ', msg);
 
   createConnection(function (err, ioSocket) {
-  // socket.on("connect", () => {
     if (err || !ioSocket) {
       thenDo('Lively askpass: unable to create socket.io connection ' + err);
       ioSocket && ioSocket.close();
       return;
     }
 
-    ioSocket.on('connect', function () {
+    let finished = false;
+    const finish = (err, answer) => {
+      if (finished) return;
+      finished = true;
+      ioSocket.close();
+      thenDo(err, answer);
+    };
+
+    ioSocket.once('connect', function () {
       log('Connected');
-      ioSocket.emit(msg, function (answer) {
+      ioSocket.emit(msg.action, msg, function (answer) {
         debug && console.error('[cmdline2lv] got answer', answer);
-        ioSocket && ioSocket.close();
-        thenDo(null, answer);
+        finish(null, answer);
       });
     });
 
-    ioSocket.on('error', function (err) {
+    const fail = function (err) {
       debug && console.error('[cmdline2lv] ', err);
-      thenDo('Error in askpass websocket client:\n' + util.inspect(err));
+      finish('Error in askpass websocket client:\n' + (err?.stack || String(err)));
+    };
+
+    ioSocket.once('connect_error', fail);
+    ioSocket.once('error', fail);
+    ioSocket.once('disconnect', function (reason) {
+      log('disconnected');
+      if (!finished) fail(new Error(`Disconnected before receiving an answer: ${reason}`));
     });
 
-    ioSocket.on('disconnect', function () { log('disconnected'); });
-    ioSocket.on('reconnect', function () { log('reconnected'); });
-    ioSocket.on('reconnecting', function () { log('reconnecting'); });
-    ioSocket.on('reconnect_error', function (err) { log('reconnect_error ' + err); });
-    ioSocket.on('reconnect_failed', function (err) { log('reconnect_failed'); });
-
     ioSocket.connect();
-  });
+  }, connect);
 }

--- a/lively.shell/tests/commandline2lively-test.js
+++ b/lively.shell/tests/commandline2lively-test.js
@@ -1,0 +1,77 @@
+/* global describe, it */
+
+import { expect } from 'mocha-es6';
+import queryLively from '../bin/commandline2lively.js';
+
+class FakeSocket {
+  constructor (answer) {
+    this.answer = answer;
+    this.handlers = new Map();
+    this.sent = [];
+    this.closed = false;
+  }
+
+  once (event, handler) {
+    this.handlers.set(event, handler);
+    return this;
+  }
+
+  connect () {
+    this.trigger('connect');
+  }
+
+  close () {
+    this.closed = true;
+  }
+
+  emit (event, message, ackFn) {
+    this.sent.push({ event, message });
+    ackFn(this.answer);
+  }
+
+  trigger (event, value) {
+    const handler = this.handlers.get(event);
+    this.handlers.delete(event);
+    if (handler) handler(value);
+  }
+}
+
+describe('command-line L2L client', () => {
+  it('sends the action as the Socket.IO event and closes after its answer', async () => {
+    const answer = { data: { result: 'ok' } };
+    const socket = new FakeSocket(answer);
+    let connection;
+
+    const received = await new Promise((resolve, reject) => {
+      queryLively(
+        { action: 'changeWorkingDirectory', data: { args: ['/tmp'] } },
+        (err, result) => err ? reject(err) : resolve(result),
+        (url, options) => {
+          connection = { url, options };
+          return socket;
+        }
+      );
+    });
+
+    expect(received).equals(answer);
+    expect(socket.sent).length(1);
+    expect(socket.sent[0].event).equals('changeWorkingDirectory');
+    expect(socket.sent[0].message.action).equals('changeWorkingDirectory');
+    expect(socket.closed).equals(true);
+    expect(connection.options.autoConnect).equals(false);
+    expect(connection.options.reconnection).equals(false);
+  });
+
+  it('closes and reports connection failures without reconnecting', async () => {
+    const socket = new FakeSocket();
+    socket.connect = () => socket.trigger('connect_error', new Error('unavailable'));
+
+    const error = await new Promise(resolve => {
+      queryLively({ action: 'test', data: {} }, err => resolve(err), () => socket);
+    });
+
+    expect(String(error)).includes('unavailable');
+    expect(socket.closed).equals(true);
+    expect(socket.sent).length(0);
+  });
+});


### PR DESCRIPTION
## Summary

- keep import-map provider fallbacks and ESM.sh/JSPM interop stable
- preserve import-map context across module normalization
- stop command-line L2L clients from reconnecting indefinitely and add coverage
- make installer package and build failures propagate as a nonzero exit status
- add resolver, resource, and L2L regression tests

## Validation

- ./install.sh --no-desktop completed successfully
- controlled freezer failure exited with status 1
- focused lively.resources, lively.modules, lively.freezer, lively.shell, and lively.2lively suites passed
- unified freezer build completed successfully